### PR TITLE
style: added agent economies on mobile, fixed typo and removed step 7…

### DIFF
--- a/components/AcceleratorPage/HowDoesAcceleratorWork.jsx
+++ b/components/AcceleratorPage/HowDoesAcceleratorWork.jsx
@@ -2,7 +2,6 @@ import { SUB_HEADER_CLASS } from 'common-util/classes';
 import { ACCELERATOR_APPLY_URL } from 'common-util/constants';
 import SectionWrapper from 'components/Layout/SectionWrapper';
 import { ExternalLink } from 'components/ui/typography';
-import Link from 'next/link';
 
 const list = [
   {
@@ -43,20 +42,20 @@ const list = [
     description:
       'Awarded on achieving 1,000 Daily Active Agents within 90 days of the MVP delivery.',
   },
-  {
-    title: 'Earn additional OLAS rewards',
-    description: (
-      <>
-        Teams that register their agent code in the Olas Protocol can also
-        receive ongoing OLAS Dev Rewards. Top developers are already earning
-        thousands of OLAS each month.{' '}
-        <Link className="text-purple-600" href="/build">
-          Learn more
-        </Link>
-        .
-      </>
-    ),
-  },
+  // {
+  //   title: 'Earn additional OLAS rewards',
+  //   description: (
+  //     <>
+  //       Teams that register their agent code in the Olas Protocol can also
+  //       receive ongoing OLAS Dev Rewards. Top developers are already earning
+  //       thousands of OLAS each month.{' '}
+  //       <Link className="text-purple-600" href="/build">
+  //         Learn more
+  //       </Link>
+  //       .
+  //     </>
+  //   ),
+  // },
 ];
 
 export const HowDoesAcceleratorWork = () => (

--- a/components/HomepageSection/Activity.jsx
+++ b/components/HomepageSection/Activity.jsx
@@ -18,10 +18,9 @@ import {
 import SectionHeading from 'components/SectionHeading';
 import { Card } from 'components/ui/card';
 import { Popover } from 'components/ui/popover';
-import { ExternalLink } from 'components/ui/typography';
+import { ExternalLink, Link } from 'components/ui/typography';
 import { usePersistentSWR } from 'hooks';
 import Image from 'next/image';
-import Link from 'next/link';
 import { useMemo } from 'react';
 
 const imgPath = '/images/homepage/activity/';
@@ -234,6 +233,21 @@ const TransactionsCard = ({ transactions }) => (
   />
 );
 
+const AgentsGrid = () => (
+  <div className="flex flex-row w-[124px] flex-wrap mb-2 px-auto">
+    {agents.map((item) => (
+      <Image
+        key={item}
+        src={`/images/homepage/activity/${item}.png`}
+        alt={item}
+        width={62}
+        height={62}
+        className="hover:-translate-y-1 duration-150"
+      />
+    ))}
+  </div>
+);
+
 export const Activity = () => {
   const { data: metrics } = usePersistentSWR('tokenMetrics', fetchMetrics);
 
@@ -302,24 +316,8 @@ export const Activity = () => {
             <OlasIsBurnedArrow />
           </div>
           <div className="flex flex-col place-items-center z-10">
-            <div className="flex flex-row w-[124px] flex-wrap mb-2 px-auto">
-              {agents.map((item) => (
-                <Image
-                  key={item}
-                  src={`/images/homepage/activity/${item}.png`}
-                  alt={item}
-                  width={62}
-                  height={62}
-                  className="hover:-translate-y-1 duration-150"
-                />
-              ))}
-            </div>
-            <Link
-              href="/agent-economies"
-              className="text-purple-700 hover:text-purple-900"
-            >
-              Agent economies
-            </Link>
+            <AgentsGrid />
+            <Link href="/agent-economies">Agent economies</Link>
           </div>
           <div className="flex flex-col">
             <DailyActiveAgentsCard
@@ -401,8 +399,15 @@ export const Activity = () => {
           alt="arrow"
           width={343}
           height={202}
-          className="mx-auto"
+          className="mx-auto mb-12"
         />
+        <div className="mx-auto grid place-items-center">
+          <AgentsGrid />
+          <div>
+            As a result, <Link href="/agent-economies">Agent economies</Link>{' '}
+            are thriving.
+          </div>
+        </div>
       </div>
     </div>
   );

--- a/components/PearlPage/WhyRunPearl.jsx
+++ b/components/PearlPage/WhyRunPearl.jsx
@@ -27,7 +27,7 @@ const list = [
   {
     title: 'Own Your AI agent',
     icon: <Copyright />,
-    desc: "When you use run an AI agent on Pearl, you don't just run it— you own it. Running an agent on Pearl means it's yours: you operate it and benefit from it.",
+    desc: "When you use an AI agent on Pearl, you don't just run it— you own it. Running an agent on Pearl means it's yours: you operate it and benefit from it.",
   },
 ];
 


### PR DESCRIPTION
… on accelerator

## Proposed changes

* Agent economies link on homepage
* Typo fix on Pearl page
* Removal of step 7 on accelerator program

## Screenshots/Recordings

<img width="357" height="764" alt="image" src="https://github.com/user-attachments/assets/2a4cabc9-d559-43e9-aaa5-9987556b7b67" />
<img width="643" height="195" alt="image" src="https://github.com/user-attachments/assets/e905bc7e-e09f-4f9d-bc55-7f34613ce115" />
<img width="794" height="867" alt="image" src="https://github.com/user-attachments/assets/51946de7-1254-4093-988a-671a9d921ed8" />
