### PR TITLE
Update bridge links for LP tokens

### DIFF
--- a/components/BondsPage/index.jsx
+++ b/components/BondsPage/index.jsx
@@ -27,7 +27,7 @@ const BondingDetailsSection = () => {
               <TableHead>Pool Symbol</TableHead>
               <TableHead>LP Token Address</TableHead>
               <TableHead>Bridged LP Token Address</TableHead>
-              <TableHead>Bridge</TableHead>
+              <TableHead>Bridge LP Token from Network to Ethereum</TableHead>
             </TableRow>
           </TableHeader>
           <TableBody>
@@ -39,7 +39,7 @@ const BondingDetailsSection = () => {
                 <TableCell>{network?.bond?.lpTokenName}</TableCell>
                 <TableCell>{network?.bond?.lpTokenAddress ? <ExternalLink href={network?.explorerBaseUrl + network?.bond?.lpTokenAddress}>{truncateAddress(network?.bond?.lpTokenAddress)}</ExternalLink> : "n/a"}</TableCell>
                 <TableCell>{network?.bond?.bridgedLpTokenAddress ? <ExternalLink href={`https://etherscan.io/token/${network?.bond?.bridgedLpTokenAddress}`}>{truncateAddress(network?.bond?.bridgedLpTokenAddress)}</ExternalLink> : "n/a"}</TableCell>
-                <TableCell>{network?.bridge?.name ? <ExternalLink href={network?.bridge?.url}>{network?.bridge?.name}</ExternalLink> : "n/a"}</TableCell>
+                <TableCell>{network?.bond?.lpTokenBridge ? <ExternalLink href={network?.bond?.lpTokenBridge?.url}>{network?.bond?.lpTokenBridge?.name}</ExternalLink> : "n/a"}</TableCell>
               </TableRow>
             ))}
           </TableBody>

--- a/components/OlasTokenPage/TokenDetails.jsx
+++ b/components/OlasTokenPage/TokenDetails.jsx
@@ -29,7 +29,8 @@ export const TOKEN_DETAILS = [
       guideUrl: 'https://olas.network/blog/inaugural-bonding-programme-proposal',
       lpTokenName: 'OLAS-ETH',
       bridgedLpTokenAddress: null,
-      lpTokenAddress: '0x09d1d767edf8fa23a64c51fa559e0688e526812f'
+      lpTokenAddress: '0x09d1d767edf8fa23a64c51fa559e0688e526812f',
+      bridge: null,
     },
   },
   {
@@ -42,10 +43,11 @@ export const TOKEN_DETAILS = [
     },
     bridge: { name: 'Omnibridge', url: 'https://omni.gnosischain.com/bridge' },
     bond: {
-      guideUrl: 'https://olas.network/blog/olas-liquidity-on-gnosis-chain',
+      guideUrl: 'https://olas.network/blog/new-bonding-products-on-gnosis-chain-proposed',
       lpTokenName: 'OLAS-WXDAI',
       bridgedLpTokenAddress: '0x27df632fd0dcf191c418c803801d521cd579f18e',
-      lpTokenAddress: '0x79c872ed3acb3fc5770dd8a0cd9cd5db3b3ac985'
+      lpTokenAddress: '0x79c872ed3acb3fc5770dd8a0cd9cd5db3b3ac985',
+      lpTokenBridge: { name: 'Omnibridge', url: 'https://omni.gnosischain.com/bridge' },
     },
   },
   {
@@ -64,7 +66,11 @@ export const TOKEN_DETAILS = [
       guideUrl: 'https://olas.network/blog/bonding-guide-polygon-arbitrum',
       lpTokenName: 'WMATIC-OLAS',
       bridgedLpTokenAddress: '0xf9825A563222f9eFC81e369311DAdb13D68e60a4',
-      lpTokenAddress: '0x62309056c759c36879cde93693e7903bf415e4bc'
+      lpTokenAddress: '0x62309056c759c36879cde93693e7903bf415e4bc',
+      lpTokenBridge: {
+        name: 'Wormhole: Portal Token Bridge',
+        url: 'https://portalbridge.com/advanced-tools/#/transfer',
+      },
     },
   },
   {
@@ -91,7 +97,11 @@ export const TOKEN_DETAILS = [
       guideUrl: 'https://olas.network/blog/bonding-guide-polygon-arbitrum',
       lpTokenName: 'OLAS-WETH',
       bridgedLpTokenAddress: '0x36B203Cb3086269f005a4b987772452243c0767f',
-      lpTokenAddress: '0xaf8912a3c4f55a8584b67df30ee0ddf0e60e01f8'
+      lpTokenAddress: '0xaf8912a3c4f55a8584b67df30ee0ddf0e60e01f8',
+      lpTokenBridge: {
+        name: 'Wormhole: Portal Token Bridge',
+        url: 'https://portalbridge.com/advanced-tools/#/transfer',
+      },
     }
   },
 ];


### PR DESCRIPTION
Adds bridge data for LP tokens, not just OLAS.

- [Bond](https://olas-website-2y7i4mcoo-autonolas.vercel.app/bonds)
- [Build](https://olas-website-2y7i4mcoo-autonolas.vercel.app/olas-token#supply)