### PR TITLE
chore: updates for operate page, reduce font-size for metrics

### DIFF
--- a/components/ContributePage/Features.jsx
+++ b/components/ContributePage/Features.jsx
@@ -28,13 +28,14 @@ const features = [
     description:
       'Showcase your position in the community with a dedicated page.',
   },
-  {
-    id: 'bf77fa18-0a70-4651-ad97-49563fd620b8',
-    title: 'Community-owned Chatbot',
-    icon: '🤖',
-    description:
-      "veOLAS holders can collaboratively shape the 'memory' of a chatbot for community newcomers to learn from.",
-  },
+  // {
+  //   id: 'bf77fa18-0a70-4651-ad97-49563fd620b8',
+  //   title: 'Community-owned Chatbot',
+  //   icon: '🤖',
+  //   description:
+  //     `veOLAS holders can collaboratively shape the 'memory' of
+  //     a chatbot for community newcomers to learn from.`,
+  // },
   {
     id: 'ed74f1e1-3b5f-4a74-80ea-61182d9764d2',
     title: 'Community-owned Social Posting',
@@ -42,13 +43,14 @@ const features = [
     description:
       'veOLAS hodlers can propose and vote on tweets to be posted by the community Twitter account.',
   },
-  {
-    id: '9a94e834-2b91-4010-b2f9-e9321fbd64d2',
-    title: 'Community Chat',
-    icon: '💬',
-    description:
-      'veOLAS holders have a dedicated space to discuss as a group and message one another via encrypted private chat.',
-  },
+  // {
+  //   id: '9a94e834-2b91-4010-b2f9-e9321fbd64d2',
+  //   title: 'Community Chat',
+  //   icon: '💬',
+  //   description:
+  //     `veOLAS holders have a dedicated space to discuss as a group
+  //     and message one another via encrypted private chat.`,
+  // },
 ];
 
 const Feature = ({ feature }) => (

--- a/components/HomepageSection/Activity.jsx
+++ b/components/HomepageSection/Activity.jsx
@@ -82,7 +82,7 @@ const Activity = ({
               <span className="block text-xl text-slate-700 mb-4">
                 {item.topText}
               </span>
-              <span className="block text-6xl text-black font-extrabold mb-4">
+              <span className="block text-5xl text-black font-extrabold mb-4">
                 {item.value ?? '--'}
               </span>
               <span className="block text-xl text-slate-700">

--- a/components/OperatePage/FAQ.jsx
+++ b/components/OperatePage/FAQ.jsx
@@ -31,17 +31,6 @@ const faqList = [
           <>
             Minimal system requirements for Mac devices:
             <ul className="list-disc ml-6">
-              <li>
-                <Link
-                  href="https://docs.docker.com/docker-for-mac/install/"
-                  className="text-purple-600"
-                  target="_blank"
-                >
-                  Docker Desktop↗
-                </Link>
-                {' '}
-                running. During Alpha and Beta phases only.
-              </li>
               <li>800 MB of free RAM (suggested 1 GB)</li>
               <li>1.3 GB disk space</li>
             </ul>
@@ -87,7 +76,7 @@ const faqList = [
               operate.olas.network
             </Link>
             {' '}
-            to get started.
+            to get started with one of the quickstarts.
           </>
         ),
       },

--- a/components/OperatePage/MeetPearl.jsx
+++ b/components/OperatePage/MeetPearl.jsx
@@ -21,7 +21,7 @@ const list = [
   },
   {
     title: 'Strong',
-    desc: 'We put your peace of mind first. Pearl provides robust recovery options to protect your funds.',
+    desc: 'Pearl puts your peace of mind first. Pearl provides robust recovery options to protect your funds.',
     icon: <LockKeyhole />,
   },
   {

--- a/components/OperatePage/WantMoreControl.jsx
+++ b/components/OperatePage/WantMoreControl.jsx
@@ -10,7 +10,7 @@ import {
 const controlList = [
   {
     title: 'Customize, experiment, and optimize your agents',
-    desc: 'With the Operate web app, you’re in charge. Select an agent, tweak settings, and tailor operations to your specifications. It’s your setup, your rules. Run as many agents as you like.',
+    desc: 'With the Quickstarts, listed on the Operate site, you’re in charge. Select an agent, tweak settings, and tailor operations to your specifications. It’s your setup, your rules. Run as many agents as you like.',
   },
   {
     title: 'Quick setup guides',


### PR DESCRIPTION
1) reduced font-size for metrics, so 1m txs can fit
2) changed texts on operate page as requested:
“We put your peace of mind first.” -> “Pearl puts your peace of mind first.”
“With the Operate web app, you’re in charge” -> “With the Quickstarts, listed on the Operate site, you’re in charge”
FAQ: drop “Docker Desktop↗ running. During Alpha and Beta phases only.”; this is no longer a requirement.
FQA: “Visit operate.olas.network to get started.” -> “Visit operate.olas.network to get started with one of the quickstarts.”
3) commented out “Community-owned Chatbot” and “Community Chat” features on contribute
