### PR TITLE
fix: adjust number formatter, fix emissions to operators chart

### DIFF
--- a/common-util/numberFormatter.js
+++ b/common-util/numberFormatter.js
@@ -1,4 +1,7 @@
 export const formatWeiNumber = (numberInWei) => {
-  const formatter = Intl.NumberFormat('en', { notation: 'compact' });
+  const formatter = Intl.NumberFormat("en", {
+    notation: "compact",
+    maximumFractionDigits: 3,
+  });
   return formatter.format(numberInWei / 10 ** 18);
 };


### PR DESCRIPTION
In this PR I only fixed the number formatter, so the legend value looks more accurate. I updated the subgraph in the background, so the emissions to the operator chart now display OLAS emitted values. You can check the values from the subgraph below.
The `totalStakingIncentive` in the `epochSettled` is the initial available incentive for the epoch
The `totalStakingIncentives` in the `epoch` is the total incentives emitted during the epoch
The `availableStakingIncentives` in the `epoch` is the initial available incentives (from epochSettled's `totalStakingIncentive`) minus `totalStakingIncentives` in the epoch entity

```
"epochSettleds": [
  {
    "epochCounter": "14",
    "totalStakingIncentive": "1684355631659056315572612",
    "returnedStakingIncentive": "0"
  }
]

epoches: [{
  "counter": 14,
  "availableStakingIncentives": "1680506119616590574172222",
  "totalStakingIncentives": "3849512042465741400390",
  "stakingIncentives": [
    {
      "chainId": "100",
      "stakingTarget": "0x000000000000000000000000389b46c259631acd6a69bde8b6cee218230bae8c",
      "stakingIncentive": "1140128703287662205787"
    },
    {
      "chainId": "100",
      "stakingTarget": "0x0000000000000000000000005344b7dd311e5d3dddd46a4f71481bd7b05aaa3e",
      "stakingIncentive": "2280257406575340188264"
    },
    {
      "chainId": "100",
      "stakingTarget": "0x000000000000000000000000ef44fb0842ddef59d37f85d61a1ef492bba6135d",
      "stakingIncentive": "429125932602739006339"
    }
  ]
}]
```

<img width="806" alt="image" src="https://github.com/user-attachments/assets/7313ea74-345d-494b-b0ee-fb4d70c2c6f3">
