### PR TITLE
feat: add links for sections on homepage

### DIFF
--- a/components/HomepageSection/PropelledBy.jsx
+++ b/components/HomepageSection/PropelledBy.jsx
@@ -107,7 +107,7 @@ const MoreFriends = () => (
 );
 
 export const PropelledBy = () => (
-  <SectionWrapper>
+  <SectionWrapper id="ecosystem">
     <SectionHeading
       color="text-gray-900"
       weight="font-bold"

--- a/components/HomepageSection/TheTech.jsx
+++ b/components/HomepageSection/TheTech.jsx
@@ -60,6 +60,7 @@ export const TheTech = ({ hideLearnMoreButton = false }) => (
   <SectionWrapper
     backgroundType="NONE"
     customClasses="text-center py-24 px-4 border-b bg-[linear-gradient(180deg,_#FFF_0%,_#F9E5FF_100%)]"
+    id="tech"
   >
     <Upcase>
       <span>THE TECH</span>

--- a/components/HomepageSection/UseCases.jsx
+++ b/components/HomepageSection/UseCases.jsx
@@ -88,7 +88,7 @@ UseCaseCard.propTypes = {
 };
 
 const UseCases = () => (
-  <SectionWrapper customClasses="text-center pt-24 md:py-24 px-4">
+  <SectionWrapper customClasses="text-center pt-24 md:py-24 px-4" id="usecases">
     <SectionHeading color="text-gray-900" weight="font-bold">
       Live use cases, creating value today
     </SectionHeading>


### PR DESCRIPTION
## Proposed changes

supports the following links which scroll the page to the corresponding sections:

- olas.network#usecases
- olas.network#tech
- olas.network#ecosystem
- olas.network#growth


## Things to keep in mind

<!-- Please check if the PR fulfills these requirements -->

- [ ] I confirm I have updated the meta title and description for the page, if applicable.
