### PR TITLE
feat: Actual Emissions Sched chart added to olas-token page

### DIFF
--- a/common-util/charts.js
+++ b/common-util/charts.js
@@ -21,6 +21,10 @@ export const EMISSIONS_CHART_COLORS = {
     legend: 'bg-amber-400',
     line: '#FFB347',
   },
+  actual: {
+    legend: 'bg-green-400',
+    line: '#3FE681',
+  },
 };
 
 const MAX_MARGIN = 1.2;

--- a/common-util/charts.js
+++ b/common-util/charts.js
@@ -1,4 +1,7 @@
-import { formatWeiNumber } from 'common-util/numberFormatter';
+import {
+  formatChartNumber,
+  formatWeiNumber,
+} from 'common-util/numberFormatter';
 
 export const EMISSIONS_CHART_COLORS = {
   available: {
@@ -68,6 +71,46 @@ export const getEmissionsChartOptions = (points) => ({
         title: (tooltipItems) => `Epoch ${tooltipItems[0].label}`,
         label: (tooltipItem) =>
           `${tooltipItem.dataset.label}: ${formatWeiNumber(tooltipItem.raw)}`,
+      },
+    },
+  },
+});
+
+export const getEmissionsChartOptionsFromNumber = () => ({
+  responsive: true,
+  maintainAspectRatio: false,
+  scales: {
+    x: {
+      title: {
+        display: true,
+        text: 'Epoch',
+      },
+    },
+    y: {
+      title: {
+        display: true,
+        text: 'OLAS Emitted',
+      },
+      ticks: {
+        callback: function (value) {
+          return formatChartNumber(value);
+        },
+      },
+    },
+  },
+  interaction: {
+    intersect: false,
+    includeInvisible: true,
+    mode: 'nearest',
+    axis: 'x',
+  },
+  plugins: {
+    tooltip: {
+      enabled: true,
+      callbacks: {
+        title: (tooltipItems) => `Epoch ${tooltipItems[0].label}`,
+        label: (tooltipItem) =>
+          `${tooltipItem.dataset.label}: ${formatChartNumber(tooltipItem.raw)}`,
       },
     },
   },

--- a/common-util/numberFormatter.js
+++ b/common-util/numberFormatter.js
@@ -5,3 +5,11 @@ export const formatWeiNumber = (numberInWei) => {
   });
   return formatter.format(numberInWei / 10 ** 18);
 };
+
+export const formatChartNumber = (number) => {
+  const formatter = Intl.NumberFormat('en', {
+    notation: 'compact',
+    maximumFractionDigits: 3,
+  });
+  return formatter.format(number);
+};

