### PR TITLE
Add comprehensive OFAC sanctions blocking

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,8 +58,10 @@ npm run lint:fix    # Fix ESLint issues automatically
 - Failed subgraph queries don't break the entire page - graceful degradation is built-in
 
 **Regional Restrictions:**
-- `middleware.js` blocks specific Ukrainian regions using Vercel's geo-headers
-- Redirects to `/restricted` page for blocked regions
+- `middleware.js` blocks OFAC sanctioned countries and regions using Vercel's geo-headers
+- Blocked countries: Cuba (CU), Iran (IR), North Korea (KP), Syria (SY), Russia (RU), Belarus (BY)
+- Blocked Ukrainian regions: UA-14, UA-09, UA-43, UA-65, UA-23 (Donetsk, Luhansk, Crimea, Sevastopol)
+- Redirects to `/restricted` page for blocked locations
 
 **Data Flow:**
 1. Frontend components call API routes via `/api/*` endpoints

--- a/middleware.js
+++ b/middleware.js
@@ -1,8 +1,14 @@
 import { NextResponse } from 'next/server';
 
-const BLOCKED_REGIONS = ['UA-14', 'UA-09', 'UA-65', 'UA-23'];
+// OFAC comprehensively sanctioned countries and specific regions
+// Cuba, Iran, North Korea, Syria, Russia (comprehensive sanctions)
+// Belarus (sectoral sanctions - often included in web3 compliance)
+const BLOCKED_COUNTRIES = ['CU', 'IR', 'KP', 'SY', 'RU', 'BY'];
+// Ukrainian regions: Donetsk (14), Luhansk (09), Crimea (43/65), Sevastopol (23)
+const BLOCKED_REGIONS = ['UA-14', 'UA-09', 'UA-43', 'UA-65', 'UA-23'];
 
 export function middleware(request) {
+  const country = request.headers.get('x-vercel-ip-country');
   const region = request.headers.get('x-vercel-ip-country-region');
 
   if (
@@ -12,7 +18,10 @@ export function middleware(request) {
     return NextResponse.next();
   }
 
-  if (region && BLOCKED_REGIONS.includes(region)) {
+  if (
+    (country && BLOCKED_COUNTRIES.includes(country)) ||
+    (region && BLOCKED_REGIONS.includes(region))
+  ) {
     return NextResponse.redirect(new URL('/restricted', request.url));
   }
 


### PR DESCRIPTION
Expand middleware to block all OFAC comprehensively sanctioned countries:
- Cuba (CU), Iran (IR), North Korea (KP), Syria (SY)
- Russia (RU) - comprehensive sanctions
- Belarus (BY) - sectoral sanctions

Also added UA-43 region code for Crimea. Update CLAUDE.md to accurately reflect the complete blocking policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)