### PR TITLE
chore: use chevron for more metrics

### DIFF
--- a/components/MechMarketplacePage/MarketplaceMetrics.jsx
+++ b/components/MechMarketplacePage/MarketplaceMetrics.jsx
@@ -2,6 +2,7 @@ import { getMainMetrics } from 'common-util/api';
 import SectionWrapper from 'components/Layout/SectionWrapper';
 import { MetricsCard } from 'components/MetricsCard';
 import { usePersistentSWR } from 'hooks';
+import { ChevronRight } from 'lucide-react';
 import Image from 'next/image';
 import Link from 'next/link';
 import { useMemo } from 'react';
@@ -63,19 +64,7 @@ export const MarketplaceMetrics = () => {
           className="inline-flex items-center text-purple-600 hover:text-purple-700 font-medium transition-colors"
         >
           More metrics on Mech Marketplace
-          <svg
-            className="ml-2 w-4 h-4"
-            fill="none"
-            stroke="currentColor"
-            viewBox="0 0 24 24"
-          >
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              strokeWidth={2}
-              d="M9 5l7 7-7 7"
-            />
-          </svg>
+          <ChevronRight size={20} />
         </Link>
       </div>
     </SectionWrapper>


### PR DESCRIPTION
## Proposed changes

Replaces svg with chevron on more metrics link in mech-marketplace page.

## Screenshots/Recordings

<img width="987" height="341" alt="image" src="https://github.com/user-attachments/assets/b293305f-097c-4de2-a5f5-c5f889d7d8d2" />
