### PR TITLE
style: disabled dark mode for 404

### DIFF
--- a/pages/404.jsx
+++ b/pages/404.jsx
@@ -1,0 +1,25 @@
+// pages/404.tsx
+import Head from 'next/head';
+import { useEffect } from 'react';
+
+const Error404Page = () => {
+  useEffect(() => {
+    document.documentElement.classList.remove('dark');
+  }, []);
+
+  return (
+    <>
+      <Head>
+        <title>404: This page could not be found.</title>
+      </Head>
+      <div className="bg-color-white h-screen text-center flex justify-center items-center">
+        <div>
+          <h1 className="next-error-h1">404</h1>
+          <div className="next-error-desc">This page could not be found.</div>
+        </div>
+      </div>
+    </>
+  );
+};
+
+export default Error404Page;

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -212,6 +212,25 @@ tr, th {
   padding-left: 16px;
 }
 
+.next-error-h1 {
+  display: inline-block;
+  margin: 0;
+  margin-right: 20px;
+  padding-right: 23px;
+  font-size: 24px;
+  font-weight: 500;
+  vertical-align: top;
+  line-height: 49px;
+  border-right: 1px solid rgba(0, 0, 0, 0.3);
+}
+.next-error-desc {
+  display: inline-block;
+  text-align: left;
+  line-height: 49px;
+  height: 49px;
+  vertical-align: middle;
+}
+
 @font-face {
   font-family: 'Neue Machina';
   src: url('/fonts/neue-machina.woff2')format('woff2');


### PR DESCRIPTION
## Proposed changes

Custome 404 page to remove darkmode version. 

## Screenshots/Recordings

Before:
<img width="1919" height="1067" alt="image" src="https://github.com/user-attachments/assets/9f0278db-dc8d-48a7-aa8e-55372f5a1973" />

After:
<img width="1919" height="1080" alt="image" src="https://github.com/user-attachments/assets/ce6746a6-fb5a-47a5-a892-0523cccc565b" />
