### PR TITLE
fix: show Polymarket warning on Polystrat ROI metrics

### DIFF
--- a/components/AgentEconomies/PredictPage/Activity.tsx
+++ b/components/AgentEconomies/PredictPage/Activity.tsx
@@ -1,7 +1,7 @@
 import SectionWrapper from 'components/Layout/SectionWrapper';
 import { Card } from 'components/ui/card';
 import { Popover } from 'components/ui/popover';
-import { StaleIndicator, StaleMetricContent } from 'components/ui/StaleIndicator';
+import { StaleIndicator, StaleMetricContent, WarningIndicator } from 'components/ui/StaleIndicator';
 import { Link } from 'components/ui/typography';
 import { isNil } from 'lodash';
 import Image from 'next/image';
@@ -215,7 +215,16 @@ const PerformanceBubble = ({ platformMetrics, title, imgSrc, id, platform }) => 
                   {metric.value || '--'}
                 </span>
               )}
-              <StaleIndicator status={metric.status} />
+              {platform === 'polystrat' && metric.id === 'roi' ? (
+                <WarningIndicator>
+                  <p>
+                    Due to recent updates on Polymarket this metric temporarily shows incorrect
+                    values
+                  </p>
+                </WarningIndicator>
+              ) : (
+                <StaleIndicator status={metric.status} />
+              )}
             </div>
           </div>
         ))}

--- a/components/AgentEconomies/PredictPage/RoiDistributionChart.tsx
+++ b/components/AgentEconomies/PredictPage/RoiDistributionChart.tsx
@@ -151,7 +151,7 @@ export const RoiDistributionChart = ({ data, className, id }: RoiDistributionCha
             Polystrat Partial ROI Distribution
           </h3>
           <WarningIndicator>
-            <p>Due to recent updates on Polymarket this metric temporarily shows incorrect values</p>
+            <p>Due to recent updates on Polymarket this chart temporarily shows incorrect values</p>
           </WarningIndicator>
         </div>
 

--- a/components/AgentEconomies/PredictPage/RoiDistributionChart.tsx
+++ b/components/AgentEconomies/PredictPage/RoiDistributionChart.tsx
@@ -2,6 +2,7 @@
 
 import { BarElement, Chart as ChartJS, ChartOptions, Legend, LinearScale, Tooltip } from 'chart.js';
 import { BinData } from 'common-util/api/predict/roi-distribution';
+import { WarningIndicator } from 'components/ui/StaleIndicator';
 import { Tabs } from 'components/ui/tabs';
 import { useState } from 'react';
 import { Bar } from 'react-chartjs-2';
@@ -145,7 +146,14 @@ export const RoiDistributionChart = ({ data, className, id }: RoiDistributionCha
     >
       {/* Header row */}
       <div className="flex items-start justify-between mb-6 flex-wrap gap-4">
-        <h3 className="text-lg font-semibold text-gray-900">Polystrat Partial ROI Distribution</h3>
+        <div className="flex items-center gap-2">
+          <h3 className="text-lg font-semibold text-gray-900">
+            Polystrat Partial ROI Distribution
+          </h3>
+          <WarningIndicator>
+            <p>Due to recent updates on Polymarket this metric temporarily shows incorrect values</p>
+          </WarningIndicator>
+        </div>
 
         <Tabs
           items={TIME_RANGES.map(({ label }) => ({ key: label, label }))}

--- a/components/ui/StaleIndicator/WarningIndicator.tsx
+++ b/components/ui/StaleIndicator/WarningIndicator.tsx
@@ -1,0 +1,25 @@
+import * as Tooltip from '@radix-ui/react-tooltip';
+import { Info } from 'lucide-react';
+import { ReactNode } from 'react';
+
+type WarningIndicatorProps = {
+  children: ReactNode;
+};
+
+export const WarningIndicator = ({ children }: WarningIndicatorProps) => {
+  return (
+    <Tooltip.Provider>
+      <Tooltip.Root delayDuration={0}>
+        <Tooltip.Trigger className="text-amber-500 inline-flex items-center">
+          <Info size={20} />
+        </Tooltip.Trigger>
+        <Tooltip.Content
+          side="top"
+          className="p-2 text-sm bg-white border rounded-lg shadow-lg max-w-[320px] z-50"
+        >
+          <div className="flex flex-col items-start text-left text-gray-800">{children}</div>
+        </Tooltip.Content>
+      </Tooltip.Root>
+    </Tooltip.Provider>
+  );
+};

--- a/components/ui/StaleIndicator/index.ts
+++ b/components/ui/StaleIndicator/index.ts
@@ -1,3 +1,4 @@
 export * from './StaleContent';
 export * from './StaleIndicator';
+export * from './WarningIndicator';
 export * from './types';


### PR DESCRIPTION
## Proposed changes

Add warning message to affected by polymarket subgraph values

## Screenshots/Recordings

### ROI distribution

<img width="561" height="174" alt="Screenshot 2026-05-05 at 09 43 01" src="https://github.com/user-attachments/assets/e6664f71-34c4-44d2-8e2a-849114063d6c" />

### Total ROI

<img width="408" height="139" alt="Screenshot 2026-05-05 at 09 39 31" src="https://github.com/user-attachments/assets/e7005952-3687-4b28-9cb0-8c5417e95213" />

## Things to keep in mind

<!-- Please check if the PR fulfills these requirements -->

- [ ] I confirm I have updated the meta title and description for the page, if applicable.
