### PR TITLE
chore: rename devs to builders

### DIFF
--- a/components/OlasTokenPage/EmissionsToBuilders.jsx
+++ b/components/OlasTokenPage/EmissionsToBuilders.jsx
@@ -19,7 +19,7 @@ import { emissionType } from './types';
 
 Chart.register(LineElement, LinearScale, PointElement, Filler, Tooltip);
 
-export const EmissionsToDevs = ({ emissions, loading }) => {
+export const EmissionsToBuilders = ({ emissions, loading }) => {
   const devIncentivesPoints = emissions.map(
     (item) => item.devIncentivesTotalTopUp || 0,
   );
@@ -78,7 +78,7 @@ export const EmissionsToDevs = ({ emissions, loading }) => {
   );
 };
 
-EmissionsToDevs.propTypes = {
+EmissionsToBuilders.propTypes = {
   emissions: PropTypes.arrayOf(emissionType).isRequired,
   loading: PropTypes.bool.isRequired,
 };

--- a/components/OlasTokenPage/UsagePieChart.jsx
+++ b/components/OlasTokenPage/UsagePieChart.jsx
@@ -23,7 +23,7 @@ export const UsagePieChart = ({ epoch, split, loading }) => (
         <Verify url="https://etherscan.io/address/0xc096362fa6f4A4B1a9ea68b1043416f3381ce300#readProxyContract#F15" />
       </div>
       <p className="mb-8 text-slate-500">
-        Tokens are distributed to developers, operators and bonders each epoch.
+        Tokens are distributed to builders, operators and bonders each epoch.
         Epochs run roughly once a month.
       </p>
     </div>
@@ -41,7 +41,7 @@ export const UsagePieChart = ({ epoch, split, loading }) => (
           of the new tokens are earmarked for
           {' '}
           <Link href="/build" className="text-cyan-500 font-bold">
-            Developers
+            Builders
           </Link>
         </div>
         <div>
@@ -78,7 +78,7 @@ export const UsagePieChart = ({ epoch, split, loading }) => (
         ) : (
           <Pie
             data={{
-              labels: ['Developers', 'Bonders', 'Operators'],
+              labels: ['Builders', 'Bonders', 'Operators'],
               datasets: [
                 {
                   data: [split.developers, split.bonders, split.staking] || [

--- a/components/OlasTokenPage/index.jsx
+++ b/components/OlasTokenPage/index.jsx
@@ -12,7 +12,7 @@ import SectionWrapper from '../Layout/SectionWrapper';
 import { UsagePieChart } from './UsagePieChart';
 import { SupplyPieChart } from './SupplyPieChart';
 import { EmissionScheduleChart } from './EmissionScheduleChart';
-import { EmissionsToDevs } from './EmissionsToDevs';
+import { EmissionsToBuilders } from './EmissionsToBuilders';
 import { EmissionsToBonders } from './EmissionsToBonders';
 import { LearnMoreAboutTokenomics } from './LearnMoreAboutTokenomics';
 import { EmissionsToOperators } from './EmissionsToOperators';
@@ -164,11 +164,9 @@ const Supply = () => {
 
           <div className="flex flex-col border rounded-lg">
             <div className="p-4 border-b">
-              <h2 className="text-xl mb-2 font-bold">
-                Emissions to Developers
-              </h2>
+              <h2 className="text-xl mb-2 font-bold">Emissions to Builders</h2>
             </div>
-            <EmissionsToDevs emissions={emissions} loading={loading} />
+            <EmissionsToBuilders emissions={emissions} loading={loading} />
           </div>
 
           <div className="flex flex-col border rounded-lg">


### PR DESCRIPTION
## Proposed changes

Rename Devs/Developers to Builders as per figma comments https://www.figma.com/design/zk2HxfJXJZaAJIFcBqJfsW/Olas-Website?node-id=2383-517&t=0mlZKE77gB3gGYlF-0

## Screenshots/Recordings

<img width="799" alt="image" src="https://github.com/user-attachments/assets/4d951868-5b2b-4867-b066-a0c726c97f28">
<img width="834" alt="image" src="https://github.com/user-attachments/assets/6a3966a1-8461-4c3e-b2e5-83a204642a7c">


## Things to keep in mind

<!-- Please check if the PR fulfills these requirements -->

- [ ] I confirm I have updated the meta title and description for the page
