### PR TITLE
chore: move tokenomics link

### DIFF
--- a/components/Layout/Footer.jsx
+++ b/components/Layout/Footer.jsx
@@ -2,9 +2,7 @@ import Image from 'next/image';
 import Link from 'next/link';
 import PropTypes from 'prop-types';
 import { MoveUpRight } from 'lucide-react';
-import {
-  REGISTRY_URL,
-} from 'common-util/constants';
+import { REGISTRY_URL } from 'common-util/constants';
 import { cn } from 'lib/utils';
 
 const SOCIAL_LINKS = [
@@ -57,10 +55,7 @@ const GET_INVOLVED_LINKS = [
   { title: 'Govern', link: '/govern' },
 ];
 
-const OTHER_APPS_LINKS = [
-  { title: 'Registry', link: REGISTRY_URL },
-  { title: 'Tokenomics', link: '/olas-token' },
-];
+const OTHER_APPS_LINKS = [{ title: 'Registry', link: REGISTRY_URL }];
 
 const RESOURCES_LINKS = [
   {
@@ -108,6 +103,10 @@ const RESOURCES_LINKS = [
     title: 'Alter Orbis',
     link: 'https://autonolas.world',
     isExternal: true,
+  },
+  {
+    title: 'Tokenomics',
+    link: '/olas-token',
   },
 ];
 

--- a/data/resources.json
+++ b/data/resources.json
@@ -62,5 +62,13 @@
     "url": "https://www.youtube.com/playlist?list=PLXztsZv11CTfXiQK9OJhMwBkfgf4ETZkl",
     "imageFilename": "awesome-autonolas.svg",
     "tags": ["build"]
+  },
+  {
+    "id": "d9b2d63d-a3bb-4e8d-9d6b-9b0d2b044d80",
+    "title": "Tokenomics",
+    "description": "Review the token distribution",
+    "url": "/olas-token",
+    "imageFilename": "awesome-autonolas.svg",
+    "tags": []
   }
 ]


### PR DESCRIPTION
## Proposed changes

Add/Move Tokenomics link to Recources in header and footer

## Screenshots/Recordings

<img width="673" alt="image" src="https://github.com/user-attachments/assets/bccaa856-e556-4204-8ed1-8cfa6c9a5954">

<img width="498" alt="image" src="https://github.com/user-attachments/assets/f8d5d0ff-e206-4f2b-b1b1-ef7f2b3d75f3">

## Things to keep in mind

<!-- Please check if the PR fulfills these requirements -->

- [ ] I confirm I have updated the meta title and description for the page, if applicable.
