### PR TITLE
chore: changed link to eth cc event on au page

### DIFF
--- a/components/AUPage/CTA.jsx
+++ b/components/AUPage/CTA.jsx
@@ -10,7 +10,7 @@ const list = [
     imageSrc: 'EthCC-Cannes.png',
     location: 'Cannes',
     date: "Jun 30 '25",
-    eventLink: 'https://ethcc.io/',
+    eventLink: 'https://lu.ma/tp6rhykz',
   },
   {
     title: 'Builders Night',


### PR DESCRIPTION
## Proposed changes

Eth Cannes event link now leads to https://lu.ma/tp6rhykz.
