### PR TITLE
feat: added case studies page

### DIFF
--- a/components/BlogBackButton.jsx
+++ b/components/BlogBackButton.jsx
@@ -1,0 +1,10 @@
+import { ChevronLeft } from 'lucide-react';
+import Link from 'next/link';
+
+export const BlogBackButton = () => (
+  <div className="w-fit mb-4 gap-2 text-purple-800">
+    <Link href="/blog" className="flex">
+      <ChevronLeft color="#7E22CE" /> Blog
+    </Link>
+  </div>
+);

--- a/components/Content/Articles.jsx
+++ b/components/Content/Articles.jsx
@@ -12,6 +12,17 @@ const URL = `${process.env.NEXT_PUBLIC_API_URL}/api`;
 const subURL = 'blog-posts';
 const fetcher = (...args) => fetch(...args).then((res) => res.json());
 
+const folders = [
+  {
+    label: 'Quarterly Updates',
+    link: '/quarterly-updates',
+  },
+  {
+    label: 'Case Studies',
+    link: '/case-studies',
+  },
+];
+
 const Articles = ({ limit, showSeeAll, displayFolders }) => {
   const params = {
     sort: ['datePublished:desc'],
@@ -39,22 +50,23 @@ const Articles = ({ limit, showSeeAll, displayFolders }) => {
           {displayFolders && (
             <>
               <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-8 my-8">
-                <Link href="/quarterly-updates">
-                  <Card className="flex p-3 gap-2 justify-between items-center">
-                    <div className="flex">
-                      <div className="p-3 bg-purple-100 rounded-lg">
-                        <FolderClosed color="#B972E8" />
+                {folders.map((folder) => (
+                  <Link key={folder.label} href={folder.link}>
+                    <Card className="flex p-3 gap-2 justify-between items-center">
+                      <div className="flex">
+                        <div className="p-3 bg-purple-100 rounded-lg">
+                          <FolderClosed color="#B972E8" />
+                        </div>
+                        <span className="font-medium my-auto ml-3">
+                          {folder.label}
+                        </span>
                       </div>
-                      <span className="font-medium my-auto ml-3">
-                        Quarterly updates
-                      </span>
-                    </div>
-                    <ChevronRight />
-                  </Card>
-                </Link>
+                      <ChevronRight />
+                    </Card>
+                  </Link>
+                ))}
               </div>
-
-              <h3 className="text-2xl font-semibold mb-4">All posts</h3>
+              ;<h3 className="text-2xl font-semibold mb-4">All posts</h3>
             </>
           )}
 

--- a/components/Content/Articles.jsx
+++ b/components/Content/Articles.jsx
@@ -66,7 +66,7 @@ const Articles = ({ limit, showSeeAll, displayFolders }) => {
                   </Link>
                 ))}
               </div>
-              ;<h3 className="text-2xl font-semibold mb-4">All posts</h3>
+              <h3 className="text-2xl font-semibold mb-4">All posts</h3>
             </>
           )}
 

--- a/components/Content/CaseStudies.jsx
+++ b/components/Content/CaseStudies.jsx
@@ -15,7 +15,9 @@ export const CaseStudies = ({ limit }) => {
     populate: '*',
     'pagination[limit]': limit,
     filters: {
-      id: { $gte: 88, $lte: 92 },
+      funnel: {
+        id: { $eq: 9 },
+      },
     },
   };
 
@@ -24,7 +26,7 @@ export const CaseStudies = ({ limit }) => {
     fetcher,
   );
 
-  const blogItems = data?.data ?? [];
+  const caseStudies = data?.data ?? [];
 
   if (isLoading) return <Spinner />;
 
