### PR TITLE
feat: Redirect /services/predict to /agent-economies/predict

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -28,6 +28,11 @@ module.exports = {
         destination: 'https://github.com/contentwillvary/brand-and-press-kit-olas/blob/main/README.md',
         permanent: false,
       },
+      {
+        source: '/services/predict',
+        destination: '/agent-economies/predict',
+        permanent: true,
+      },
     ];
   },
   async headers() {


### PR DESCRIPTION
permanent redirect of `/services/predict` to `/agent-economies/predict`