### PR TITLE
fix: add redirects for education articles and whitepaper

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -20,6 +20,16 @@ module.exports = withPlausibleProxy()({
         permanent: true,
       },
       {
+        source: '/education-articles',
+        destination: '/blog',
+        permanent: true,
+      },
+      {
+        source: '/poaa-whitepaper.pdf',
+        destination: '/whitepaper',
+        permanent: true,
+      },
+      {
         source: '/explore',
         destination: '/agents',
         permanent: true,


### PR DESCRIPTION
## Proposed changes

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

- Redirect educational articles to the blogs section.
- Redirect POAA whitepaper to the whitepaper page.

## Screenshots/Recordings

<!-- Add screenshots or recordings of the changes you made. -->

## Things to keep in mind

<!-- Please check if the PR fulfills these requirements -->

- [ ] I confirm I have updated the meta title and description for the page, if applicable.
