### PR TITLE
fix: pearl daa discrepancy

### DIFF
--- a/common-util/graphql/queries.js
+++ b/common-util/graphql/queries.js
@@ -297,15 +297,15 @@ export const dailyPredictAgentsPerformancesQuery = gql`
 export const dailyPredictAgentPerformancesWithMultisigsQuery = gql`
   query DailyPredictAgentPerformancesWithMultisigs(
     $agentId_in: [Int!]!
-    $dayTimestamp_gte: Int!
-    $dayTimestamp_lte: Int!
+    $dayTimestamp_gt: Int!
+    $dayTimestamp_lt: Int!
   ) {
     dailyAgentPerformances(
       where: {
         and: [
           { agentId_in: $agentId_in }
-          { dayTimestamp_gte: $dayTimestamp_gte }
-          { dayTimestamp_lte: $dayTimestamp_lte }
+          { dayTimestamp_gt: $dayTimestamp_gt }
+          { dayTimestamp_lt: $dayTimestamp_lt }
         ]
       }
       orderBy: dayTimestamp


### PR DESCRIPTION
## Proposed changes

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->
- Correct time range for Predict DAA call
- Added agentsfun DAAs

85+31+8 (individual values can be verified from the KPIs dashboard)

<img width="702" height="461" alt="Screenshot 2025-12-11 at 10 43 09 PM" src="https://github.com/user-attachments/assets/ad565057-e255-41cf-8aa3-18b280e6a85e" />


## Screenshots/Recordings

<!-- Add screenshots or recordings of the changes you made. -->

## Things to keep in mind

<!-- Please check if the PR fulfills these requirements -->

- [x] I confirm I have updated the meta title and description for the page, if applicable.
