### PR TITLE
Add new subgraph queries for operator count on 

### DIFF
--- a/common-util/graphql/queries.js
+++ b/common-util/graphql/queries.js
@@ -204,6 +204,15 @@ export const registryGlobalsQuery = gql`
   }
 `;
 
+export const operatorGlobalsQuery = gql`
+  query OperatorGlobals {
+    globals {
+      id
+      totalOperators
+    }
+  }
+`;
+
 export const ataTransactionsQuery = gql`
   query AtaTransactions {
     globals(where: { id: "" }) {

--- a/components/DataPage/Operators.jsx
+++ b/components/DataPage/Operators.jsx
@@ -1,0 +1,78 @@
+import { SUB_HEADER_LG_CLASS, TEXT_MEDIUM_CLASS } from 'common-util/classes';
+import { operatorGlobalsQuery } from 'common-util/graphql/queries';
+import SectionWrapper from 'components/Layout/SectionWrapper';
+import { ExternalLink } from 'components/ui/typography';
+import { CodeSnippet } from './CodeSnippet';
+
+export const OperatorsInfo = () => {
+  return (
+    <SectionWrapper id="operators">
+      <h2 className={SUB_HEADER_LG_CLASS}>Operators</h2>
+
+      <div className="space-y-6 mt-4">
+        <p>
+          Tracks the total number of unique operators across all supported
+          networks. This metric aggregates operator data from multiple
+          blockchain sources to provide a comprehensive view of the autonomous
+          agent operator ecosystem and network participation.
+        </p>
+
+        <p>The following query aggregates operators from all chains:</p>
+
+        <h3 className={`${TEXT_MEDIUM_CLASS} font-bold`}>Operators Query</h3>
+
+        <p className="text-purple-600">
+          Subgraph links:{' '}
+          <ExternalLink
+            href={process.env.NEXT_PUBLIC_GNOSIS_REGISTRY_SUBGRAPH_URL}
+            className="mr-2"
+          >
+            Gnosis
+          </ExternalLink>
+          <ExternalLink
+            href={process.env.NEXT_PUBLIC_BASE_REGISTRY_SUBGRAPH_URL}
+            className="mr-2"
+          >
+            Base
+          </ExternalLink>
+          <ExternalLink
+            href={process.env.NEXT_PUBLIC_MODE_REGISTRY_SUBGRAPH_URL}
+            className="mr-2"
+          >
+            Mode
+          </ExternalLink>
+          <ExternalLink
+            href={process.env.NEXT_PUBLIC_OPTIMISM_REGISTRY_SUBGRAPH_URL}
+            className="mr-2"
+          >
+            Optimism
+          </ExternalLink>
+          <ExternalLink
+            href={process.env.NEXT_PUBLIC_CELO_REGISTRY_SUBGRAPH_URL}
+            className="mr-2"
+          >
+            Celo
+          </ExternalLink>
+          <ExternalLink
+            href={process.env.NEXT_PUBLIC_ETHEREUM_REGISTRY_SUBGRAPH_URL}
+            className="mr-2"
+          >
+            Ethereum
+          </ExternalLink>
+          <ExternalLink
+            href={process.env.NEXT_PUBLIC_POLYGON_REGISTRY_SUBGRAPH_URL}
+            className="mr-2"
+          >
+            Polygon
+          </ExternalLink>
+          <ExternalLink
+            href={process.env.NEXT_PUBLIC_ARBITRUM_REGISTRY_SUBGRAPH_URL}
+          >
+            Arbitrum
+          </ExternalLink>
+        </p>
+        <CodeSnippet>{operatorGlobalsQuery}</CodeSnippet>
+      </div>
+    </SectionWrapper>
+  );
+};

--- a/components/HomepageSection/Activity.jsx
+++ b/components/HomepageSection/Activity.jsx
@@ -1,10 +1,6 @@
 import { getMainMetrics } from 'common-util/api';
 import { getTotalUniqueStakers } from 'common-util/api/dune';
-import {
-  DUNE_AGENTS_QUERY_URL,
-  DUNE_MMV2_URL,
-  VALORY_GIT_URL,
-} from 'common-util/constants';
+import { DUNE_MMV2_URL, VALORY_GIT_URL } from 'common-util/constants';
 import SectionHeading from 'components/SectionHeading';
 import { Card } from 'components/ui/card';
 import { Popover } from 'components/ui/popover';
@@ -42,6 +38,10 @@ const fetchMetrics = async () => {
     mechTurnover:
       mainMetrics.status === 'fulfilled'
         ? mainMetrics.value?.data?.mechFees
+        : null,
+    totalOperators:
+      mainMetrics.status === 'fulfilled'
+        ? mainMetrics.value?.data?.totalOperators
         : null,
   };
 };
@@ -156,14 +156,15 @@ const ActivityCard = ({
   );
 };
 
-const UsersCard = ({ agents, olasStaked }) => (
+const UsersCard = ({ olasStaked, totalOperators }) => (
   <ActivityCard
     icon="users.png"
     text="Users"
     primary={{
-      value: agents,
-      text: 'agents deployed',
-      link: DUNE_AGENTS_QUERY_URL,
+      value: totalOperators,
+      text: 'Agents deployed',
+      link: '/data#operators',
+      isLinkExternal: false,
     }}
     secondary={{
       value: olasStaked,
@@ -269,6 +270,7 @@ export const Activity = () => {
       dailyActiveAgents: metrics.dailyActiveAgents?.toLocaleString() || '--',
       mechTurnover: metrics.mechTurnover || '--',
       ataTransactions: metrics.ataTransactions?.toLocaleString() || '--',
+      totalOperators: metrics.totalOperators?.toLocaleString() || '--',
     };
   }, [metrics]);
 
@@ -304,6 +306,7 @@ export const Activity = () => {
           <UsersCard
             agents={processedMetrics?.agents}
             olasStaked={processedMetrics?.olasStaked}
+            totalOperators={processedMetrics?.totalOperators}
           />
           <Image
             src={`${imgPath}arrow.png`}
@@ -366,6 +369,7 @@ export const Activity = () => {
         <UsersCard
           agents={processedMetrics?.agents}
           olasStaked={processedMetrics?.olasStaked}
+          totalOperators={processedMetrics?.totalOperators}
         />
         <Image
           src={`${imgPath}mobile-arrow.png`}

--- a/components/OperatePage/OperateMetrics.jsx
+++ b/components/OperatePage/OperateMetrics.jsx
@@ -1,26 +1,21 @@
-import {
-  get7DaysAvgActivity,
-  getTotalUniqueStakers,
-} from 'common-util/api/dune';
-import {
-  DUNE_DAAS_QUERY_URL,
-  DUNE_OPERATORS_QUERY_URL,
-} from 'common-util/constants';
+import { get7DaysAvgActivity } from 'common-util/api/dune';
+import { DUNE_DAAS_QUERY_URL } from 'common-util/constants';
 import SectionWrapper from 'components/Layout/SectionWrapper';
 import { Card } from 'components/ui/card';
 import { ExternalLink } from 'components/ui/typography';
 import { usePersistentSWR } from 'hooks';
 import Image from 'next/image';
 import { useMemo } from 'react';
+import { fetchTotalOperators } from '../../pages/api/main-metrics';
 
 const fetchMetrics = async () => {
-  const [dailyActiveAgents, totalUniqueStakers] = await Promise.allSettled([
+  const [dailyActiveAgents, totalOperators] = await Promise.allSettled([
     get7DaysAvgActivity(),
-    getTotalUniqueStakers(),
+    fetchTotalOperators(),
   ]);
   return {
     dailyActiveAgents: dailyActiveAgents.value,
-    totalUniqueStakers: totalUniqueStakers.value,
+    totalOperators: totalOperators.value,
   };
 };
 
@@ -37,8 +32,8 @@ export const OperateMetrics = () => {
         imageSrc: 'operators.png',
         labelText: 'Operators',
         subText: 'All-time unique agent Operators',
-        value: metrics?.totalUniqueStakers?.toLocaleString(),
-        source: DUNE_OPERATORS_QUERY_URL,
+        value: metrics?.totalOperators?.toLocaleString(),
+        source: '/data#operators',
       },
       {
         id: 'DAA',

--- a/pages/api/main-metrics.js
+++ b/pages/api/main-metrics.js
@@ -127,7 +127,7 @@ const fetchTransactions = async () => {
   }
 };
 
-const fetchTotalOperators = async () => {
+export const fetchTotalOperators = async () => {
   try {
     const results = await Promise.allSettled([
       REGISTRY_GRAPH_CLIENTS.gnosis.request(operatorGlobalsQuery),

--- a/pages/api/main-metrics.js
+++ b/pages/api/main-metrics.js
@@ -9,6 +9,7 @@ import {
   dailyAgentPerformancesQuery,
   legacyMechFeesQuery,
   newMechFeesQuery,
+  operatorGlobalsQuery,
   registryGlobalsQuery,
   stakingGlobalsQuery,
 } from 'common-util/graphql/queries';
@@ -126,6 +127,35 @@ const fetchTransactions = async () => {
   }
 };
 
+const fetchTotalOperators = async () => {
+  try {
+    const results = await Promise.allSettled([
+      REGISTRY_GRAPH_CLIENTS.gnosis.request(operatorGlobalsQuery),
+      REGISTRY_GRAPH_CLIENTS.base.request(operatorGlobalsQuery),
+      REGISTRY_GRAPH_CLIENTS.mode.request(operatorGlobalsQuery),
+      REGISTRY_GRAPH_CLIENTS.optimism.request(operatorGlobalsQuery),
+      REGISTRY_GRAPH_CLIENTS.celo.request(operatorGlobalsQuery),
+      REGISTRY_GRAPH_CLIENTS.ethereum.request(operatorGlobalsQuery),
+      REGISTRY_GRAPH_CLIENTS.polygon.request(operatorGlobalsQuery),
+      REGISTRY_GRAPH_CLIENTS.arbitrum.request(operatorGlobalsQuery),
+    ]);
+
+    const operatorsByChains = results
+      .filter((result) => result.status === 'fulfilled')
+      .map((result) => result.value.globals?.[0]?.totalOperators ?? 0);
+
+    const totalOperators = operatorsByChains.reduce(
+      (sum, operatorsByChain) => sum + operatorsByChain,
+      0,
+    );
+
+    return totalOperators;
+  } catch (error) {
+    console.error('Error fetching total operators:', error);
+    return null;
+  }
+};
+
 const fetchAtaTransactions = async () => {
   try {
     const results = await Promise.allSettled([
@@ -191,12 +221,14 @@ const fetchAllAgentMetrics = async () => {
       transactionsResult,
       ataTransactionsResult,
       mechFeesResult,
+      totalOperatorsResult,
     ] = await Promise.allSettled([
       fetchDailyAgentPerformance(),
       fetchTotalOlasStaked(),
       fetchTransactions(),
       fetchAtaTransactions(),
       fetchMechFees(),
+      fetchTotalOperators(),
     ]);
 
     const metrics = {
@@ -205,6 +237,7 @@ const fetchAllAgentMetrics = async () => {
       transactions: null,
       ataTransactions: null,
       mechFees: null,
+      totalOperators: null,
     };
 
     // Process the results from Promise.allSettled
@@ -242,6 +275,15 @@ const fetchAllAgentMetrics = async () => {
       metrics.mechFees = mechFeesResult.value;
     } else {
       console.error('Fetch mech fees failed:', mechFeesResult.reason);
+    }
+
+    if (totalOperatorsResult.status === 'fulfilled') {
+      metrics.totalOperators = totalOperatorsResult.value;
+    } else {
+      console.error(
+        'Fetch total operators failed:',
+        totalOperatorsResult.reason,
+      );
     }
 
     const data = {

--- a/pages/data/index.jsx
+++ b/pages/data/index.jsx
@@ -4,6 +4,7 @@ import { DailyActiveAgentsInfo } from 'components/DataPage/DailyActiveAgents';
 import { FeesInfo } from 'components/DataPage/Fees';
 import { MechTurnoverInfo } from 'components/DataPage/MechTurnover';
 import { OlasStakedInfo } from 'components/DataPage/OlasStaked';
+import { OperatorsInfo } from 'components/DataPage/Operators';
 import { PredictAccuracyInfo } from 'components/DataPage/PredictAccuracy';
 import { PredictRoiInfo } from 'components/DataPage/PredictRoiInfo';
 import { TransactionsInfo } from 'components/DataPage/Transactions';
@@ -18,6 +19,7 @@ const DataVerifyPage = () => (
       className={`${SCREEN_WIDTH_XL} divide-y divide-dashed divide-gray-200`}
     >
       <DailyActiveAgentsInfo />
+      <OperatorsInfo />
       <TransactionsInfo />
       <AtaTransactionsInfo />
       <MechTurnoverInfo />


### PR DESCRIPTION
## Proposed changes

- Homepage: Display operator count in UsersCard primary metric using GraphQL query
- Operate Page: Replace Dune operators data with GraphQL query for consistency
- Data Page: Add OperatorsInfo component following ATA pattern with all subgraph links
- Backend: Export fetchTotalOperators function for reusable multi-chain operator aggregation

## Screenshots/Recordings

<img width="483" height="255" alt="Screenshot_20250828_180010" src="https://github.com/user-attachments/assets/02a097ec-d3de-42ac-b8f5-5a807235d9d1" />
<img width="1198" height="1267" alt="Screenshot_20250828_175849" src="https://github.com/user-attachments/assets/d02f3bcb-cdf0-499b-af43-6ec5c7861771" />
<img width="423" height="240" alt="Screenshot_20250828_175825" src="https://github.com/user-attachments/assets/d3dff8e5-f191-4aa7-9f72-0123b6279307" />


## Things to keep in mind

<!-- Please check if the PR fulfills these requirements -->

- [ ] I confirm I have updated the meta title and description for the page, if applicable.
