### PR TITLE
feat: add Instagram link and rename blog link on homepage hero

### DIFF
--- a/components/HomepageSection/Hero.tsx
+++ b/components/HomepageSection/Hero.tsx
@@ -75,7 +75,7 @@ const Hero = () => (
             height={206}
             className="mb-4 shadow-md rounded-2xl transition-all duration-300 ease-in-out hover:scale-[1.01] hover:[box-shadow:0_32px_9px_0_rgba(88,92,101,0.00),0_21px_8px_0_rgba(88,92,101,0.01),0_11px_7px_0_rgba(88,92,101,0.03),0_5px_5px_0_rgba(88,92,101,0.05),0_1px_3px_0_rgba(88,92,101,0.06)]"
           />
-          <div className="flex items-center gap-1 font-medium text-sm justify-center hover:text-purple-600">
+          <div className="flex items-center gap-1 font-medium text-sm justify-center hover:text-black">
             Read the blog <ChevronRight size={16} />
           </div>
         </Link>
@@ -83,7 +83,7 @@ const Hero = () => (
           href="https://www.instagram.com/ai.cant.replace/"
           target="_blank"
           rel="noopener noreferrer"
-          className="mt-2 flex items-center gap-1.5 font-medium text-sm justify-center hover:text-purple-600"
+          className="mt-2 flex items-center gap-1.5 font-medium text-sm justify-center hover:text-black"
         >
           View on Instagram <SquareArrowOutUpRight size={14} />
         </a>
@@ -105,7 +105,7 @@ const Hero = () => (
               height={160}
               className="mb-2 shadow-md rounded-2xl mx-auto transition-all duration-300 ease-in-out hover:scale-[1.01] hover:[box-shadow:0_32px_9px_0_rgba(88,92,101,0.00),0_21px_8px_0_rgba(88,92,101,0.01),0_11px_7px_0_rgba(88,92,101,0.03),0_5px_5px_0_rgba(88,92,101,0.05),0_1px_3px_0_rgba(88,92,101,0.06)]"
             />
-            <div className="flex items-center gap-1 font-medium text-sm justify-center hover:text-purple-600">
+            <div className="flex items-center gap-1 font-medium text-sm justify-center hover:text-black">
               Read the blog <ChevronRight size={16} />
             </div>
           </Link>
@@ -113,7 +113,7 @@ const Hero = () => (
             href="https://www.instagram.com/ai.cant.replace/"
             target="_blank"
             rel="noopener noreferrer"
-            className="mt-2 flex items-center gap-1.5 font-medium text-sm justify-center hover:text-purple-600"
+            className="mt-2 flex items-center gap-1.5 font-medium text-sm justify-center hover:text-black"
           >
             View on Instagram <SquareArrowOutUpRight size={14} />
           </a>

--- a/components/HomepageSection/Hero.tsx
+++ b/components/HomepageSection/Hero.tsx
@@ -1,4 +1,4 @@
-import { ChevronRight } from 'lucide-react';
+import { ChevronRight, SquareArrowOutUpRight } from 'lucide-react';
 
 import SectionWrapper from 'components/Layout/SectionWrapper';
 import { Tag } from 'components/ui/tag';
@@ -66,8 +66,8 @@ const Hero = () => (
         <div className="transparent-gradient h-[2000px] w-[5000px] -bottom-[210px] -right-[1400px] absolute" />
       </div>
 
-      <Link href="/blog/uniquely-human" className="hidden lg:block">
-        <div className="absolute right-8 top-1/3 -translate-y-1/2 animate-float">
+      <div className="absolute right-8 top-1/3 -translate-y-1/2 animate-float hidden lg:block">
+        <Link href="/blog/uniquely-human">
           <Image
             src="/images/homepage/ai-card.png"
             alt="AI card"
@@ -75,11 +75,19 @@ const Hero = () => (
             height={206}
             className="mb-4 shadow-md rounded-2xl transition-all duration-300 ease-in-out hover:scale-[1.01] hover:[box-shadow:0_32px_9px_0_rgba(88,92,101,0.00),0_21px_8px_0_rgba(88,92,101,0.01),0_11px_7px_0_rgba(88,92,101,0.03),0_5px_5px_0_rgba(88,92,101,0.05),0_1px_3px_0_rgba(88,92,101,0.06)]"
           />
-          <div className="flex items-center gap-1 font-medium text-sm justify-center">
-            #UniquelyHuman <ChevronRight size={20} />
+          <div className="flex items-center gap-1 font-medium text-sm justify-center hover:text-purple-600">
+            Read the blog <ChevronRight size={16} />
           </div>
-        </div>
-      </Link>
+        </Link>
+        <a
+          href="https://www.instagram.com/ai.cant.replace/"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="mt-2 flex items-center gap-1.5 font-medium text-sm justify-center hover:text-purple-600"
+        >
+          View on Instagram <SquareArrowOutUpRight size={14} />
+        </a>
+      </div>
 
       <div className="absolute inset-0 flex flex-col items-center justify-center text-center px-4 lg:hidden">
         <h1 className="tracking-tight text-5xl md:text-6xl mb-4 text-black font-extrabold">
@@ -88,18 +96,28 @@ const Hero = () => (
         <div className="max-md:text-lg text-xl leading-8 text-gray-900 mb-6">
           Olas enables everyone to own and monetize their AI agents.
         </div>
-        <Link href="/blog/uniquely-human" className="animate-float">
-          <Image
-            src="/images/homepage/ai-card.png"
-            alt="AI card"
-            width={140}
-            height={160}
-            className="mb-2 shadow-md rounded-2xl mx-auto transition-all duration-300 ease-in-out hover:scale-[1.01] hover:[box-shadow:0_32px_9px_0_rgba(88,92,101,0.00),0_21px_8px_0_rgba(88,92,101,0.01),0_11px_7px_0_rgba(88,92,101,0.03),0_5px_5px_0_rgba(88,92,101,0.05),0_1px_3px_0_rgba(88,92,101,0.06)]"
-          />
-          <div className="flex items-center gap-1 font-medium text-sm justify-center">
-            #UniquelyHuman <ChevronRight size={20} />
-          </div>
-        </Link>
+        <div className="animate-float">
+          <Link href="/blog/uniquely-human">
+            <Image
+              src="/images/homepage/ai-card.png"
+              alt="AI card"
+              width={140}
+              height={160}
+              className="mb-2 shadow-md rounded-2xl mx-auto transition-all duration-300 ease-in-out hover:scale-[1.01] hover:[box-shadow:0_32px_9px_0_rgba(88,92,101,0.00),0_21px_8px_0_rgba(88,92,101,0.01),0_11px_7px_0_rgba(88,92,101,0.03),0_5px_5px_0_rgba(88,92,101,0.05),0_1px_3px_0_rgba(88,92,101,0.06)]"
+            />
+            <div className="flex items-center gap-1 font-medium text-sm justify-center hover:text-purple-600">
+              Read the blog <ChevronRight size={16} />
+            </div>
+          </Link>
+          <a
+            href="https://www.instagram.com/ai.cant.replace/"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="mt-2 flex items-center gap-1.5 font-medium text-sm justify-center hover:text-purple-600"
+          >
+            View on Instagram <SquareArrowOutUpRight size={14} />
+          </a>
+        </div>
       </div>
 
       <div className="absolute inset-x-0 h-[500px] 2xl:h-[600px] place-content-center mx-auto text-center align-middle hidden lg:block pointer-events-none">


### PR DESCRIPTION
## Summary
- Rename `#UniquelyHuman` to `Read the blog` under the hero AI card (desktop + mobile)
- Add a new `View on Instagram` link below it pointing to https://www.instagram.com/ai.cant.replace/

<img width="235" height="323" alt="image" src="https://github.com/user-attachments/assets/e3da180b-89dd-4fa6-a9af-32147eafb5b2" />


## Test plan
- [ ] Visit `/` on desktop (≥ lg) and confirm the floating AI card shows `Read the blog ›` and `View on Instagram ↗` below it
- [ ] Visit `/` on mobile (< lg) and confirm the same two links are centered below the card
- [ ] Click `Read the blog` → navigates to `/blog/uniquely-human`
- [ ] Click `View on Instagram` → opens https://www.instagram.com/ai.cant.replace/ in a new tab
- [ ] Hover states: both links turn purple on hover

🤖 Generated with [Claude Code](https://claude.com/claude-code)