--- a/components/OlasTokenPage/ActualEmissionsChart.jsx
+++ b/components/OlasTokenPage/ActualEmissionsChart.jsx
@@ -1,0 +1,90 @@
+import {
+  Chart,
+  Filler,
+  LineElement,
+  LinearScale,
+  PointElement,
+  Tooltip,
+} from 'chart.js';
+import {
+  EMISSIONS_CHART_COLORS,
+  getEmissionsChartOptions,
+} from 'common-util/charts';
+import PropTypes from 'prop-types';
+import { Line } from 'react-chartjs-2';
+import { LegendItem } from './LegendItem';
+import { emissionType } from './types';
+
+Chart.register(LineElement, LinearScale, PointElement, Filler, Tooltip);
+
+export const ActualEmissionsChart = ({ emissions, loading }) => {
+  const maxAvailableEmissions = emissions.map(
+    (item) =>
+      parseFloat(item.availableDevIncentives || 0) +
+      parseFloat(item.availableStakingIncentives || 0) +
+      parseFloat(item.effectiveBond || 0),
+  );
+  const actualEmissions = emissions.map(
+    (item) =>
+      parseFloat(item.devIncentivesTotalTopUp || 0) +
+      parseFloat(item.totalStakingIncentives || 0) +
+      parseFloat(item.totalCreateBondsAmountOLAS || 0),
+  );
+
+  return (
+    <div className="flex flex-col flex-auto p-4">
+      <h2 className="text-sm text-slate-500 font-bold tracking-widest uppercase mb-6">
+        Actual emissions per epoch
+      </h2>
+      <div className="flex flex-wrap gap-x-4 gap-y-1 mb-6">
+        <LegendItem
+          color={EMISSIONS_CHART_COLORS.available.legend}
+          label="Max available emissions"
+        />
+        <LegendItem
+          color={EMISSIONS_CHART_COLORS.actual.legend}
+          label="Actual emissions"
+        />
+      </div>
+      <div className="flex flex-col flex-auto gap-8">
+        <div className="flex-auto h-[500px]">
+          {loading ? (
+            <div className="text-center">Loading...</div>
+          ) : (
+            <Line
+              data={{
+                labels: emissions.map((item) => item.counter),
+                datasets: [
+                  {
+                    label: 'Available emissions',
+                    data: maxAvailableEmissions,
+                    order: 1,
+                    pointBackgroundColor: EMISSIONS_CHART_COLORS.available.line,
+                    borderColor: EMISSIONS_CHART_COLORS.available.line,
+                  },
+                  {
+                    label: 'Actual emissions',
+                    data: actualEmissions,
+                    order: 2,
+                    pointBackgroundColor: EMISSIONS_CHART_COLORS.actual.line,
+                    borderColor: EMISSIONS_CHART_COLORS.actual.line,
+                  },
+                ],
+              }}
+              options={getEmissionsChartOptions([
+                ...maxAvailableEmissions,
+                ...maxAvailableEmissions,
+                10 ** 18, // Add this temporarily while we don't have data on staking
+              ])}
+            />
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+ActualEmissionsChart.propTypes = {
+  emissions: PropTypes.arrayOf(emissionType).isRequired,
+  loading: PropTypes.bool.isRequired,
+};

--- a/components/OlasTokenPage/ActualEmissionsChart.jsx
+++ b/components/OlasTokenPage/ActualEmissionsChart.jsx
@@ -8,28 +8,34 @@ import {
 } from 'chart.js';
 import {
   EMISSIONS_CHART_COLORS,
-  getEmissionsChartOptions,
+  getEmissionsChartOptionsFromNumber,
 } from 'common-util/charts';
 import PropTypes from 'prop-types';
 import { Line } from 'react-chartjs-2';
+import Web3 from 'web3';
 import { LegendItem } from './LegendItem';
 import { emissionType } from './types';
 
 Chart.register(LineElement, LinearScale, PointElement, Filler, Tooltip);
 
 export const ActualEmissionsChart = ({ emissions, loading }) => {
-  const maxAvailableEmissions = emissions.map(
-    (item) =>
-      parseFloat(item.availableDevIncentives || 0) +
-      parseFloat(item.availableStakingIncentives || 0) +
-      parseFloat(item.effectiveBond || 0),
-  );
-  const actualEmissions = emissions.map(
-    (item) =>
-      parseFloat(item.devIncentivesTotalTopUp || 0) +
-      parseFloat(item.totalStakingIncentives || 0) +
-      parseFloat(item.totalCreateBondsAmountOLAS || 0),
-  );
+  const maxAvailableEmissions = emissions.map((item) => {
+    const total =
+      BigInt(item.availableDevIncentives ?? 0) +
+      BigInt(item.availableStakingIncentives ?? 0) +
+      BigInt(item.effectiveBond ?? 0);
+
+    return Web3.utils.fromWei(total, 'ether');
+  });
+
+  const actualEmissions = emissions.map((item) => {
+    const total =
+      BigInt(item.devIncentivesTotalTopUp ?? 0) +
+      BigInt(item.totalStakingIncentives ?? 0) +
+      BigInt(item.totalCreateBondsAmountOLAS ?? 0);
+
+    return Web3.utils.fromWei(total, 'ether');
+  });
 
   return (
     <div className="flex flex-col flex-auto p-4">
@@ -71,11 +77,10 @@ export const ActualEmissionsChart = ({ emissions, loading }) => {
                   },
                 ],
               }}
-              options={getEmissionsChartOptions([
+              options={getEmissionsChartOptionsFromNumber(
                 ...maxAvailableEmissions,
-                ...maxAvailableEmissions,
-                10 ** 18, // Add this temporarily while we don't have data on staking
-              ])}
+                ...actualEmissions,
+              )}
             />
           )}
         </div>

--- a/components/OlasTokenPage/index.jsx
+++ b/components/OlasTokenPage/index.jsx
@@ -157,7 +157,7 @@ const Supply = () => {
                 Actual Emissions Schedule
               </h2>
               <p className="text-slate-500">
-                What are the actual amount of OLAS minted by the protocol per
+                What is the actual amount of OLAS minted by the protocol per
                 epoch?
               </p>
             </div>

--- a/components/OlasTokenPage/index.jsx
+++ b/components/OlasTokenPage/index.jsx
@@ -1,22 +1,23 @@
-import React, { useState, useEffect } from 'react';
-import { Chart, CategoryScale, LinearScale, BarElement } from 'chart.js';
+import { BarElement, CategoryScale, Chart, LinearScale } from 'chart.js';
 import Image from 'next/image';
+import { useEffect, useState } from 'react';
 
-import { web3, getTokenomicsContract } from 'common-util/web3';
-import { emissionsQuery } from 'common-util/graphql/queries';
-import { tokenomicsGraphClient } from 'common-util/graphql/client';
 import { FLIPSIDE_URL } from 'common-util/constants';
-import Hero from './Hero';
-import { TokenDetails } from './TokenDetails';
-import { OlasUtility } from './OlasUtility';
+import { tokenomicsGraphClient } from 'common-util/graphql/client';
+import { emissionsQuery } from 'common-util/graphql/queries';
+import { getTokenomicsContract, web3 } from 'common-util/web3';
 import SectionWrapper from '../Layout/SectionWrapper';
-import { UsagePieChart } from './UsagePieChart';
-import { SupplyPieChart } from './SupplyPieChart';
+import { ActualEmissionsChart } from './ActualEmissionsChart';
 import { EmissionScheduleChart } from './EmissionScheduleChart';
-import { EmissionsToBuilders } from './EmissionsToBuilders';
 import { EmissionsToBonders } from './EmissionsToBonders';
-import { LearnMoreAboutTokenomics } from './LearnMoreAboutTokenomics';
+import { EmissionsToBuilders } from './EmissionsToBuilders';
 import { EmissionsToOperators } from './EmissionsToOperators';
+import Hero from './Hero';
+import { LearnMoreAboutTokenomics } from './LearnMoreAboutTokenomics';
+import { OlasUtility } from './OlasUtility';
+import { SupplyPieChart } from './SupplyPieChart';
+import { TokenDetails } from './TokenDetails';
+import { UsagePieChart } from './UsagePieChart';
 
 // manually register arc element, category scale, linear scale,
 // and bar element – required due to chart.js tree shaking
@@ -152,6 +153,21 @@ const Supply = () => {
 
           <div className="border rounded-lg">
             <div className="p-4 border-b">
+              <h2 className="text-xl mb-2 font-bold">
+                Actual Emissions Schedule
+              </h2>
+              <p className="text-slate-500">
+                What are the actual amount of OLAS minted by the protocol per
+                epoch?
+              </p>
+            </div>
+            <div className="p-4">
+              <ActualEmissionsChart emissions={emissions} loading={loading} />
+            </div>
+          </div>
+
+          <div className="border rounded-lg">
+            <div className="p-4 border-b">
               <h2 className="text-xl mb-2 font-bold">Current Usage</h2>
               <p className="text-slate-500">
                 What are newly minted tokens used for right now?
@@ -182,29 +198,29 @@ const Supply = () => {
             </div>
             <EmissionsToOperators emissions={emissions} loading={loading} />
           </div>
-        </div>
 
-        <div className="text-center">
-          <div className="inline-block mx-auto mb-4">
-            <Image
-              src="/images/olas-token-page/flipside.svg"
-              width={60}
-              height={60}
-              alt="Flipside logo"
-            />
+          <div className="flex flex-col border rounded-lg place-content-center text-center">
+            <div className="inline-block mx-auto mb-4">
+              <Image
+                src="/images/olas-token-page/flipside.svg"
+                width={60}
+                height={60}
+                alt="Flipside logo"
+              />
+            </div>
+
+            <h2 className="text-xl mb-4 font-bold">
+              Dive into the current distribution details
+            </h2>
+            <a
+              href={FLIPSIDE_URL}
+              className="text-purple-500"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Visit OLAS Flipside dashboard ↗
+            </a>
           </div>
-
-          <h2 className="text-xl mb-4 font-bold">
-            Dive into the current distribution details
-          </h2>
-          <a
-            href={FLIPSIDE_URL}
-            className="text-purple-500"
-            rel="noopener noreferrer"
-            target="_blank"
-          >
-            Visit OLAS Flipside dashboard ↗
-          </a>
         </div>
       </SectionWrapper>
     </div>


### PR DESCRIPTION
## Proposed changes

Added Actual Emissions Schedule chart that shows sum of actual emissions and sum of available. Changed placement of "Dive into current distribution details" part.

## Screenshots/Recordings

![image](https://github.com/user-attachments/assets/a1cc8dc9-1bad-4d8f-8c6c-17fb19501784)
![image](https://github.com/user-attachments/assets/0f9d7e11-c95b-4779-867e-52363af49725)
