### PR TITLE
feat: replaced dune endpoint and fixed Sankey diagram

### DIFF
--- a/common-util/api/dune.js
+++ b/common-util/api/dune.js
@@ -106,11 +106,12 @@ export const getFeeFlowMetrics = async () => {
     const json = await duneApiCall({
       queryId: FEE_FLOW_QUERY_ID,
     });
-    const totalFees = get(json, 'result.rows[0].usd_amount');
-    const collectedFees = get(json, 'result.rows[1].usd_amount');
-    const unclaimedFees = get(json, 'result.rows[2].usd_amount');
-    const recievedFees = get(json, 'result.rows[3].usd_amount');
-    return { totalFees, collectedFees, unclaimedFees, recievedFees };
+    const totalFees = get(json, 'result.rows[0].Total_Agent_Fees_Collected');
+    const claimedFees = get(json, 'result.rows[0].Claimed_Fees');
+    const unclaimedFees = get(json, 'result.rows[0].Unclaimed_Fees');
+    const recievedFees = get(json, 'result.rows[0].Recieved_Fees');
+    const olasBurned = get(json, 'result.rows[0].OLAS_Burned');
+    return { totalFees, claimedFees, unclaimedFees, recievedFees, olasBurned };
   } catch (error) {
     console.error('Error in getFeeFlowMetrics: ', error);
     return;

--- a/common-util/constants.js
+++ b/common-util/constants.js
@@ -33,7 +33,7 @@ export const OLAS_ECONOMY_DASHBOARD_URL =
   'https://dune.com/adrian0x/autonolas-ecosystem-activity';
 export const OLAS_PROTOCOL_LIQUIDITY_URL = 'https://dune.com/adrian0x/olas';
 export const DAILY_CONTRIBUTORS_QUERY_ID = '4349554';
-export const FEE_FLOW_QUERY_ID = '5103896';
+export const FEE_FLOW_QUERY_ID = '5166975';
 
 export const SHORTS_URL = 'https://shorts.wtf';
 export const REGISTRY_URL = 'https://registry.olas.network/';

--- a/components/MechPage/FeeMetrics.jsx
+++ b/components/MechPage/FeeMetrics.jsx
@@ -28,7 +28,7 @@ const fetchMetrics = async () => {
 };
 
 const formatToTooltip = ({ from, to }) =>
-  `${from.label} → ${to.label} | $${to.value} (${Number((to.value / from.value) * 100).toFixed(2)}%))`;
+  `${from.label} → ${to.label} | $${to.value.toFixed(2)} (${Number((to.value / from.value) * 100).toFixed(2)}%)`;
 
 export const FeeMetrics = () => {
   const { data: metrics, error } = usePersistentSWR(

--- a/components/MechPage/FeeMetrics.jsx
+++ b/components/MechPage/FeeMetrics.jsx
@@ -15,10 +15,11 @@ const fetchMetrics = async () => {
       throw new Error('Failed to fetch metrics');
     }
     return {
-      collectedFees: result.collectedFees,
-      recievedFees: result.recievedFees,
-      unclaimedFees: result.unclaimedFees,
       totalFees: result.totalFees,
+      claimedFees: result.claimedFees,
+      unclaimedFees: result.unclaimedFees,
+      recievedFees: result.recievedFees,
+      olasBurned: result.olasBurned,
     };
   } catch (error) {
     console.error('Error in fetchMetrics:', error);
@@ -66,19 +67,29 @@ export const FeeMetrics = () => {
       recieved: {
         id: 'received',
         label: 'Fees Received',
-        value: metrics?.recievedFees || metrics?.claimedFees * 0.99 || 0,
+        value: metrics?.recievedFees || 0,
         color: '#68bcce',
       },
       burned: {
         id: 'olas-burned',
         label: 'OLAS Burned',
-        // Olas burned will always be 1% of claimed fees
-        value: metrics?.claimedFees * 0.01 || 0,
+        // Olas burned should always be 1% of claimed fees
+        value: metrics?.olasBurned || 0,
         color: '#dab2e4',
       },
     }),
     [metrics],
   );
+
+  const CheckOlasBurnt = () => {
+    const { burned, recieved } = formerData;
+
+    const isZero = burned.value === 0;
+    return {
+      olasBurnedBranch: isZero ? 0 : burned.value * 10,
+      recievedFeesBranch: isZero ? recieved.value : recieved.value * (90 / 99),
+    };
+  };
 
   // Sankey diagram data structure:
   // Each row represents a flow between nodes with format: [From, To, Value, Tooltip]
@@ -111,7 +122,7 @@ export const FeeMetrics = () => {
       'Claimed Fees',
       'OLAS Burned',
       // Using 10% for visual clarity instead of actual 1% to make the flow visible
-      formerData.burned.value * 10,
+      CheckOlasBurnt().olasBurnedBranch,
       formatToTooltip({
         from: formerData.claimed,
         to: formerData.burned,
@@ -121,12 +132,16 @@ export const FeeMetrics = () => {
       'Claimed Fees',
       'Fees Received',
       // Using 90% to fit "Claimed Fees" branch
-      formerData.recieved.value * (90 / 99),
+      CheckOlasBurnt().recievedFeesBranch,
       formatToTooltip({
         from: formerData.claimed,
         to: formerData.recieved,
       }),
     ],
+    // Add a small dummy flow when olasBurned is 0 to maintain spacing between Unclaimed Fees and Fees Recieved node
+    ...(formerData.burned.value === 0
+      ? [['Claimed Fees', 'OLAS Burned', 0.01, '']]
+      : []),
   ];
 
   const options = {
@@ -206,9 +221,9 @@ export const FeeMetrics = () => {
                     href={DUNE_MMV2_URL}
                     target="_blank"
                     rel="noopener noreferrer"
-                    className="block text-4xl whitespace-nowrap max-sm:text-xl font-extrabold mb-4 mt-auto"
+                    className="block text-3xl whitespace-nowrap max-sm:text-xl font-extrabold mb-4 mt-auto"
                   >
-                    $ {item.value} ↗
+                    $ {Number(item.value.toFixed(2)).toLocaleString()} ↗
                   </Link>
                 </div>
               );


### PR DESCRIPTION
## Proposed changes

* Replaced dune endpoint to get MM fee values from
* Sankey diagram looked awkward when olasBurned was 0:
  * Created fallback so when olasBurned is 0, the node is accurate in showing that 100% of claimed fees are going into recievedFees
  * When olasBurned !== 0, olasBurned branch value is set to 10% (visually) and olasRecieved set to 90% for better visual clarity
  * Also added a tiny dummy flow for when olasBurned is 0 because the graph looks awkward without it (node overlap as seen in screenshot 1)
  * Fixed displayed value formatting

## Screenshots/Recordings

Without dummy branch:
![image](https://github.com/user-attachments/assets/19148e2b-ca4d-42bb-a16d-c49ce53c9cc0)

With dummy branch:
![image](https://github.com/user-attachments/assets/8f3e2ae2-7998-497d-8483-9cc3c5678e58)