### PR TITLE
fix: hero section horizontal scroll bug

### DIFF
--- a/components/HomepageSection/Hero.jsx
+++ b/components/HomepageSection/Hero.jsx
@@ -87,7 +87,7 @@ const Hero = () => (
     >
       <source src="/videos/homepage/hero-bg.webm" type="video/webm" />
     </video>
-    <div className="absolute w-full h-full overflow-hidden">
+    <div className="absolute inset-0 overflow-hidden">
       <div className="transparent-gradient h-[2000px] w-[5000px] bottom-0 -right-[1500px] absolute" />
     </div>
     <div className="absolute h-[500px] 2xl:h-[800px] place-content-center mx-auto text-center align-middle">

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -92,7 +92,7 @@ video {
 
 .homepage-hero-bg {
   object-fit: contain;
-  width: 100vw;
+  width: 100%;
   top: 0;
   left: 0;
 }


### PR DESCRIPTION
## Proposed changes

This PR fixes the existing horizontal scroll at the hero section in the live website

## Screenshots/Recordings
<img width="1440" height="819" alt="Screenshot 2025-09-16 at 19 43 45" src="https://github.com/user-attachments/assets/ed2c4dbe-8a43-4b8c-ab48-f798ac1e6a47" />
If you see closely above, the scrollbar is present with animation being "cut" on the left side


&nbsp;
&nbsp;
&nbsp;
&nbsp;


<img width="1440" height="861" alt="Screenshot 2025-09-16 at 19 45 06" src="https://github.com/user-attachments/assets/59a4fad0-fde7-489d-99fc-b2869a4937cb" />
After the fix, there is no horizontal bar on the hero section, hence background animation being fixed as well

## Issue
The issue happens due to `w-full h-full` being paired with `100vw` which results in irregular bg animation as shown in the screenshot.

## Fix
I have added `inset-0` that will allow to cover the hero/background section being end to end


## Test
- tested on chromium
- tested on safari


