### PR TITLE
style: make stack page mobile friendly

### DIFF
--- a/components/StackPage/StackKeyFeatures.jsx
+++ b/components/StackPage/StackKeyFeatures.jsx
@@ -36,17 +36,17 @@ const list = [
 ];
 
 export const StackKeyFeatures = () => (
-  <SectionWrapper customClasses="lg:p-24 px-4 py-12 border-y" id="key-features">
+  <SectionWrapper customClasses="xl:p-24 px-4 py-12 border-y" id="key-features">
     <div className="max-w-[872px] mx-auto flex flex-col gap-5">
       <p>
         The Olas Stack is the technical foundation of Olas. It consists of four
         core innovations:
       </p>
 
-      <div className="grid grid-cols-2 gap-4">
+      <div className="grid md:grid-cols-2 gap-4">
         {list.map((item) => (
           <Link key={item.title} href={item.url}>
-            <Card className="p-4 flex gap-4 w-full h-[100px] hover:bg-slate-100 duration-100 ease-in">
+            <Card className="p-4 flex gap-4 w-full h-full lg:h-[100px] hover:bg-slate-100 duration-100 ease-in">
               <Image
                 src={`/images/stack-page/${item.imgUrl}`}
                 alt={item.title}


### PR DESCRIPTION
## Proposed changes

Make stack page friendly for smaller screens.

## Screenshots/Recordings

Laptop:
<img width="646" height="550" alt="image" src="https://github.com/user-attachments/assets/1053927f-68f0-4c0a-ae62-0a56de0138d1" />

Tablet:
<img width="503" height="510" alt="image" src="https://github.com/user-attachments/assets/d808cde2-4042-483f-9dd3-a89d4971200a" />

Phone:
<img width="251" height="825" alt="image" src="https://github.com/user-attachments/assets/a3f00101-6c6c-41e5-ade0-8c0a8e136ad1" />
