### PR TITLE
chore: added replay link for cannes AU

### DIFF
--- a/components/AUPage/CTA.jsx
+++ b/components/AUPage/CTA.jsx
@@ -12,6 +12,8 @@ const list = [
     location: 'Cannes',
     date: "Jun 30 '25",
     eventLink: 'https://lu.ma/tp6rhykz',
+    replayLink:
+      'https://www.youtube.com/playlist?list=PLoP4p0r-X94quxM9EVcheuv--pJB0UfXM',
   },
   {
     title: 'Builders Night',


### PR DESCRIPTION
## Proposed changes

Added link for Cannes AU . Remove "Upcoming" tag.

## Screenshots/Recordings

<img width="1078" height="395" alt="image" src="https://github.com/user-attachments/assets/3a78a2ad-079d-49c7-aec8-1c5ceab87dd1" />
