### PR TITLE
fix: hash state is not initially set

### DIFF
--- a/hooks/useHash.js
+++ b/hooks/useHash.js
@@ -6,6 +6,8 @@ export const useHash = () => {
   useEffect(() => {
     const handleHashChange = () => setHash(window.location.hash);
 
+    handleHashChange();
+
     window.addEventListener('hashchange', handleHashChange);
     return () => window.removeEventListener('hashchange', handleHashChange);
   }, []);


### PR DESCRIPTION
## Proposed changes

When a page url already contains hash, it's not properly set in useState, before only changing was handled

## Screenshots/Recordings

<!-- Add screenshots or recordings of the changes you made. -->

## Things to keep in mind

<!-- Please check if the PR fulfills these requirements -->

- [ ] I confirm I have updated the meta title and description for the page, if applicable.