@@ -36,13 +38,15 @@ export const CaseStudies = ({ limit }) => {
         </h2>
 
         <div className="grid gap-8 md:grid-cols-2 lg:grid-cols-3">
-          {(limit ? blogItems.slice(0, limit) : blogItems).map((blogItem) => (
-            <Article
-              key={blogItem.id}
-              article={blogItem}
-              href={`/blog/${blogItem?.attributes?.slug}`}
-            />
-          ))}
+          {(limit ? caseStudies.slice(0, limit) : caseStudies).map(
+            (blogItem) => (
+              <Article
+                key={blogItem.id}
+                article={blogItem}
+                href={`/blog/${blogItem?.attributes?.slug}`}
+              />
+            ),
+          )}
         </div>
       </div>
     </section>

--- a/components/Content/CaseStudies.jsx
+++ b/components/Content/CaseStudies.jsx
@@ -1,0 +1,57 @@
+import PropTypes from 'prop-types';
+import qs from 'qs';
+import useSWR from 'swr';
+
+import { Spinner } from '../Spinner';
+import Article from './Article';
+
+const URL = `${process.env.NEXT_PUBLIC_API_URL}/api`;
+const subURL = 'blog-posts';
+const fetcher = (...args) => fetch(...args).then((res) => res.json());
+
+export const CaseStudies = ({ limit }) => {
+  const params = {
+    sort: ['datePublished:desc'],
+    populate: '*',
+    'pagination[limit]': limit,
+    filters: {
+      id: { $gte: 88, $lte: 92 },
+    },
+  };
+
+  const { data, isLoading } = useSWR(
+    `${URL}/${subURL}${params ? '?' : ''}${qs.stringify(params)}`,
+    fetcher,
+  );
+
+  const blogItems = data?.data ?? [];
+
+  if (isLoading) return <Spinner />;
+
+  return (
+    <section>
+      <div>
+        <h2 className="mb-8 text-3xl lg:text-5xl tracking-tight font-extrabold text-gray-900 ">
+          Case Studies
+        </h2>
+
+        <div className="grid gap-8 md:grid-cols-2 lg:grid-cols-3">
+          {(limit ? blogItems.slice(0, limit) : blogItems).map((blogItem) => (
+            <Article
+              key={blogItem.id}
+              article={blogItem}
+              href={`/blog/${blogItem?.attributes?.slug}`}
+            />
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+};
+
+CaseStudies.propTypes = {
+  limit: PropTypes.number,
+};
+CaseStudies.defaultProps = {
+  limit: 1000,
+};

--- a/components/Content/CaseStudies.jsx
+++ b/components/Content/CaseStudies.jsx
@@ -9,6 +9,8 @@ const URL = `${process.env.NEXT_PUBLIC_API_URL}/api`;
 const subURL = 'blog-posts';
 const fetcher = (...args) => fetch(...args).then((res) => res.json());
 
+const CASE_STUDIES_FUNNEL_ID = 9;
+
 export const CaseStudies = ({ limit }) => {
   const params = {
     sort: ['datePublished:desc'],
@@ -16,7 +18,7 @@ export const CaseStudies = ({ limit }) => {
     'pagination[limit]': limit,
     filters: {
       funnel: {
-        id: { $eq: 9 },
+        id: { $eq: CASE_STUDIES_FUNNEL_ID },
       },
     },
   };
@@ -26,7 +28,7 @@ export const CaseStudies = ({ limit }) => {
     fetcher,
   );
 
-  const caseStudies = data?.data ?? [];
+  const items = data?.data ?? [];
 
   if (isLoading) return <Spinner />;
 
@@ -38,15 +40,13 @@ export const CaseStudies = ({ limit }) => {
         </h2>
 
         <div className="grid gap-8 md:grid-cols-2 lg:grid-cols-3">
-          {(limit ? caseStudies.slice(0, limit) : caseStudies).map(
-            (blogItem) => (
-              <Article
-                key={blogItem.id}
-                article={blogItem}
-                href={`/blog/${blogItem?.attributes?.slug}`}
-              />
-            ),
-          )}
+          {(limit ? items.slice(0, limit) : items).map((blogItem) => (
+            <Article
+              key={blogItem.id}
+              article={blogItem}
+              href={`/blog/${blogItem?.attributes?.slug}`}
+            />
+          ))}
         </div>
       </div>
     </section>

--- a/components/Content/CaseStudies.jsx
+++ b/components/Content/CaseStudies.jsx
@@ -28,7 +28,7 @@ export const CaseStudies = ({ limit }) => {
     fetcher,
   );
 
-  const items = data?.data ?? [];
+  const caseStudies = data?.data ?? [];
 
   if (isLoading) return <Spinner />;
 
@@ -40,11 +40,11 @@ export const CaseStudies = ({ limit }) => {
         </h2>
 
         <div className="grid gap-8 md:grid-cols-2 lg:grid-cols-3">
-          {(limit ? items.slice(0, limit) : items).map((blogItem) => (
+          {(limit ? caseStudies.slice(0, limit) : caseStudies).map((item) => (
             <Article
-              key={blogItem.id}
-              article={blogItem}
-              href={`/blog/${blogItem?.attributes?.slug}`}
+              key={item.id}
+              article={item}
+              href={`/blog/${item?.attributes?.slug}`}
             />
           ))}
         </div>

--- a/components/Content/Updates.jsx
+++ b/components/Content/Updates.jsx
@@ -15,7 +15,9 @@ export const Updates = ({ limit }) => {
     populate: '*',
     'pagination[limit]': limit,
     filters: {
-      id: { $gte: 80, $lte: 86 },
+      funnel: {
+        id: { $eq: 8 },
+      },
     },
   };
 

--- a/components/Content/Updates.jsx
+++ b/components/Content/Updates.jsx
@@ -9,6 +9,8 @@ const URL = `${process.env.NEXT_PUBLIC_API_URL}/api`;
 const subURL = 'blog-posts';
 const fetcher = (...args) => fetch(...args).then((res) => res.json());
 
+const QUARTERLY_UPDATES_FUNNEL_ID = 8;
+
 export const Updates = ({ limit }) => {
   const params = {
     sort: ['datePublished:desc'],
@@ -16,7 +18,7 @@ export const Updates = ({ limit }) => {
     'pagination[limit]': limit,
     filters: {
       funnel: {
-        id: { $eq: 8 },
+        id: { $eq: QUARTERLY_UPDATES_FUNNEL_ID },
       },
     },
   };

--- a/pages/case-studies.jsx
+++ b/pages/case-studies.jsx
@@ -1,20 +1,20 @@
 import { BlogBackButton } from 'components/BlogBackButton';
-import { Updates } from 'components/Content/Updates';
+import { CaseStudies } from 'components/Content/CaseStudies';
 import PageWrapper from 'components/Layout/PageWrapper';
 import SectionWrapper from 'components/Layout/SectionWrapper';
 import Meta from 'components/Meta';
 
-const UpdatesPage = () => (
+const CaseStudiesPage = () => (
   <PageWrapper>
     <Meta
-      pageTitle="Quarterly Updates"
-      description="Stay informed with our latest quarterly updates, featuring key insights, progress reports, and upcoming developments."
+      pageTitle="Case Studies"
+      description="Read up on the various success stories achieved with Olas!"
     />
     <SectionWrapper>
       <BlogBackButton />
-      <Updates />
+      <CaseStudies />
     </SectionWrapper>
   </PageWrapper>
 );
 
-export default UpdatesPage;
+export default CaseStudiesPage;


### PR DESCRIPTION
## Proposed changes

Added Case Studies page - filtered similarly to the Quarterly Updates page as there is no funnel for case studies currently.

## Screenshots/Recordings

![image](https://github.com/user-attachments/assets/018e2f86-3186-4177-97c3-742faec4c04d)
![image](https://github.com/user-attachments/assets/3b213f1b-8fbc-4d7b-9d4e-606e718eadc4)

## Things to keep in mind

- [x] I confirm I have updated the meta title and description for the page, if applicable.
