### PR TITLE
feat: display olas apy on babydegen page

### DIFF
--- a/common-util/api/index.js
+++ b/common-util/api/index.js
@@ -127,21 +127,18 @@ export const getAverageAprs = async () => {
 };
 
 const ONE_YEAR = 1 * 24 * 60 * 60 * 365;
-const getMaxApy = (contracts) => {
-  const getApy = (contract) => {
+const getMaxApr = (contracts) => {
+  const getApr = (contract) => {
     const rewardsPerYear = BigInt(contract.rewardsPerSecond) * BigInt(ONE_YEAR);
     const apy =
       (rewardsPerYear * BigInt(100)) / BigInt(contract.minStakingDeposit);
     return Number(apy) / (1 + Number(contract.numAgentInstances));
   };
 
-  const firstApy = getApy(contracts[0]);
-  console.log('firstApy', firstApy);
-
-  return Math.max(...contracts.map((contract) => getApy(contract)));
+  return Math.max(...contracts.map((contract) => getApr(contract)));
 };
 
-export const getBabydegenOlasApy = async () => {
+export const getBabydegenOlasApr = async () => {
   try {
     const [modiusContractsResult, optimusContractsResult] =
       await Promise.allSettled([
@@ -163,11 +160,11 @@ export const getBabydegenOlasApy = async () => {
         : null;
 
     return {
-      modius: modiusContracts ? getMaxApy(modiusContracts) : null,
-      optimus: optimusContracts ? getMaxApy(optimusContracts) : null,
+      modius: modiusContracts ? getMaxApr(modiusContracts) : null,
+      optimus: optimusContracts ? getMaxApr(optimusContracts) : null,
     };
   } catch (error) {
-    console.error('Error fetching OLAS APYs:', error);
+    console.error('Error fetching OLAS APRs:', error);
     return {
       modius: null,
       optimus: null,

--- a/common-util/constants.js
+++ b/common-util/constants.js
@@ -57,7 +57,8 @@ export const BONDING_PROGRAMS_URL =
   'https://bond.olas.network/bonding-products';
 
 export const DEV_REWARDS_URL = 'https://build.olas.network/dev-incentives';
-export const OPERATE_AGENTS_URL = 'https://operate.olas.network/agents';
+export const OPERATE_URL = 'https://operate.olas.network';
+export const OPERATE_AGENTS_URL = `${OPERATE_URL}/agents`;
 export const LAUNCH_URL = 'https://launch.olas.network/';
 export const VEOLAS_URL = 'https://govern.olas.network/veolas';
 
@@ -68,3 +69,18 @@ export const ACCELERATOR_APPLY_URL =
 export const QUICKSTART_URL = 'https://github.com/valory-xyz/quickstart';
 
 export const DISCORD_INVITE_URL = 'https://discord.com/invite/BQzYqhjGjQ';
+
+export const MODIUS_STAKING_CONTRACTS = [
+  '0x534C0A05B6d4d28d5f3630D6D74857B253cf8332',
+  '0xeC013E68FE4B5734643499887941eC197fd757D0',
+  '0x9034D0413D122015710f1744A19eFb1d7c2CEB13',
+  '0x8BcAdb2c291C159F9385964e5eD95a9887302862',
+  '0x5fc25f50e96857373c64dc0edb1abcbed4587e91',
+  '0xa008f200a4eba119d25a19c8e100751a6da1f52c',
+  '0xed8cded731b34c90bdaf5f6e9d9035433cf73689',
+];
+export const OPTIMUS_STAKING_CONTRACTS = [
+  '0xBCA056952D2A7a8dD4A002079219807CFDF9fd29',
+  '0x0f69f35652B1acdbD769049334f1AC580927E139',
+  '0x6891Cf116f9a3bDbD1e89413118eF81F69D298C3',
+];

--- a/common-util/graphql/queries.js
+++ b/common-util/graphql/queries.js
@@ -35,3 +35,14 @@ export const rewardUpdates = (epochs) => gql`
     )}
   }
 `;
+
+export const stakingContractsQuery = (addresses) => gql`
+  {
+    stakingContracts(where: {instance_in: [${addresses.map((address) => `"${address}"`)}]}) {
+      id
+      rewardsPerSecond
+      minStakingDeposit
+      numAgentInstances
+    }
+  }
+`;

--- a/components/BabydegenEconomyPage/BabydegenMetrics.jsx
+++ b/components/BabydegenEconomyPage/BabydegenMetrics.jsx
@@ -1,7 +1,7 @@
 import Image from 'next/image';
 import { useMemo } from 'react';
 
-import { getAverageAprs, getBabydegenOlasApy } from 'common-util/api';
+import { getAverageAprs, getBabydegenOlasApr } from 'common-util/api';
 import { OPERATE_URL } from 'common-util/constants';
 import SectionWrapper from 'components/Layout/SectionWrapper';
 import { Card } from 'components/ui/card';
@@ -15,26 +15,26 @@ const OPTIMUS_HUGGINGFACE_URL =
 
 const fetchMetrics = async () => {
   try {
-    const [averageAprsResult, maxOlasApysResult] = await Promise.allSettled([
+    const [averageAprsResult, maxOlasAprsResult] = await Promise.allSettled([
       getAverageAprs(),
-      getBabydegenOlasApy(),
+      getBabydegenOlasApr(),
     ]);
 
     const averageAprs =
       averageAprsResult.status === 'fulfilled' ? averageAprsResult.value : null;
-    const maxOlasApys =
-      maxOlasApysResult.status === 'fulfilled' ? maxOlasApysResult.value : null;
+    const maxOlasAprs =
+      maxOlasAprsResult.status === 'fulfilled' ? maxOlasAprsResult.value : null;
 
     return {
       modius: {
         latestAvgApr: averageAprs?.modius?.latestAvgApr || null,
         latestEthApr: averageAprs?.modius?.latestEthApr || null,
-        maxOlasApy: maxOlasApys?.modius || null,
+        maxOlasApr: maxOlasAprs?.modius || null,
       },
       optimus: {
         latestAvgApr: averageAprs?.optimus?.latestAvgApr || null,
         latestEthApr: averageAprs?.optimus?.latestEthApr || null,
-        maxOlasApy: maxOlasApys?.optimus || null,
+        maxOlasApr: maxOlasAprs?.optimus || null,
       },
     };
   } catch (error) {
@@ -69,9 +69,9 @@ const MetricsBubble = ({ metrics, sourceUrl, image, title }) => {
         source: sourceUrl,
       },
       {
-        id: 'olasApy',
-        subText: 'APY, OLAS - Via OLAS Staking',
-        value: metrics?.maxOlasApy ? formatNumber(metrics.maxOlasApy) : null,
+        id: 'olasApr',
+        subText: 'APR, OLAS - Via OLAS Staking',
+        value: metrics?.maxOlasApr ? formatNumber(metrics.maxOlasApr) : null,
         source: OPERATE_URL,
       },
     ],

--- a/components/BabydegenEconomyPage/BabydegenMetrics.jsx
+++ b/components/BabydegenEconomyPage/BabydegenMetrics.jsx
@@ -1,6 +1,8 @@
+import Image from 'next/image';
 import { useMemo } from 'react';
 
-import { getAverageAprs } from 'common-util/api';
+import { getAverageAprs, getBabydegenOlasApy } from 'common-util/api';
+import { OPERATE_URL } from 'common-util/constants';
 import SectionWrapper from 'components/Layout/SectionWrapper';
 import { Card } from 'components/ui/card';
 import { ExternalLink } from 'components/ui/typography';
@@ -13,16 +15,26 @@ const OPTIMUS_HUGGINGFACE_URL =
 
 const fetchMetrics = async () => {
   try {
-    const averageAprs = await getAverageAprs();
+    const [averageAprsResult, maxOlasApysResult] = await Promise.allSettled([
+      getAverageAprs(),
+      getBabydegenOlasApy(),
+    ]);
+
+    const averageAprs =
+      averageAprsResult.status === 'fulfilled' ? averageAprsResult.value : null;
+    const maxOlasApys =
+      maxOlasApysResult.status === 'fulfilled' ? maxOlasApysResult.value : null;
 
     return {
       modius: {
         latestAvgApr: averageAprs?.modius?.latestAvgApr || null,
         latestEthApr: averageAprs?.modius?.latestEthApr || null,
+        maxOlasApy: maxOlasApys?.modius || null,
       },
       optimus: {
         latestAvgApr: averageAprs?.optimus?.latestAvgApr || null,
         latestEthApr: averageAprs?.optimus?.latestEthApr || null,
+        maxOlasApy: maxOlasApys?.optimus || null,
       },
     };
   } catch (error) {
@@ -37,62 +49,54 @@ const formatNumber = (num) => {
   return `${numTo1dp}%`;
 };
 
-const MetricsBubble = ({ metrics, sourceUrl, name }) => {
+const MetricsBubble = ({ metrics, sourceUrl, image, title }) => {
   const data = useMemo(
     () => [
       {
+        id: 'toUSDC',
+        subText: 'APR, Relative to USDC - Moving Average 7D',
+        value: metrics?.latestEthApr
+          ? formatNumber(metrics.latestEthApr)
+          : null,
+        source: sourceUrl,
+      },
+      {
         id: 'toETH',
-        subText: 'Relative to ETH',
+        subText: 'APR, Relative to ETH - Moving Average 7D',
         value: metrics?.latestAvgApr
           ? formatNumber(metrics.latestAvgApr)
           : null,
         source: sourceUrl,
       },
       {
-        id: 'toUSDC',
-        subText: 'Relative to USDC',
-        value: metrics?.latestEthApr
-          ? formatNumber(metrics.latestEthApr)
-          : null,
-        source: sourceUrl,
+        id: 'olasApy',
+        subText: 'APY, OLAS - Via OLAS Staking',
+        value: metrics?.maxOlasApy ? formatNumber(metrics.maxOlasApy) : null,
+        source: OPERATE_URL,
       },
     ],
     [metrics, sourceUrl],
   );
 
   return (
-    <Card className="p-6 border border-purple-200 rounded-full text-xl w-fit rounded-2xl bg-gradient-to-t from-[#F1DBFF] to-[#FDFAFF] items-center">
-      <div className="text-center mb-6">
-        <div className="font-bold">{name}</div>
-        <span className="text-lg text-black max-w-fit">
-          📈 APR - Moving Average 7d
-        </span>
-      </div>
+    <Card className="p-8 border border-slate-200 rounded-full text-xl w-fit rounded-2xl bg-gradient-to-b from-[rgba(244,247,251,0.2)] to-[#F4F7FB] items-center">
+      <Image alt={title} src={image} width="48" height="48" className="mb-4" />
+      <div className="text-lg font-medium mb-6">{title}</div>
 
-      <div className="md:grid-cols-2 grid gap-6">
-        {data.map((item, index) => {
-          const borderClassName =
-            index === 0
-              ? 'max-sm:border-b-1.5 md:border-r-1.5 border-purple-200'
-              : '';
-
-          return (
-            <div
-              key={item.id}
-              className={`text-center w-[345px] py-6 2xl:py-3 px-8 border-gray-300 h-full w-full ${borderClassName}`}
-            >
-              <span className="block text-5xl max-sm:text-4xl font-extrabold mb-4 text-purple-600">
-                <ExternalLink href={item.source} hideArrow>
-                  {!metrics || item.value === null ? '0.0%' : item.value}
-                  <span className="text-2xl">↗</span>
-                </ExternalLink>
-              </span>
-              <span className="block text-lg text-slate-700">
-                {item.subText}
-              </span>
-            </div>
-          );
-        })}
+      <div className="flex flex-col gap-8">
+        {data.map((item) => (
+          <div key={item.id} className="flex flex-col gap-3">
+            <span className="block text-base text-slate-700">
+              {item.subText}
+            </span>
+            <span className="block text-2xl font-semibold text-purple-600">
+              <ExternalLink href={item.source} hideArrow>
+                {!metrics || item.value === null ? '0.0%' : item.value}
+                <span className="text-2xl">↗</span>
+              </ExternalLink>
+            </span>
+          </div>
+        ))}
       </div>
     </Card>
   );
@@ -103,21 +107,19 @@ export const BabydegenMetrics = () => {
 
   return (
     <SectionWrapper id="stats">
-      <div className="flex flex-wrap gap-8 justify-center">
-        <div className="flex flex-col gap-4">
-          <MetricsBubble
-            name="MODIUS"
-            metrics={metrics?.modius}
-            sourceUrl={MODIUS_HUGGINGFACE_URL}
-          />
-        </div>
-        <div className="flex flex-col gap-4">
-          <MetricsBubble
-            name="OPTIMUS"
-            metrics={metrics?.optimus}
-            sourceUrl={OPTIMUS_HUGGINGFACE_URL}
-          />
-        </div>
+      <div className="flex flex-wrap gap-6 justify-center">
+        <MetricsBubble
+          title="Modius Agent Economy"
+          image="/images/babydegen-econ-page/modius.png"
+          metrics={metrics?.modius}
+          sourceUrl={MODIUS_HUGGINGFACE_URL}
+        />
+        <MetricsBubble
+          title="Optimus Agent Economy"
+          image="/images/babydegen-econ-page/optimus.png"
+          metrics={metrics?.optimus}
+          sourceUrl={OPTIMUS_HUGGINGFACE_URL}
+        />
       </div>
     </SectionWrapper>
   );

--- a/pages/api/babydegen-metrics.js
+++ b/pages/api/babydegen-metrics.js
@@ -1,7 +1,7 @@
 import { Client } from '@gradio/client';
 
 const MIN_TOTAL_TRACES = 2;
-const CACHE_DURATION_SECONDS = 24 * 60 * 60; // 86400 seconds = 24 hours
+const CACHE_DURATION_SECONDS = 12 * 60 * 60; // 12 hours
 
 const fetchAgentPerformance = async (agentName) => {
   try {


### PR DESCRIPTION
## Proposed changes

display APY (by the same logic as on operate app) on babydegen page

To be confirmed with Michael: if we agreed on we display as is but just rename APY OLAS to APR OLAS


## Screenshots/Recordings

<img width="1512" alt="image" src="https://github.com/user-attachments/assets/de023361-3ac1-41b3-aedc-0b17fa5c3397" />

## Things to keep in mind

<!-- Please check if the PR fulfills these requirements -->

- [ ] I confirm I have updated the meta title and description for the page, if applicable.
