### PR TITLE
feat: add agent-type switcher to predict economy page

### DIFF
--- a/common-util/api/predict/roi-distribution.ts
+++ b/common-util/api/predict/roi-distribution.ts
@@ -59,7 +59,6 @@ export type QmrData = {
 
 /** Per-agent daily aggregates, used for 'd7' | 'd30' | 'd90' distributions */
 export type DailyAgentEntry = {
-  bets: number;
   profit: string;
   payout: string;
   /**
@@ -455,7 +454,7 @@ const updateAgentBlueprintData = async (
     const ensureEntry = (dKey: string, aid: string): DailyAgentEntry => {
       if (!byDay[dKey]) byDay[dKey] = { agents: {} };
       if (!byDay[dKey].agents[aid]) {
-        byDay[dKey].agents[aid] = { bets: 0, profit: '0', payout: '0', mechRequests: 0 };
+        byDay[dKey].agents[aid] = { profit: '0', payout: '0', mechRequests: 0 };
       }
       return byDay[dKey].agents[aid];
     };
@@ -494,7 +493,6 @@ const updateAgentBlueprintData = async (
         }
 
         agents[agentId] = {
-          bets: Number(stat.totalBets),
           profit: stat.dailyProfit,
           payout: stat.totalPayout,
           mechRequests,
@@ -656,7 +654,7 @@ const computeAgentBlueprintHistogram = (
     const yesterdayTs = getMidnightUtcTimestampDaysAgo(1);
     const cutoffTs = yesterdayTs - (daysBack - 1) * DAY_SECONDS;
 
-    type Totals = { profit: bigint; payout: bigint; mechRequests: number; bets: number };
+    type Totals = { profit: bigint; payout: bigint; mechRequests: number };
     const agentTotals = new Map<string, Totals>();
 
     for (const [dayKeyStr, dayData] of Object.entries(agentBlueprintData.byDay)) {
@@ -669,19 +667,21 @@ const computeAgentBlueprintHistogram = (
           profit: 0n,
           payout: 0n,
           mechRequests: 0,
-          bets: 0,
         };
         prev.profit += BigInt(entry.profit);
         prev.payout += BigInt(entry.payout);
         prev.mechRequests += entry.mechRequests;
-        prev.bets += entry.bets ?? 0;
         agentTotals.set(agentId, prev);
       }
     }
 
-    for (const totals of agentTotals.values()) {
-      // Apply the same activity threshold as the Max tab, scoped to the window.
-      if (totals.bets < MIN_TRADES_FOR_ROI_DISPLAY) {
+    for (const [agentId, totals] of agentTotals.entries()) {
+      // Activity threshold uses lifetime bets from traderAgents, not bets in
+      // the window — the floor means "agent has enough history to be
+      // statistically meaningful," which is a property of the agent, not the
+      // window.
+      const lifetimeBets = agentBlueprintData.allTimeAgents?.[agentId]?.totalBets ?? 0;
+      if (lifetimeBets < MIN_TRADES_FOR_ROI_DISPLAY) {
         excludedLowActivity++;
         continue;
       }

--- a/common-util/api/predict/roi-distribution.ts
+++ b/common-util/api/predict/roi-distribution.ts
@@ -679,9 +679,11 @@ const computeAgentBlueprintHistogram = (
       // Activity threshold uses lifetime bets from traderAgents, not bets in
       // the window — the floor means "agent has enough history to be
       // statistically meaningful," which is a property of the agent, not the
-      // window.
-      const lifetimeBets = agentBlueprintData.allTimeAgents?.[agentId]?.totalBets ?? 0;
-      if (lifetimeBets < MIN_TRADES_FOR_ROI_DISPLAY) {
+      // window. Only apply the threshold when a lifetime total is present;
+      // a missing entry (partial allTimeAgents snapshot) shouldn't silently
+      // drop the agent and risk emptying the histogram.
+      const lifetimeEntry = agentBlueprintData.allTimeAgents?.[agentId];
+      if (lifetimeEntry !== undefined && lifetimeEntry.totalBets < MIN_TRADES_FOR_ROI_DISPLAY) {
         excludedLowActivity++;
         continue;
       }

--- a/components/AgentEconomies/PredictPage/Activity.tsx
+++ b/components/AgentEconomies/PredictPage/Activity.tsx
@@ -1,15 +1,27 @@
 import SectionWrapper from 'components/Layout/SectionWrapper';
 import { Card } from 'components/ui/card';
 import { Popover } from 'components/ui/popover';
-import { StaleIndicator, StaleMetricContent, WarningIndicator } from 'components/ui/StaleIndicator';
+import { StaleIndicator } from 'components/ui/StaleIndicator';
 import { Link } from 'components/ui/typography';
 import { isNil } from 'lodash';
 import Image from 'next/image';
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
+import { Platform, PlatformActivitySection, PlatformMetrics } from './PlatformActivitySection';
 import { RoiDistributionChart } from './RoiDistributionChart';
 import { ToolAccuracyTable } from './ToolAccuracyTable';
 
-const processPredictMetrics = (metrics: any) => {
+const processPredictMetrics = (
+  metrics: any
+): {
+  omenstrat: PlatformMetrics & {
+    dailyActiveAgents: number | null;
+    dailyActiveAgentsStatus: any;
+  };
+  polystrat: PlatformMetrics & {
+    dailyActiveAgents: number | null;
+    dailyActiveAgentsStatus: any;
+  };
+} => {
   if (!metrics) {
     return {
       omenstrat: {
@@ -82,186 +94,6 @@ const processPredictMetrics = (metrics: any) => {
   };
 };
 
-const PerformanceBubble = ({ platformMetrics, title, imgSrc, id, platform }) => {
-  const bubbleData = useMemo(() => {
-    const performanceMetrics = [
-      {
-        id: 'roi',
-        subText: (
-          <span className="flex items-center gap-2">
-            Total ROI - Average{' '}
-            {!isNil(platformMetrics.partialRoi) && (
-              <Popover>
-                <div className="flex flex-col max-w-[320px] gap-4 text-base">
-                  <p className="text-gray-500">
-                    Total ROI shows your agent&apos;s overall earnings, including profits from
-                    predictions and staking rewards, minus all related costs.
-                  </p>
-                  <p className="text-gray-500">
-                    Partial ROI reflects only prediction performance, excluding staking rewards.
-                  </p>
-                  <div className="flex justify-between">
-                    <span className="text-gray-900">Partial ROI</span>
-                    <span className={`${platformMetrics.roiStatus?.stale ? 'text-gray-400' : ''}`}>
-                      {`${platformMetrics.partialRoi}%`}
-                    </span>
-                  </div>
-                  <div className="text-sm">
-                    <StaleMetricContent status={platformMetrics.roiStatus} />
-                  </div>
-                </div>
-              </Popover>
-            )}
-          </span>
-        ),
-        value: isNil(platformMetrics.finalRoi) ? null : `${platformMetrics.finalRoi}%`,
-        status: platformMetrics.roiStatus,
-        source: { link: `/data#${platform}-predict-roi`, isExternal: false },
-      },
-      {
-        id: 'apr',
-        subText: 'APR, OLAS - Via OLAS Staking',
-        value: isNil(platformMetrics.apr) ? null : `${platformMetrics.apr}%`,
-        status: platformMetrics.aprStatus,
-        source: { link: `/data#${platform}-predict-apr`, isExternal: false },
-      },
-      {
-        id: 'accuracy',
-        subText: 'Prediction Accuracy - Average (Last 10K Trades)',
-        value: isNil(platformMetrics.successRate) ? null : `${platformMetrics.successRate}%`,
-        status: platformMetrics.successRateStatus,
-        source: { link: `/data#${platform}-predict-accuracy`, isExternal: false },
-      },
-    ];
-
-    const transactionMetrics = [
-      {
-        id: 'traders',
-        subText: (
-          <div className="flex items-center gap-2">
-            <span>Traders</span>
-            <Image alt="Traders" src="/images/predict-page/traders.png" width="32" height="15" />
-          </div>
-        ),
-        value: isNil(platformMetrics.traderTxs) ? null : platformMetrics.traderTxs.toLocaleString(),
-        status: platformMetrics.txsStatus,
-        source: { link: `/data#${platform}-predict-transactions-by-type`, isExternal: false },
-      },
-      {
-        id: 'mechs',
-        subText: (
-          <div className="flex items-center gap-2">
-            <span>Mechs: Prediction Brokers</span>
-            <Image alt="Mechs" src="/images/predict-page/mechs.png" width="32" height="15" />
-          </div>
-        ),
-        value: isNil(platformMetrics.mechTxs) ? null : platformMetrics.mechTxs.toLocaleString(),
-        status: platformMetrics.txsStatus,
-        source: { link: `/data#${platform}-predict-transactions-by-type`, isExternal: false },
-      },
-    ];
-
-    if (platformMetrics.marketCreatorTxs !== undefined) {
-      transactionMetrics.push({
-        id: 'marketCreatorsAndClosers',
-        subText: (
-          <div className="flex flex-wrap items-center gap-2">
-            <span>Market Creators</span>
-            <Image
-              alt="Market Creators"
-              src="/images/predict-page/market-creators.png"
-              width="32"
-              height="15"
-            />
-            <span>Closers</span>
-            <Image alt="Closers" src="/images/predict-page/closers.png" width="32" height="15" />
-          </div>
-        ),
-        value: isNil(platformMetrics.marketCreatorTxs)
-          ? null
-          : platformMetrics.marketCreatorTxs.toLocaleString(),
-        status: platformMetrics.txsStatus,
-        source: { link: `/data#${platform}-predict-transactions-by-type`, isExternal: false },
-      });
-    }
-
-    return { performanceMetrics, transactionMetrics };
-  }, [platformMetrics, platform]);
-
-  return (
-    <Card
-      id={id}
-      className="p-8 border border-slate-200 rounded-full text-xl w-full rounded-2xl bg-gradient-to-b from-[rgba(244,247,251,0.2)] to-[#F4F7FB] flex flex-col"
-    >
-      <Image alt={title} src={imgSrc} width="48" height="48" className="mb-4" />
-
-      {/* Agent performance metrics */}
-      <div className="text-lg font-semibold mb-6">{title}</div>
-      <div className="flex flex-col gap-4">
-        {bubbleData.performanceMetrics.map((metric) => (
-          <div key={metric.id} className="flex flex-col gap-1">
-            <div className="text-sm text-gray-600">{metric.subText}</div>
-            <div className="flex items-center gap-2">
-              {metric.source?.link ? (
-                <Link href={metric.source.link} className="text-2xl font-bold">
-                  <span className={metric.status?.stale ? 'text-gray-400' : ''}>
-                    {metric.value || '--'}
-                  </span>
-                </Link>
-              ) : (
-                <span
-                  className={`text-2xl font-bold ${metric.status?.stale || metric.value === 'Coming soon' ? 'text-gray-400' : ''}`}
-                >
-                  {metric.value || '--'}
-                </span>
-              )}
-              {platform === 'polystrat' && metric.id === 'roi' ? (
-                <WarningIndicator>
-                  <p>
-                    Due to recent updates on Polymarket this metric temporarily shows incorrect
-                    values
-                  </p>
-                </WarningIndicator>
-              ) : (
-                <StaleIndicator status={metric.status} />
-              )}
-            </div>
-          </div>
-        ))}
-      </div>
-
-      {/* Divider */}
-      <div className="border-t border-[#D7DDEA] my-8" />
-
-      {/* Transaction metrics */}
-      <div className="text-lg font-semibold mb-6">Transactions by Agent Type</div>
-      <div className="flex flex-col gap-4">
-        {bubbleData.transactionMetrics.map((metric) => (
-          <div key={metric.id} className="flex flex-col gap-1">
-            <div className="text-sm text-gray-600">{metric.subText}</div>
-            <div className="flex items-center gap-2">
-              {metric.source?.link ? (
-                <Link href={metric.source.link} className="text-2xl font-bold">
-                  <span className={metric.status?.stale ? 'text-gray-400' : ''}>
-                    {metric.value || '--'}
-                  </span>
-                </Link>
-              ) : (
-                <span
-                  className={`text-2xl font-bold ${metric.status?.stale || metric.value === 'Coming soon' ? 'text-gray-400' : ''}`}
-                >
-                  {metric.value || '--'}
-                </span>
-              )}
-              <StaleIndicator status={metric.status} />
-            </div>
-          </div>
-        ))}
-      </div>
-    </Card>
-  );
-};
-
 const DaaCard = ({ title, imgSrc, daaValue, status, href, popoverText, id }) => {
   return (
     <Card
@@ -293,6 +125,7 @@ export const Activity = ({ metrics: initialMetrics, roiDistribution, toolAccurac
   const metrics = useMemo(() => {
     return processPredictMetrics(initialMetrics);
   }, [initialMetrics]);
+  const [platform, setPlatform] = useState<Platform>('omenstrat');
 
   return (
     <SectionWrapper customClasses="py-16 px-4 border-t" id="stats">
@@ -320,33 +153,29 @@ export const Activity = ({ metrics: initialMetrics, roiDistribution, toolAccurac
             popoverText="7-day average Daily Active Agents for Polystrat (Polymarket)"
           />
 
-          {/* Partial ROI Distribution Chart */}
-          <RoiDistributionChart
-            id="roi-distribution"
-            data={roiDistribution}
+          {/* Switcher-driven per-platform performance & lifetime activity */}
+          <PlatformActivitySection
+            metrics={{ omenstrat: metrics.omenstrat, polystrat: metrics.polystrat }}
+            platform={platform}
+            onPlatformChange={setPlatform}
             className="md:col-span-2"
           />
 
-          {/* Omenstrat Unified Bubble */}
-          <PerformanceBubble
-            id="omenstrat-performance"
-            title="Omenstrat Performance"
-            platform="omenstrat"
-            platformMetrics={metrics.omenstrat}
-            imgSrc="/images/predict-page/omenstrat-icon.png"
+          {/* ROI Distribution Chart — filtered to the selected platform */}
+          <RoiDistributionChart
+            id="roi-distribution"
+            data={roiDistribution}
+            platform={platform}
+            className="md:col-span-2"
           />
 
-          {/* Polystrat Unified Bubble */}
-          <PerformanceBubble
-            id="polystrat-performance"
-            title="Polystrat Performance"
-            platform="polystrat"
-            platformMetrics={metrics.polystrat}
-            imgSrc="/images/predict-page/polystrat-icon.png"
+          {/* Tool Accuracy Table — filtered to the selected platform */}
+          <ToolAccuracyTable
+            id="tool-accuracy"
+            data={toolAccuracy}
+            platform={platform}
+            className="md:col-span-2"
           />
-
-          {/* Tool Accuracy Table */}
-          <ToolAccuracyTable id="tool-accuracy" data={toolAccuracy} className="md:col-span-2" />
         </div>
       </div>
     </SectionWrapper>

--- a/components/AgentEconomies/PredictPage/Activity.tsx
+++ b/components/AgentEconomies/PredictPage/Activity.tsx
@@ -6,7 +6,8 @@ import { Link } from 'components/ui/typography';
 import { isNil } from 'lodash';
 import Image from 'next/image';
 import { useMemo, useState } from 'react';
-import { Platform, PlatformActivitySection, PlatformMetrics } from './PlatformActivitySection';
+import { PlatformActivitySection } from './PlatformActivitySection';
+import type { Platform, PlatformMetrics } from './PlatformActivitySection';
 import { RoiDistributionChart } from './RoiDistributionChart';
 import { ToolAccuracyTable } from './ToolAccuracyTable';
 

--- a/components/AgentEconomies/PredictPage/PlatformActivitySection.tsx
+++ b/components/AgentEconomies/PredictPage/PlatformActivitySection.tsx
@@ -12,7 +12,7 @@ import { Tabs } from 'components/ui/tabs';
 import { Link } from 'components/ui/typography';
 import { isNil } from 'lodash';
 import Image from 'next/image';
-import { ReactNode, useState } from 'react';
+import { ReactNode } from 'react';
 
 export type Platform = 'polystrat' | 'omenstrat';
 
@@ -126,7 +126,8 @@ export const PlatformActivitySection = ({
   onPlatformChange,
   className,
 }: PlatformActivitySectionProps) => {
-  const [timeRange, setTimeRange] = useState('max');
+  // Time-range tabs are placeholder UI for upcoming work — only "Max" is
+  // selectable today, so the active key is hardcoded and onChange is a no-op.
   const m = metrics[platform];
 
   const performanceItems: MetricItemProps[] = [
@@ -195,7 +196,7 @@ export const PlatformActivitySection = ({
     },
   ];
 
-  if (platform === 'omenstrat' && m.marketCreatorTxs !== undefined) {
+  if (m.marketCreatorTxs !== undefined) {
     lifetimeItems.push({
       label: 'Market Creators & Closers',
       value: isNil(m.marketCreatorTxs) ? null : m.marketCreatorTxs.toLocaleString(),
@@ -212,7 +213,7 @@ export const PlatformActivitySection = ({
         <Card className="p-6 border border-slate-200 rounded-2xl bg-gradient-to-b from-[rgba(244,247,251,0.2)] to-[#F4F7FB] flex flex-col gap-6">
           <div className="flex items-center justify-between flex-wrap gap-3">
             <div className="text-lg font-semibold">Performance</div>
-            <Tabs items={TIME_RANGE_TABS} activeKey={timeRange} onChange={setTimeRange} />
+            <Tabs items={TIME_RANGE_TABS} activeKey="max" onChange={() => {}} />
           </div>
           <div className="grid sm:grid-cols-2 gap-4">
             {performanceItems.map((item, i) => (

--- a/components/AgentEconomies/PredictPage/PlatformActivitySection.tsx
+++ b/components/AgentEconomies/PredictPage/PlatformActivitySection.tsx
@@ -2,7 +2,12 @@
 
 import { Card } from 'components/ui/card';
 import { Popover } from 'components/ui/popover';
-import { StaleIndicator, StaleMetricContent, WarningIndicator } from 'components/ui/StaleIndicator';
+import {
+  StaleIndicator,
+  StaleIndicatorProps,
+  StaleMetricContent,
+  WarningIndicator,
+} from 'components/ui/StaleIndicator';
 import { Tabs } from 'components/ui/tabs';
 import { Link } from 'components/ui/typography';
 import { isNil } from 'lodash';
@@ -11,7 +16,7 @@ import { ReactNode, useState } from 'react';
 
 export type Platform = 'polystrat' | 'omenstrat';
 
-type MetricStatus = { stale?: boolean } | undefined;
+type MetricStatus = StaleIndicatorProps['status'];
 
 export type PlatformMetrics = {
   apr: number | null;

--- a/components/AgentEconomies/PredictPage/PlatformActivitySection.tsx
+++ b/components/AgentEconomies/PredictPage/PlatformActivitySection.tsx
@@ -1,0 +1,230 @@
+'use client';
+
+import { Card } from 'components/ui/card';
+import { Popover } from 'components/ui/popover';
+import { StaleIndicator, StaleMetricContent, WarningIndicator } from 'components/ui/StaleIndicator';
+import { Tabs } from 'components/ui/tabs';
+import { Link } from 'components/ui/typography';
+import { isNil } from 'lodash';
+import Image from 'next/image';
+import { ReactNode, useState } from 'react';
+
+export type Platform = 'polystrat' | 'omenstrat';
+
+type MetricStatus = { stale?: boolean } | undefined;
+
+export type PlatformMetrics = {
+  apr: number | null;
+  aprStatus: MetricStatus;
+  partialRoi: number | null;
+  finalRoi: number | null;
+  roiStatus: MetricStatus;
+  successRate: number | null;
+  successRateStatus: MetricStatus;
+  traderTxs: number | null;
+  mechTxs: number | null;
+  marketCreatorTxs?: number | null;
+  txsStatus: MetricStatus;
+};
+
+type PlatformActivitySectionProps = {
+  metrics: { polystrat: PlatformMetrics; omenstrat: PlatformMetrics };
+  platform: Platform;
+  onPlatformChange: (next: Platform) => void;
+  className?: string;
+};
+
+const PLATFORM_TABS: Array<{ key: Platform; label: string; icon: string }> = [
+  {
+    key: 'omenstrat',
+    label: 'Omenstrat',
+    icon: '/images/predict-page/omenstrat-icon.png',
+  },
+  {
+    key: 'polystrat',
+    label: 'Polystrat',
+    icon: '/images/predict-page/polystrat-icon.png',
+  },
+];
+
+const TIME_RANGE_TABS = [
+  { key: '7d', label: '7D', disabled: true, tooltip: 'Coming soon' },
+  { key: '30d', label: '30D', disabled: true, tooltip: 'Coming soon' },
+  { key: '90d', label: '90D', disabled: true, tooltip: 'Coming soon' },
+  { key: 'max', label: 'Max' },
+];
+
+type MetricItemProps = {
+  label: ReactNode;
+  value: string | null;
+  status?: MetricStatus;
+  href?: string;
+  warning?: ReactNode;
+};
+
+const MetricItem = ({ label, value, status, href, warning }: MetricItemProps) => {
+  const valueClass = `text-2xl font-bold ${status?.stale ? 'text-gray-400' : ''}`;
+  return (
+    <div className="flex flex-col gap-1">
+      <div className="text-sm text-slate-500">{label}</div>
+      <div className="flex items-center gap-2">
+        {href ? (
+          <Link href={href} className="text-2xl font-bold">
+            <span className={status?.stale ? 'text-gray-400' : ''}>{value || '--'}</span>
+          </Link>
+        ) : (
+          <span className={valueClass}>{value || '--'}</span>
+        )}
+        {warning ? (
+          <WarningIndicator>{warning}</WarningIndicator>
+        ) : (
+          <StaleIndicator status={status} />
+        )}
+      </div>
+    </div>
+  );
+};
+
+const PlatformSwitcher = ({
+  platform,
+  onChange,
+}: {
+  platform: Platform;
+  onChange: (next: Platform) => void;
+}) => (
+  <div className="flex items-stretch gap-1 bg-white border border-slate-200 rounded-xl p-1">
+    {PLATFORM_TABS.map(({ key, label, icon }) => {
+      const isActive = platform === key;
+      return (
+        <button
+          key={key}
+          type="button"
+          onClick={() => onChange(key)}
+          className={`flex-1 flex items-center justify-center gap-3 px-10 py-1.5 rounded-lg text-base font-normal transition-colors ${
+            isActive ? 'bg-slate-200 text-gray-900' : 'text-slate-500 hover:text-slate-700'
+          }`}
+        >
+          <Image src={icon} alt="" width={28} height={28} />
+          <span>
+            {label}
+            <span className="hidden sm:inline"> Agent Economy</span>
+          </span>
+        </button>
+      );
+    })}
+  </div>
+);
+
+export const PlatformActivitySection = ({
+  metrics,
+  platform,
+  onPlatformChange,
+  className,
+}: PlatformActivitySectionProps) => {
+  const [timeRange, setTimeRange] = useState('max');
+  const m = metrics[platform];
+
+  const performanceItems: MetricItemProps[] = [
+    {
+      label: (
+        <span className="flex items-center gap-2">
+          Total ROI - Average{' '}
+          {!isNil(m.partialRoi) && (
+            <Popover>
+              <div className="flex flex-col max-w-[320px] gap-4 text-base">
+                <p className="text-gray-500">
+                  Total ROI shows your agent&apos;s overall earnings, including profits from
+                  predictions and staking rewards, minus all related costs.
+                </p>
+                <p className="text-gray-500">
+                  Partial ROI reflects only prediction performance, excluding staking rewards.
+                </p>
+                <div className="flex justify-between">
+                  <span className="text-gray-900">Partial ROI</span>
+                  <span className={m.roiStatus?.stale ? 'text-gray-400' : ''}>
+                    {`${m.partialRoi}%`}
+                  </span>
+                </div>
+                <div className="text-sm">
+                  <StaleMetricContent status={m.roiStatus} />
+                </div>
+              </div>
+            </Popover>
+          )}
+        </span>
+      ),
+      value: isNil(m.finalRoi) ? null : `${m.finalRoi}%`,
+      status: m.roiStatus,
+      href: `/data#${platform}-predict-roi`,
+      warning:
+        platform === 'polystrat' ? (
+          <p>Due to recent updates on Polymarket this metric temporarily shows incorrect values</p>
+        ) : undefined,
+    },
+    {
+      label: 'OLAS Staking APR',
+      value: isNil(m.apr) ? null : `${m.apr}%`,
+      status: m.aprStatus,
+      href: `/data#${platform}-predict-apr`,
+    },
+    {
+      label: 'Prediction Accuracy - Average (Last 10K Trades)',
+      value: isNil(m.successRate) ? null : `${m.successRate}%`,
+      status: m.successRateStatus,
+      href: `/data#${platform}-predict-accuracy`,
+    },
+  ];
+
+  const lifetimeItems: MetricItemProps[] = [
+    {
+      label: 'Traders',
+      value: isNil(m.traderTxs) ? null : m.traderTxs.toLocaleString(),
+      status: m.txsStatus,
+      href: `/data#${platform}-predict-transactions-by-type`,
+    },
+    {
+      label: 'Mechs: Prediction Brokers',
+      value: isNil(m.mechTxs) ? null : m.mechTxs.toLocaleString(),
+      status: m.txsStatus,
+      href: `/data#${platform}-predict-transactions-by-type`,
+    },
+  ];
+
+  if (platform === 'omenstrat' && m.marketCreatorTxs !== undefined) {
+    lifetimeItems.push({
+      label: 'Market Creators & Closers',
+      value: isNil(m.marketCreatorTxs) ? null : m.marketCreatorTxs.toLocaleString(),
+      status: m.txsStatus,
+      href: `/data#${platform}-predict-transactions-by-type`,
+    });
+  }
+
+  return (
+    <div className={`flex flex-col gap-6 ${className ?? ''}`}>
+      <PlatformSwitcher platform={platform} onChange={onPlatformChange} />
+
+      <div className="grid md:grid-cols-2 gap-6">
+        <Card className="p-6 border border-slate-200 rounded-2xl bg-gradient-to-b from-[rgba(244,247,251,0.2)] to-[#F4F7FB] flex flex-col gap-6">
+          <div className="flex items-center justify-between flex-wrap gap-3">
+            <div className="text-lg font-semibold">Performance</div>
+            <Tabs items={TIME_RANGE_TABS} activeKey={timeRange} onChange={setTimeRange} />
+          </div>
+          <div className="grid sm:grid-cols-2 gap-4">
+            {performanceItems.map((item, i) => (
+              <MetricItem key={i} {...item} />
+            ))}
+          </div>
+        </Card>
+
+        <Card className="p-6 border border-slate-200 rounded-2xl bg-gradient-to-b from-[rgba(244,247,251,0.2)] to-[#F4F7FB] flex flex-col gap-6">
+          <div className="text-lg font-semibold">Transactions by Agent Type</div>
+          <div className="grid sm:grid-cols-2 gap-4">
+            {lifetimeItems.map((item, i) => (
+              <MetricItem key={i} {...item} />
+            ))}
+          </div>
+        </Card>
+      </div>
+    </div>
+  );
+};

--- a/components/AgentEconomies/PredictPage/RoiDistributionChart.tsx
+++ b/components/AgentEconomies/PredictPage/RoiDistributionChart.tsx
@@ -88,6 +88,7 @@ const ROI_DISTRIBUTION_CHART_OPTIONS: ChartOptions<'bar'> = {
 
 type RoiDistributionChartProps = {
   data: RoiDistributionData | null;
+  platform: 'polystrat' | 'omenstrat';
   className?: string;
   id?: string;
 };
@@ -98,38 +99,44 @@ const safeMidpoint = (min: number, max: number) => {
   return (min + max) / 2;
 };
 
-export const RoiDistributionChart = ({ data, className, id }: RoiDistributionChartProps) => {
+export const RoiDistributionChart = ({
+  data,
+  platform,
+  className,
+  id,
+}: RoiDistributionChartProps) => {
   const [activeRange, setActiveRange] = useState<TimeRange>('7D');
 
   const activeKey = TIME_RANGES.find((range) => range.label === activeRange)?.key ?? 'd7';
   const bins = data?.[activeKey] ?? null;
 
+  const isOmen = platform === 'omenstrat';
+  const datasetMeta = isOmen
+    ? {
+        label: 'Omenstrat',
+        background: OMENSTRAT_COLOR,
+        border: OMENSTRAT_COLOR_BORDER,
+        pick: (bin: BinData) => bin.omenstrat,
+      }
+    : {
+        label: 'Polystrat',
+        background: POLYSTRAT_COLOR,
+        border: POLYSTRAT_COLOR_BORDER,
+        pick: (bin: BinData) => bin.polystrat,
+      };
+
   const chartData = bins
     ? {
         datasets: [
-          // {
-          //   label: 'Omenstrat',
-          //   data: bins.map((bin) => ({
-          //     x: safeMidpoint(bin.min, bin.max),
-          //     y: bin.omenstrat,
-          //     range: bin.label,
-          //   })),
-          //   backgroundColor: OMENSTRAT_COLOR,
-          //   borderColor: OMENSTRAT_COLOR_BORDER,
-          //   borderWidth: 1,
-          //   borderRadius: 2,
-          //   barPercentage: 0.9,
-          //   categoryPercentage: 0.85,
-          // },
           {
-            label: 'Polystrat',
+            label: datasetMeta.label,
             data: bins.map((bin) => ({
               x: safeMidpoint(bin.min, bin.max),
-              y: bin.polystrat,
+              y: datasetMeta.pick(bin),
               range: bin.label,
             })),
-            backgroundColor: POLYSTRAT_COLOR,
-            borderColor: POLYSTRAT_COLOR_BORDER,
+            backgroundColor: datasetMeta.background,
+            borderColor: datasetMeta.border,
             borderWidth: 1,
             borderRadius: 2,
             barPercentage: 0.9,
@@ -148,11 +155,15 @@ export const RoiDistributionChart = ({ data, className, id }: RoiDistributionCha
       <div className="flex items-start justify-between mb-6 flex-wrap gap-4">
         <div className="flex items-center gap-2">
           <h3 className="text-lg font-semibold text-gray-900">
-            Polystrat Partial ROI Distribution
+            {datasetMeta.label} Partial ROI Distribution
           </h3>
-          <WarningIndicator>
-            <p>Due to recent updates on Polymarket this chart temporarily shows incorrect values</p>
-          </WarningIndicator>
+          {!isOmen && (
+            <WarningIndicator>
+              <p>
+                Due to recent updates on Polymarket this chart temporarily shows incorrect values
+              </p>
+            </WarningIndicator>
+          )}
         </div>
 
         <Tabs
@@ -161,12 +172,6 @@ export const RoiDistributionChart = ({ data, className, id }: RoiDistributionCha
           onChange={(key) => setActiveRange(key as TimeRange)}
         />
       </div>
-
-      {/* Legend row */}
-      {/* <div className="flex flex-wrap gap-x-4 gap-y-1 mb-6">
-        <LegendItem color={`bg-[#A755F7]`} label="Omenstrat" />
-        <LegendItem color={`bg-[#4D74FF]`} label="Polystrat" />
-      </div> */}
 
       {/* Chart area */}
       {chartData ? (

--- a/components/AgentEconomies/PredictPage/RoiDistributionChart.tsx
+++ b/components/AgentEconomies/PredictPage/RoiDistributionChart.tsx
@@ -9,7 +9,7 @@ import { Bar } from 'react-chartjs-2';
 
 ChartJS.register(LinearScale, BarElement, Tooltip, Legend);
 
-type TimeRange = '7D' | '30D' | '90D' | 'Max';
+type TimeRange = '7d' | '30d' | '90d' | 'max';
 
 type RoiDistributionData = {
   d7: BinData[] | null;
@@ -24,11 +24,15 @@ type DataPoint = {
   range: string;
 };
 
-const TIME_RANGES: Array<{ label: TimeRange; key: keyof RoiDistributionData }> = [
-  { label: '7D', key: 'd7' },
-  { label: '30D', key: 'd30' },
-  { label: '90D', key: 'd90' },
-  { label: 'Max', key: 'all' },
+const TIME_RANGES: Array<{
+  key: TimeRange;
+  label: string;
+  dataKey: keyof RoiDistributionData;
+}> = [
+  { key: '7d', label: '7D', dataKey: 'd7' },
+  { key: '30d', label: '30D', dataKey: 'd30' },
+  { key: '90d', label: '90D', dataKey: 'd90' },
+  { key: 'max', label: 'Max', dataKey: 'all' },
 ];
 
 const OMENSTRAT_COLOR = '#A755F7';
@@ -105,10 +109,10 @@ export const RoiDistributionChart = ({
   className,
   id,
 }: RoiDistributionChartProps) => {
-  const [activeRange, setActiveRange] = useState<TimeRange>('7D');
+  const [activeRange, setActiveRange] = useState<TimeRange>('7d');
 
-  const activeKey = TIME_RANGES.find((range) => range.label === activeRange)?.key ?? 'd7';
-  const bins = data?.[activeKey] ?? null;
+  const activeDataKey = TIME_RANGES.find((range) => range.key === activeRange)?.dataKey ?? 'd7';
+  const bins = data?.[activeDataKey] ?? null;
 
   const isOmen = platform === 'omenstrat';
   const datasetMeta = isOmen
@@ -167,7 +171,7 @@ export const RoiDistributionChart = ({
         </div>
 
         <Tabs
-          items={TIME_RANGES.map(({ label }) => ({ key: label, label }))}
+          items={TIME_RANGES.map(({ key, label }) => ({ key, label }))}
           activeKey={activeRange}
           onChange={(key) => setActiveRange(key as TimeRange)}
         />

--- a/components/AgentEconomies/PredictPage/ToolAccuracyTable.tsx
+++ b/components/AgentEconomies/PredictPage/ToolAccuracyTable.tsx
@@ -1,25 +1,20 @@
-import { useState } from 'react';
 import { ToolAccuracyData } from 'common-util/api/predict/tool-accuracy';
 import { Card } from 'components/ui/card';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from 'components/ui/table';
-import { Tabs } from 'components/ui/tabs';
-
-type AgentBlueprint = 'omenstrat' | 'polystrat';
+import { Platform } from './PlatformActivitySection';
 
 type ToolAccuracyTableProps = {
   data: ToolAccuracyData | null;
+  platform: Platform;
   className?: string;
   id?: string;
 };
 
-const AGENT_BLUEPRINTS = [
-  { key: 'omenstrat', label: 'Omenstrat' },
-  { key: 'polystrat', label: 'Polystrat' },
-];
-
-const BLUEPRINT_LABELS: Record<AgentBlueprint, string> = {
-  omenstrat: 'Omenstrat',
-  polystrat: 'Polystrat',
+const PLATFORM_DESCRIPTIONS: Record<Platform, string> = {
+  omenstrat:
+    'These tools are designed to forecast outcomes on Omen. The leaderboard shows which tools had the strongest historical accuracy.',
+  polystrat:
+    'These tools are designed to forecast outcomes on Polymarket. The leaderboard shows which tools had the strongest historical accuracy.',
 };
 
 const parseIrrelevantTools = (envValue: string | undefined): Set<string> => {
@@ -33,57 +28,61 @@ const parseIrrelevantTools = (envValue: string | undefined): Set<string> => {
   return new Set();
 };
 
-const IRRELEVANT_TOOLS: Record<AgentBlueprint, Set<string>> = {
+const IRRELEVANT_TOOLS: Record<Platform, Set<string>> = {
   omenstrat: parseIrrelevantTools(process.env.NEXT_PUBLIC_OMENSTRAT_IRRELEVANT_TOOLS),
   polystrat: parseIrrelevantTools(process.env.NEXT_PUBLIC_POLYSTRAT_IRRELEVANT_TOOLS),
 };
 
-export const ToolAccuracyTable = ({ data, className, id }: ToolAccuracyTableProps) => {
-  const [activeBlueprint, setActiveBlueprint] = useState<AgentBlueprint>('polystrat');
-
-  const rows = data?.[activeBlueprint] ?? null;
+export const ToolAccuracyTable = ({ data, platform, className, id }: ToolAccuracyTableProps) => {
+  const rows = data?.[platform] ?? null;
 
   if (!data || (!data.omenstrat?.length && !data.polystrat?.length)) return null;
 
-  const irrelevant = IRRELEVANT_TOOLS[activeBlueprint];
+  const irrelevant = IRRELEVANT_TOOLS[platform];
   const filteredRows = rows ? rows.filter((r) => !irrelevant.has(r.tool.toLowerCase())) : [];
   const sortedRows = filteredRows.sort((a, b) => b.accuracy - a.accuracy);
 
   return (
     <Card
       id={id}
-      className={`p-8 overflow-hidden border border-slate-200 rounded-2xl bg-gradient-to-b from-[rgba(244,247,251,0.2)] to-[#F4F7FB] flex flex-col ${className ?? ''}`}
+      className={`overflow-hidden border border-slate-200 rounded-2xl bg-gradient-to-b from-[rgba(244,247,251,0.2)] to-[#F4F7FB] flex flex-col ${className ?? ''}`}
     >
-      <div className="flex items-start justify-between mb-6 flex-wrap gap-4">
-        <div className="text-lg font-semibold">Tool Accuracy</div>
-        <Tabs
-          items={AGENT_BLUEPRINTS}
-          activeKey={activeBlueprint}
-          onChange={(key) => setActiveBlueprint(key as AgentBlueprint)}
-        />
+      <div className="flex flex-col gap-3 px-6 py-4">
+        <div className="text-lg font-semibold text-gray-900">Tool accuracy</div>
+        <p className="text-base text-slate-500">{PLATFORM_DESCRIPTIONS[platform]}</p>
       </div>
 
       {sortedRows.length === 0 ? (
-        <div className="text-sm text-gray-500 py-4">No tool accuracy data available.</div>
+        <div className="text-sm text-gray-500 px-8 pb-8">No tool accuracy data available.</div>
       ) : (
-        <Table>
+        <Table className="text-base">
           <TableHeader>
-            <TableRow>
-              <TableHead className="text-base">Tool</TableHead>
-              <TableHead className="text-right text-base">Accuracy %</TableHead>
-              <TableHead className="text-right text-base">Total Bets</TableHead>
-              <TableHead className="text-right text-base">Correct</TableHead>
+            <TableRow className="border-t border-b border-slate-200 hover:bg-transparent">
+              <TableHead className="px-6 py-3 text-base font-normal text-slate-500">Tool</TableHead>
+              <TableHead className="px-6 py-3 text-right text-base font-normal text-slate-500">
+                Accuracy
+              </TableHead>
+              <TableHead className="px-6 py-3 text-right text-base font-normal text-slate-500">
+                Total Trades
+              </TableHead>
+              <TableHead className="px-6 py-3 text-right text-base font-normal text-slate-500">
+                Correct Trades
+              </TableHead>
             </TableRow>
           </TableHeader>
           <TableBody>
             {sortedRows.map((row) => (
-              <TableRow key={row.tool}>
-                <TableCell className="text-sm font-medium">{row.tool}</TableCell>
-                <TableCell className="text-sm text-right">{row.accuracy}%</TableCell>
-                <TableCell className="text-sm text-right">
+              <TableRow key={row.tool} className="border-b border-slate-200 hover:bg-transparent">
+                <TableCell className="px-6 py-3 text-base font-medium text-gray-900">
+                  {row.tool}
+                </TableCell>
+                <TableCell className="px-6 py-3 text-right text-base text-gray-900">
+                  {row.accuracy}%
+                </TableCell>
+                <TableCell className="px-6 py-3 text-right text-base text-gray-900">
                   {row.totalBets.toLocaleString()}
                 </TableCell>
-                <TableCell className="text-sm text-right">
+                <TableCell className="px-6 py-3 text-right text-base text-gray-900">
                   {row.correctBets.toLocaleString()}
                 </TableCell>
               </TableRow>

--- a/components/AgentEconomies/PredictPage/ToolAccuracyTable.tsx
+++ b/components/AgentEconomies/PredictPage/ToolAccuracyTable.tsx
@@ -1,7 +1,7 @@
 import { ToolAccuracyData } from 'common-util/api/predict/tool-accuracy';
 import { Card } from 'components/ui/card';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from 'components/ui/table';
-import { Platform } from './PlatformActivitySection';
+import type { Platform } from './PlatformActivitySection';
 
 type ToolAccuracyTableProps = {
   data: ToolAccuracyData | null;

--- a/components/ui/tabs.tsx
+++ b/components/ui/tabs.tsx
@@ -1,3 +1,5 @@
+import * as Tooltip from '@radix-ui/react-tooltip';
+
 type TabItem = {
   key: string;
   label: string;
@@ -12,36 +14,45 @@ type TabsProps = {
 };
 
 export const Tabs = ({ items, activeKey, onChange }: TabsProps) => (
-  <div className="flex items-center gap-1 bg-white border border-slate-100 rounded-lg p-1">
-    {items.map(({ key, label, disabled, tooltip }) => {
-      const isActive = activeKey === key;
-      const stateClasses = disabled
-        ? 'text-gray-300 cursor-not-allowed'
-        : isActive
-          ? 'bg-slate-100 text-gray-900 shadow-sm'
-          : 'text-gray-500 hover:text-gray-700';
-      const button = (
-        <button
-          key={key}
-          type="button"
-          disabled={disabled}
-          onClick={() => {
-            if (!disabled) onChange(key);
-          }}
-          className={`px-3 py-1 rounded-md text-sm font-medium transition-colors ${stateClasses}`}
-        >
-          {label}
-        </button>
-      );
-      // `title` on a disabled <button> is suppressed by the browser, so wrap
-      // in a span that owns the tooltip and lets pointer events through.
-      return disabled && tooltip ? (
-        <span key={key} title={tooltip} className="inline-flex">
-          {button}
-        </span>
-      ) : (
-        button
-      );
-    })}
-  </div>
+  <Tooltip.Provider delayDuration={150}>
+    <div className="flex items-center gap-1 bg-white border border-slate-100 rounded-lg p-1">
+      {items.map(({ key, label, disabled, tooltip }) => {
+        const isActive = activeKey === key;
+        const stateClasses = disabled
+          ? 'text-gray-300 cursor-not-allowed'
+          : isActive
+            ? 'bg-slate-100 text-gray-900 shadow-sm'
+            : 'text-gray-500 hover:text-gray-700';
+        // Use `aria-disabled` rather than `disabled` so the button stays
+        // keyboard-focusable and the Radix tooltip is reachable on focus
+        // and touch — not just mouse hover.
+        const button = (
+          <button
+            key={key}
+            type="button"
+            aria-disabled={disabled || undefined}
+            onClick={() => {
+              if (!disabled) onChange(key);
+            }}
+            className={`px-3 py-1 rounded-md text-sm font-medium transition-colors ${stateClasses}`}
+          >
+            {label}
+          </button>
+        );
+        return disabled && tooltip ? (
+          <Tooltip.Root key={key}>
+            <Tooltip.Trigger asChild>{button}</Tooltip.Trigger>
+            <Tooltip.Content
+              side="top"
+              className="px-2 py-1 text-xs bg-white border rounded-md shadow-sm shadow-gray-500/10 mb-1"
+            >
+              {tooltip}
+            </Tooltip.Content>
+          </Tooltip.Root>
+        ) : (
+          button
+        );
+      })}
+    </div>
+  </Tooltip.Provider>
 );

--- a/components/ui/tabs.tsx
+++ b/components/ui/tabs.tsx
@@ -1,6 +1,8 @@
 type TabItem = {
   key: string;
   label: string;
+  disabled?: boolean;
+  tooltip?: string;
 };
 
 type TabsProps = {
@@ -11,18 +13,35 @@ type TabsProps = {
 
 export const Tabs = ({ items, activeKey, onChange }: TabsProps) => (
   <div className="flex items-center gap-1 bg-white border border-slate-100 rounded-lg p-1">
-    {items.map(({ key, label }) => (
-      <button
-        key={key}
-        onClick={() => onChange(key)}
-        className={`px-3 py-1 rounded-md text-sm font-medium transition-colors ${
-          activeKey === key
-            ? 'bg-slate-100 text-gray-900 shadow-sm'
-            : 'text-gray-500 hover:text-gray-700'
-        }`}
-      >
-        {label}
-      </button>
-    ))}
+    {items.map(({ key, label, disabled, tooltip }) => {
+      const isActive = activeKey === key;
+      const stateClasses = disabled
+        ? 'text-gray-300 cursor-not-allowed'
+        : isActive
+          ? 'bg-slate-100 text-gray-900 shadow-sm'
+          : 'text-gray-500 hover:text-gray-700';
+      const button = (
+        <button
+          key={key}
+          type="button"
+          disabled={disabled}
+          onClick={() => {
+            if (!disabled) onChange(key);
+          }}
+          className={`px-3 py-1 rounded-md text-sm font-medium transition-colors ${stateClasses}`}
+        >
+          {label}
+        </button>
+      );
+      // `title` on a disabled <button> is suppressed by the browser, so wrap
+      // in a span that owns the tooltip and lets pointer events through.
+      return disabled && tooltip ? (
+        <span key={key} title={tooltip} className="inline-flex">
+          {button}
+        </span>
+      ) : (
+        button
+      );
+    })}
   </div>
 );


### PR DESCRIPTION
## Proposed changes

Introduce a global Omenstrat/Polystrat switcher below the DAA cards that drives the Performance + Transactions cards, the ROI distribution chart, and the Tool accuracy table. Also fix the ROI distribution activity threshold to use lifetime totalBets from traderAgents instead of summing daily stats, so the floor reflects an agent's overall history rather than its activity within the window.

## Screenshots/Recordings

### Omenstrat
<img width="472" height="668" alt="Screenshot 2026-05-07 at 18 52 05" src="https://github.com/user-attachments/assets/bc94733a-4126-40e1-bf66-6c72b07365dd" />

### Polystrat
<img width="458" height="613" alt="Screenshot 2026-05-07 at 18 52 10" src="https://github.com/user-attachments/assets/14e82069-51e8-4640-9953-4b2413d38567" />


## Things to keep in mind

<!-- Please check if the PR fulfills these requirements -->

- [ ] I confirm I have updated the meta title and description for the page, if applicable.
