### PR TITLE
fix: predict metrics precision

### DIFF
--- a/pages/api/predict-metrics.js
+++ b/pages/api/predict-metrics.js
@@ -26,6 +26,7 @@ import { getMidnightUtcTimestampDaysAgo } from 'common-util/time';
 const CACHE_DURATION_SECONDS = 12 * 60 * 60; // 12 hours
 const LIMIT = 1000;
 const PAGES = 10;
+const SCALE = 100n; // 2 decimals
 const OLAS_ADDRESS = '0xce11e14225575945b8e6dc0d4f2dd4c570f79d9f';
 const COINGECKO_OLAS_IN_USD_PRICE_URL = `https://api.coingecko.com/api/v3/simple/token_price/xdai?contract_addresses=${OLAS_ADDRESS}&vs_currencies=usd`;
 const INVALID_ANSWER_HEX =
@@ -193,13 +194,17 @@ const fetchRoi = async () => {
       BigInt(1e18);
 
     const partialRoi =
-      ((totalMarketPayout - totalCosts) * BigInt(100)) / totalCosts;
+      ((totalMarketPayout - totalCosts) * BigInt(100) * SCALE) / totalCosts;
     const finalRoi =
       ((totalMarketPayout + totalOlasRewardsPayoutInUsd - totalCosts) *
-        BigInt(100)) /
+        BigInt(100) *
+        SCALE) /
       totalCosts;
 
-    return { partialRoi: Number(partialRoi), finalRoi: Number(finalRoi) };
+    return {
+      partialRoi: Number(partialRoi) / Number(SCALE),
+      finalRoi: Number(finalRoi) / Number(SCALE),
+    };
   } catch (error) {
     throw error;
   }


### PR DESCRIPTION
## Proposed changes

Partial ROI became <1, and started looking broken:
<img width="422" height="191" alt="image" src="https://github.com/user-attachments/assets/ed45d962-4498-4ed4-9c02-243fc2766bb5" />

added precision:
<img width="414" height="367" alt="image" src="https://github.com/user-attachments/assets/67d81e6c-d772-401e-bc8b-b866b5943fde" />


## Screenshots/Recordings

<!-- Add screenshots or recordings of the changes you made. -->

## Things to keep in mind

<!-- Please check if the PR fulfills these requirements -->

- [ ] I confirm I have updated the meta title and description for the page, if applicable.
