### PR TITLE
fix: bonding page text link

### DIFF
--- a/common-util/constants.js
+++ b/common-util/constants.js
@@ -16,7 +16,7 @@ export const FLIPSIDE_URL = 'https://flipsidecrypto.xyz/flipsideteam/olas-key-ac
 
 export const SHORTS_URL = 'https://shorts.wtf';
 export const REGISTRY_URL = 'https://registry.olas.network/';
-export const BONDING_PROGRAMS_URL = 'https://bonds.olas.network/bonding-products';
+export const BONDING_PROGRAMS_URL = 'https://bond.olas.network/bonding-products';
 export const DEV_REWARDS_URL = 'https://build.olas.network/dev-incentives';
 export const OPERATE_AGENTS_URL = 'https://operate.olas.network/agents';
 export const LAUNCH_URL = 'https://launch.olas.network/';


### PR DESCRIPTION
## Proposed changes

Fixed text link from bonds page in HowBondingWorks section.

## Screenshots/Recordings

https://github.com/user-attachments/assets/aa2ab9af-2c7d-4f91-bf83-f9f0867821bb
