### PR TITLE
chore: replaced a2a transactions api from dune to flipside

### DIFF
--- a/common-util/api/dune.js
+++ b/common-util/api/dune.js
@@ -1,5 +1,4 @@
 import {
-  A2A_TRANSACTIONS_QUERY_ID,
   DAILY_CONTRIBUTORS_QUERY_ID,
   MECH_TXS_QUERY_ID,
   UNIQUE_BUILDERS_QUERY_ID,
@@ -86,17 +85,6 @@ export const getVeOlasHolders = async () => {
     return veOlasHolders;
   } catch (error) {
     console.error('Error in getVeOlasHolders: ', error);
-    return;
-  }
-};
-
-export const getA2ATransactions = async () => {
-  try {
-    const json = await duneApiCall({ queryId: A2A_TRANSACTIONS_QUERY_ID });
-    const a2aTransactions = get(json, 'result.rows[0].total_requests');
-    return a2aTransactions;
-  } catch (error) {
-    console.error('Error in getA2ATransactions: ', error);
     return;
   }
 };

--- a/common-util/api/flipside.js
+++ b/common-util/api/flipside.js
@@ -39,6 +39,19 @@ export const get7DaysAvgActivity = async () => {
   return Math.floor(average);
 };
 
+const A2A_TRANSACTIONS_ID = '7e9a5b20-b6e6-47d7-8420-2410542085d5';
+export const getA2ATransactions = async () => {
+  try {
+    const result = await flipsideCryptoApiCall({
+      queryId: A2A_TRANSACTIONS_ID,
+    });
+    const a2aTxs = get(result, "[1]['CUMULATIVE_TOTAL']") || null;
+    return a2aTxs;
+  } catch (error) {
+    console.error('Error in getA2ATransactions: ', error);
+  }
+};
+
 const SEVEN_DAY_AVG_DAILY_ACTIVE_AGENTS_ID =
   '276784c3-8481-4b46-9334-6e579b524628';
 export const getSevenDayAvgDailyActiveAgents = async () => {

--- a/components/HomepageSection/Activity.jsx
+++ b/components/HomepageSection/Activity.jsx
@@ -1,6 +1,6 @@
-import { getA2ATransactions } from 'common-util/api/dune';
 import {
   get7DaysAvgActivity,
+  getA2ATransactions,
   getTotalTransactionsCount,
   getTotalUnitsCount,
 } from 'common-util/api/flipside';
@@ -60,7 +60,7 @@ export const Activity = () => {
             {metrics?.a2aTransactions ? (
               <ExternalLink
                 className="text-2xl font-bold text-purple-600"
-                href="https://dune.com/queries/4414339/7394666"
+                href="https://flipsidecrypto.xyz/flipsideteam/q/PVARr5q0B7HD/mech-requests/visualizations/v2/34079b3c-8115-428b-9902-5a0afca3149e"
               >
                 {metrics.a2aTransactions.toLocaleString()}
               </ExternalLink>


### PR DESCRIPTION
## Proposed changes

Now using flipside for homepage agent-to-agent transactions metric.

## Screenshots/Recordings

![image](https://github.com/user-attachments/assets/634c7682-1434-4b12-b9b7-4e51813829c4)
