### PR TITLE
feat: add emissions to operators chart, fix emissions to bonders chart

### DIFF
--- a/common-util/charts.js
+++ b/common-util/charts.js
@@ -17,6 +17,10 @@ export const EMISSIONS_CHART_COLORS = {
     legend: "bg-purple-500",
     line: "#A855F7",
   },
+  operators: {
+    legend: "bg-amber-400",
+    line: "#FFB347",
+  },
 };
 
 const MAX_MARGIN = 1.2;

--- a/common-util/graphql/queries.js
+++ b/common-util/graphql/queries.js
@@ -10,6 +10,8 @@ export const emissionsQuery = gql`
       effectiveBond
       totalCreateProductsSupply
       totalCreateBondsAmountOLAS
+      availableStakingIncentives
+      totalStakingIncentives
     }
   }
 `;

--- a/components/OlasTokenPage/EmissionsToBonders.jsx
+++ b/components/OlasTokenPage/EmissionsToBonders.jsx
@@ -14,6 +14,7 @@ import {
   EMISSIONS_CHART_COLORS,
 } from 'common-util/charts';
 import { LegendItem } from './LegendItem';
+import { emissionType } from './types';
 
 Chart.register(LineElement, LinearScale, PointElement, Filler, Tooltip);
 
@@ -36,7 +37,7 @@ export const EmissionsToBonders = ({ emissions, loading }) => {
       <div className="flex flex-wrap gap-x-4 gap-y-1 mb-6">
         <LegendItem
           color={EMISSIONS_CHART_COLORS.available.legend}
-          label="Available bonding emissions"
+          label="OLAS available for bonding programmes via DAO vote"
         />
         <LegendItem
           color={EMISSIONS_CHART_COLORS.products.legend}
@@ -93,14 +94,6 @@ export const EmissionsToBonders = ({ emissions, loading }) => {
 };
 
 EmissionsToBonders.propTypes = {
-  emissions: PropTypes.arrayOf(PropTypes.shape({
-    id: PropTypes.string,
-    counter: PropTypes.number,
-    availableDevIncentives: PropTypes.string,
-    devIncentivesTotalTopUp: PropTypes.string,
-    effectiveBond: PropTypes.string,
-    totalCreateProductsSupply: PropTypes.string,
-    totalCreateBondsAmountOLAS: PropTypes.string,
-  })).isRequired,
+  emissions: PropTypes.arrayOf(emissionType).isRequired,
   loading: PropTypes.bool.isRequired,
 };

--- a/components/OlasTokenPage/EmissionsToOperators.jsx
+++ b/components/OlasTokenPage/EmissionsToOperators.jsx
@@ -9,7 +9,6 @@ import {
   Filler,
   Tooltip,
 } from 'chart.js';
-
 import {
   getEmissionsChartOptions,
   EMISSIONS_CHART_COLORS,
@@ -19,12 +18,12 @@ import { emissionType } from './types';
 
 Chart.register(LineElement, LinearScale, PointElement, Filler, Tooltip);
 
-export const EmissionsToDevs = ({ emissions, loading }) => {
-  const devIncentivesPoints = emissions.map(
-    (item) => item.devIncentivesTotalTopUp || 0,
+export const EmissionsToOperators = ({ emissions, loading }) => {
+  const availableStakingIncentivesPoints = emissions.map(
+    (item) => item.availableStakingIncentives || 0,
   );
-  const availableDevIncentivesPoints = emissions.map(
-    (item) => item.availableDevIncentives || 0,
+  const totalStakingIncentivesPoints = emissions.map(
+    (item) => item.totalStakingIncentives || 0,
   );
 
   return (
@@ -32,18 +31,18 @@ export const EmissionsToDevs = ({ emissions, loading }) => {
       <h2 className="text-sm text-slate-500 font-bold tracking-widest uppercase mb-6">
         Actual emissions per epoch
       </h2>
-      <div className="flex gap-4 mb-6">
+      <div className="flex flex-wrap gap-x-4 gap-y-1 mb-6">
         <LegendItem
           color={EMISSIONS_CHART_COLORS.available.legend}
-          label="Dev rewards available for claiming"
+          label="Available staking emissions"
         />
         <LegendItem
-          color={EMISSIONS_CHART_COLORS.devRewards.legend}
-          label="Dev rewards claimed"
+          color={EMISSIONS_CHART_COLORS.operators.legend}
+          label="OLAS emitted to staking contracts"
         />
       </div>
       <div className="flex flex-col flex-auto gap-8">
-        <div className="flex-auto">
+        <div className="flex-auto h-72">
           {loading ? (
             <div className="text-center">Loading...</div>
           ) : (
@@ -52,23 +51,25 @@ export const EmissionsToDevs = ({ emissions, loading }) => {
                 labels: emissions.map((item) => item.counter),
                 datasets: [
                   {
-                    label: 'Available incentives',
-                    data: availableDevIncentivesPoints,
+                    label: 'Available emissions',
+                    data: availableStakingIncentivesPoints,
+                    order: 1,
                     pointBackgroundColor: EMISSIONS_CHART_COLORS.available.line,
                     borderColor: EMISSIONS_CHART_COLORS.available.line,
                   },
                   {
-                    label: 'Emitted incentives',
-                    data: devIncentivesPoints,
-                    pointBackgroundColor:
-                      EMISSIONS_CHART_COLORS.devRewards.line,
-                    borderColor: EMISSIONS_CHART_COLORS.devRewards.line,
+                    label: 'Staking incentives',
+                    data: totalStakingIncentivesPoints,
+                    order: 2,
+                    pointBackgroundColor: EMISSIONS_CHART_COLORS.operators.line,
+                    borderColor: EMISSIONS_CHART_COLORS.operators.line,
                   },
                 ],
               }}
               options={getEmissionsChartOptions([
-                ...devIncentivesPoints,
-                ...availableDevIncentivesPoints,
+                ...availableStakingIncentivesPoints,
+                ...availableStakingIncentivesPoints,
+                10 ** 18, // Add this temporarily while we don't have data on staking
               ])}
             />
           )}
@@ -78,7 +79,7 @@ export const EmissionsToDevs = ({ emissions, loading }) => {
   );
 };
 
-EmissionsToDevs.propTypes = {
+EmissionsToOperators.propTypes = {
   emissions: PropTypes.arrayOf(emissionType).isRequired,
   loading: PropTypes.bool.isRequired,
 };

--- a/components/OlasTokenPage/index.jsx
+++ b/components/OlasTokenPage/index.jsx
@@ -15,6 +15,7 @@ import { EmissionScheduleChart } from './EmissionScheduleChart';
 import { EmissionsToDevs } from './EmissionsToDevs';
 import { EmissionsToBonders } from './EmissionsToBonders';
 import { LearnMoreAboutTokenomics } from './LearnMoreAboutTokenomics';
+import { EmissionsToOperators } from './EmissionsToOperators';
 
 // manually register arc element, category scale, linear scale,
 // and bar element – required due to chart.js tree shaking
@@ -103,7 +104,12 @@ const Supply = () => {
         const emissionsData = await tokenomicsGraphClient.request(
           emissionsQuery,
         );
-        setEmissions(emissionsData.epoches);
+        setEmissions(
+          // Filter out the current epoch, because it may contain incorrect data
+          emissionsData.epoches.filter(
+            (epochEmissions) => epochEmissions.counter !== Number(newEpoch),
+          ),
+        );
 
         setLoading(false);
       } catch (error) {
@@ -170,6 +176,13 @@ const Supply = () => {
               <h2 className="text-xl mb-2 font-bold">Emissions to Bonders</h2>
             </div>
             <EmissionsToBonders emissions={emissions} loading={loading} />
+          </div>
+
+          <div className="flex flex-col border rounded-lg">
+            <div className="p-4 border-b">
+              <h2 className="text-xl mb-2 font-bold">Emissions to Operators</h2>
+            </div>
+            <EmissionsToOperators emissions={emissions} loading={loading} />
           </div>
         </div>
 

--- a/components/OlasTokenPage/types.js
+++ b/components/OlasTokenPage/types.js
@@ -1,0 +1,13 @@
+import PropTypes from 'prop-types';
+
+export const emissionType = PropTypes.shape({
+  id: PropTypes.string,
+  counter: PropTypes.number,
+  availableDevIncentives: PropTypes.string,
+  devIncentivesTotalTopUp: PropTypes.string,
+  effectiveBond: PropTypes.string,
+  totalCreateProductsSupply: PropTypes.string,
+  totalCreateBondsAmountOLAS: PropTypes.string,
+  availableStakingIncentives: PropTypes.string,
+  totalStakingIncentives: PropTypes.string,
+});


### PR DESCRIPTION
1) all epochs are shifted now by 1 epoch, dues to a mistake in subgraph calculations
2) some labels were changed as agreed on a call with David M
3) added emissions to stakers chart, but the values will be here when current epoch ends

https://olas-website-git-tanya-emissions-to-stakers-autonolas.vercel.app/olas-token