### PR TITLE
style: changed operators link text on mech page

### DIFF
--- a/components/MechPage/GetInvolved.jsx
+++ b/components/MechPage/GetInvolved.jsx
@@ -23,7 +23,7 @@ const list = [
   {
     title: 'For Operators',
     desc: 'Run agents using Pearl or manually, stake & have a chance to earn rewards.',
-    urlName: 'Run Optimus agent',
+    urlName: 'Explore paths',
     url: '/operate',
     isExternal: false,
   },


### PR DESCRIPTION
## Proposed changes

Silent fix requested: changing operators link text in get involved section on the mech page.

## Screenshots/Recordings

![image](https://github.com/user-attachments/assets/ecbe44a5-0a8c-4516-aa87-271c8d528664)
