### PR TITLE
style: improve blog post spacing and markdown rendering

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "graphql-request": "7.2.0",
     "lodash": "4.18.0",
     "lucide-react": "0.414.0",
-    "next": "15.5.15",
+    "next": "15.5.18",
     "next-plausible": "3.12.4",
     "next-sitemap": "4.2.3",
     "postcss": "8.5.10",

--- a/pages/blog/[id].tsx
+++ b/pages/blog/[id].tsx
@@ -21,7 +21,7 @@ const BlogItem = ({ blog }) => {
   const imageUrl = apiUrl && imagePath ? `${apiUrl}${imagePath}` : '';
 
   const formattedContent = (
-    <Markdown className="text-lg font-light text-gray-600">{content}</Markdown>
+    <Markdown className="text-lg text-gray-700 leading-relaxed">{content}</Markdown>
   );
   const description = getLimitedText(formattedContent.props.children, DESC_CHAR_LIMIT);
 

--- a/pages/blog/[id].tsx
+++ b/pages/blog/[id].tsx
@@ -20,24 +20,26 @@ const BlogItem = ({ blog }) => {
   const apiUrl = getApiUrl();
   const imageUrl = apiUrl && imagePath ? `${apiUrl}${imagePath}` : '';
 
-  const formattedContent = <Markdown>{content}</Markdown>;
+  const formattedContent = (
+    <Markdown className="text-lg font-light text-gray-600">{content}</Markdown>
+  );
   const description = getLimitedText(formattedContent.props.children, DESC_CHAR_LIMIT);
 
   return (
     <PageWrapper>
       <Meta pageTitle={title} description={description} siteImageUrl={imageUrl} />
-      <div className="max-w-3xl mx-auto p-4">
+      <div className="max-w-3xl mx-auto px-4 py-8 md:py-10">
         {imagePath && (
           <Image
             src={imageUrl}
             width={headerImage.data[0].attributes.formats.large.width}
             height={headerImage.data[0].attributes.formats.large.height}
             alt={title}
-            className="border mb-4 rounded-lg"
+            className="border mb-12 rounded-lg"
           />
         )}
-        <h1 className={`${TITLE.SMALL} mb-4`}>{title}</h1>
-        <div className={`${TEXT} mb-4`}>{formattedDate}</div>
+        <h1 className={`${TITLE.SMALL} mb-3`}>{title}</h1>
+        <div className={`${TEXT} mb-8`}>{formattedDate}</div>
         {formattedContent}
       </div>
     </PageWrapper>

--- a/styles/globals.tsx
+++ b/styles/globals.tsx
@@ -37,7 +37,7 @@ export const markdownComponents = {
   ),
   ol: ({ node: _node, ...props }) => (
     <ol
-      className="list-none pl-0 mb-4 last:mb-0 [counter-reset:list-counter] [&>li]:[counter-increment:list-counter] [&>li]:relative [&>li]:pl-12 [&>li]:mb-3 [&>li:last-child]:mb-0 [&>li]:before:[content:counter(list-counter,decimal-leading-zero)] [&>li]:before:absolute [&>li]:before:left-0 [&>li]:before:top-0 [&>li]:before:flex [&>li]:before:items-center [&>li]:before:justify-center [&>li]:before:w-8 [&>li]:before:h-8 [&>li]:before:rounded-full [&>li]:before:bg-purple-100 [&>li]:before:text-purple-800 [&>li]:before:text-xs [&>li]:before:font-semibold"
+      className="list-decimal list-outside pl-6 mb-4 last:mb-0 marker:text-purple-800 marker:font-medium"
       {...props}
     />
   ),

--- a/styles/globals.tsx
+++ b/styles/globals.tsx
@@ -30,10 +30,7 @@ export const markdownComponents = {
   strong: ({ node: _node, ...props }) => <strong {...props}></strong>,
   // Apply tailwind classes to style lists
   ul: ({ node: _node, ...props }) => (
-    <ul
-      className="list-disc list-outside pl-6 mb-4 last:mb-0 marker:text-purple-800"
-      {...props}
-    />
+    <ul className="list-disc list-outside pl-6 mb-4 last:mb-0" {...props} />
   ),
   ol: ({ node: _node, ...props }) => (
     <ol

--- a/styles/globals.tsx
+++ b/styles/globals.tsx
@@ -37,7 +37,7 @@ export const markdownComponents = {
   ),
   ol: ({ node: _node, ...props }) => (
     <ol
-      className="list-decimal list-outside pl-6 mb-4 last:mb-0 marker:text-purple-800 marker:font-medium"
+      className="list-none pl-0 mb-4 last:mb-0 [counter-reset:list-counter] [&>li]:[counter-increment:list-counter] [&>li]:relative [&>li]:pl-12 [&>li]:mb-3 [&>li:last-child]:mb-0 [&>li]:before:[content:counter(list-counter,decimal-leading-zero)] [&>li]:before:absolute [&>li]:before:left-0 [&>li]:before:top-0 [&>li]:before:flex [&>li]:before:items-center [&>li]:before:justify-center [&>li]:before:w-8 [&>li]:before:h-8 [&>li]:before:rounded-full [&>li]:before:bg-purple-100 [&>li]:before:text-purple-800 [&>li]:before:text-xs [&>li]:before:font-semibold"
       {...props}
     />
   ),

--- a/styles/globals.tsx
+++ b/styles/globals.tsx
@@ -25,35 +25,54 @@ export const markdownComponents = {
     />
   ),
   // Apply margin to paragraphs to create space between them
-  p: ({ node: _node, ...props }) => <p {...props} />,
+  p: ({ node: _node, ...props }) => <p className="mb-4 last:mb-0" {...props} />,
 
   strong: ({ node: _node, ...props }) => <strong {...props}></strong>,
   // Apply tailwind classes to style lists
   ul: ({ node: _node, ...props }) => (
-    <>
-      <ul className="list-disc list-inside pl-4 inline-block w-full" {...props} />
-      <br />
-    </>
+    <ul
+      className="list-disc list-outside pl-6 mb-4 last:mb-0 marker:text-purple-800"
+      {...props}
+    />
   ),
   ol: ({ node: _node, ...props }) => (
-    <ol className="list-decimal list-inside inline-block" {...props} />
+    <ol
+      className="list-decimal list-outside pl-6 mb-4 last:mb-0 marker:text-purple-800 marker:font-medium"
+      {...props}
+    />
   ),
 
-  li: ({ node: _node, ...props }) => <li className="mb-2" {...props} />,
-  h1: ({ node: _node, ...props }) => <h2 className="text-3xl font-bold mb-4" {...props} />,
-  h2: ({ node: _node, ...props }) => <h2 className="text-2xl font-semibold mb-3" {...props} />,
-  h3: ({ node: _node, ...props }) => <h3 className="text-xl font-medium mb-2" {...props} />,
-  h4: ({ node: _node, ...props }) => <h4 className="text-lg font-medium mb-2" {...props} />,
-  h5: ({ node: _node, ...props }) => <h5 className="text-[17px] font-medium mb-2" {...props} />,
-  h6: ({ node: _node, ...props }) => <h6 className="text-sm font-medium mb-2" {...props} />,
+  li: ({ node: _node, ...props }) => <li className="mb-2 pl-1 last:mb-0" {...props} />,
+  h1: ({ node: _node, ...props }) => (
+    <h2 className="text-3xl font-bold text-gray-900 mt-8 mb-4 first:mt-0" {...props} />
+  ),
+  h2: ({ node: _node, ...props }) => (
+    <h2 className="text-2xl font-semibold text-gray-900 mt-8 mb-3 first:mt-0" {...props} />
+  ),
+  h3: ({ node: _node, ...props }) => (
+    <h3 className="text-xl font-medium text-gray-900 mt-6 mb-2 first:mt-0" {...props} />
+  ),
+  h4: ({ node: _node, ...props }) => (
+    <h4 className="text-lg font-medium text-gray-900 mt-6 mb-2 first:mt-0" {...props} />
+  ),
+  h5: ({ node: _node, ...props }) => (
+    <h5 className="text-[17px] font-medium text-gray-900 mt-4 mb-2 first:mt-0" {...props} />
+  ),
+  h6: ({ node: _node, ...props }) => (
+    <h6 className="text-base font-medium text-gray-900 mt-4 mb-2 first:mt-0" {...props} />
+  ),
   pre: ({ node: _node, ...props }) => (
-    <pre className="p-4 bg-gray-800 border rounded-md overflow-auto" {...props} />
+    <pre className="p-4 bg-gray-800 border rounded-md overflow-auto mb-4 last:mb-0" {...props} />
   ),
 
   code: ({ node: _node, ...props }) => <code className="text-sm" {...props} />,
+  img: ({ node: _node, ...props }) => (
+    // eslint-disable-next-line @next/next/no-img-element, jsx-a11y/alt-text
+    <img className="rounded-lg my-8 first:mt-0 last:mb-0 max-w-full h-auto" {...props} />
+  ),
   blockquote: ({ node: _node, children, className, ...props }) => (
     <blockquote
-      className={`border-l-4 border-gray-800 pl-6 mb-4 italic ${className || ''}`}
+      className={`border-l-4 border-gray-800 pl-6 my-4 last:mb-0 italic ${className || ''}`}
       {...props}
     >
       {children}

--- a/styles/globals.tsx
+++ b/styles/globals.tsx
@@ -18,7 +18,7 @@ export const markdownComponents = {
   // Apply tailwind classes to style links
   a: ({ node: _node, ...props }) => (
     <a
-      className="text-purple-800 hover:text-blue-800"
+      className="text-purple-700 hover:text-purple-800"
       target="_blank"
       rel="noopener noreferrer"
       {...props}
@@ -47,7 +47,7 @@ export const markdownComponents = {
     <h2 className="text-3xl font-bold text-gray-900 mt-8 mb-4 first:mt-0" {...props} />
   ),
   h2: ({ node: _node, ...props }) => (
-    <h2 className="text-2xl font-semibold text-gray-900 mt-8 mb-3 first:mt-0" {...props} />
+    <h2 className="text-2xl font-semibold text-gray-900 mt-12 mb-3 first:mt-0" {...props} />
   ),
   h3: ({ node: _node, ...props }) => (
     <h3 className="text-xl font-medium text-gray-900 mt-6 mb-2 first:mt-0" {...props} />

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -11,6 +11,7 @@ module.exports = {
     './common-util/**/*.{js,jsx,ts,tsx}',
     './app/**/*.{js,jsx,ts,tsx}',
     './src/**/*.{js,jsx,ts,tsx}',
+    './styles/**/*.{js,jsx,ts,tsx}',
   ],
   prefix: '',
   theme: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1285,10 +1285,10 @@
     "@emnapi/runtime" "^1.4.3"
     "@tybys/wasm-util" "^0.10.0"
 
-"@next/env@15.5.15":
-  version "15.5.15"
-  resolved "https://registry.yarnpkg.com/@next/env/-/env-15.5.15.tgz#24b29b94852da52dd8e10f3ea0382a3ddb8733a6"
-  integrity sha512-vcmyu5/MyFzN7CdqRHO3uHO44p/QPCZkuTUXroeUmhNP8bL5PHFEhik22JUazt+CDDoD6EpBYRCaS2pISL+/hg==
+"@next/env@15.5.18":
+  version "15.5.18"
+  resolved "https://registry.yarnpkg.com/@next/env/-/env-15.5.18.tgz#207ab150d3f1c787ac343946155392d478506c1b"
+  integrity sha512-hAV85Ckd9QR6RvH04MEKwsfLTksvFpO47j9xwtoIuvuPnlwecpSi+uZTtm8HirVbtlI2Fnz//xpcSTjFdyJk+g==
 
 "@next/env@^13.4.3":
   version "13.5.11"
@@ -1302,45 +1302,45 @@
   dependencies:
     fast-glob "3.3.1"
 
-"@next/swc-darwin-arm64@15.5.15":
-  version "15.5.15"
-  resolved "https://registry.yarnpkg.com/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.5.15.tgz#c8de0985b21b6914c17097d548dbf9b95e12bc57"
-  integrity sha512-6PvFO2Tzt10GFK2Ro9tAVEtacMqRmTarYMFKAnV2vYMdwWc73xzmDQyAV7SwEdMhzmiRoo7+m88DuiXlJlGeaw==
+"@next/swc-darwin-arm64@15.5.18":
+  version "15.5.18"
+  resolved "https://registry.yarnpkg.com/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.5.18.tgz#d4376e2d31f90679128c5d83aecfb7aa244e475c"
+  integrity sha512-w0WvQf1n+txiwns/9pwIQteCJpZTbxzO2SE0FLcwuD4v0WEh1JPOjdyxWL21XwJsdpx8cFRjyzxzCS/siP7HcQ==
 
-"@next/swc-darwin-x64@15.5.15":
-  version "15.5.15"
-  resolved "https://registry.yarnpkg.com/@next/swc-darwin-x64/-/swc-darwin-x64-15.5.15.tgz#e237a2c7991e729a8b5051e019b3ea1ea16a9071"
-  integrity sha512-G+YNV+z6FDZTp/+IdGyIMFqalBTaQSnvAA+X/hrt+eaTRFSznRMz9K7rTmzvM6tDmKegNtyzgufZW0HwVzEqaQ==
+"@next/swc-darwin-x64@15.5.18":
+  version "15.5.18"
+  resolved "https://registry.yarnpkg.com/@next/swc-darwin-x64/-/swc-darwin-x64-15.5.18.tgz#35e179f2863d0ea1b249d5f8a1616593431f1645"
+  integrity sha512-znn71QmDuxm+BOaglihMZfvyySMnNljkVIY5Z2TCssBmm+WqL6c19VhtH5ktFkHa8EZ2bnTUpcNcmNSQsg67og==
 
-"@next/swc-linux-arm64-gnu@15.5.15":
-  version "15.5.15"
-  resolved "https://registry.yarnpkg.com/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.5.15.tgz#d9e52844ec5585c75ec23e9eb9b2a1b4ab37780c"
-  integrity sha512-eVkrMcVIBqGfXB+QUC7jjZ94Z6uX/dNStbQFabewAnk13Uy18Igd1YZ/GtPRzdhtm7QwC0e6o7zOQecul4iC1w==
+"@next/swc-linux-arm64-gnu@15.5.18":
+  version "15.5.18"
+  resolved "https://registry.yarnpkg.com/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.5.18.tgz#5c97bd8422cc0d43b6b07329514bfaceb04b8014"
+  integrity sha512-yPPe5MNL+igZUa+OsqQJisqSfh6oarIuA1Q0BDxljGJhRQyZeP+WRHh7rs/jZUGMh5aY0YdIjXZG0VohkKkUdw==
 
-"@next/swc-linux-arm64-musl@15.5.15":
-  version "15.5.15"
-  resolved "https://registry.yarnpkg.com/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.5.15.tgz#4f727669c0070bafc8ace8686600c49b9d4de777"
-  integrity sha512-RwSHKMQ7InLy5GfkY2/n5PcFycKA08qI1VST78n09nN36nUPqCvGSMiLXlfUmzmpQpF6XeBYP2KRWHi0UW3uNg==
+"@next/swc-linux-arm64-musl@15.5.18":
+  version "15.5.18"
+  resolved "https://registry.yarnpkg.com/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.5.18.tgz#497dda6be6e905e3ab7b02624a5493ccf08f06e7"
+  integrity sha512-glaCczEWIrHsokFZ3pP08U4BpKxwIdnT+txdOM32OBgpL9Yw4aqx8NejmgtZQZOdstQ5f0L3CasIZudzCuD+nw==
 
-"@next/swc-linux-x64-gnu@15.5.15":
-  version "15.5.15"
-  resolved "https://registry.yarnpkg.com/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.5.15.tgz#25435233caf9bb60e3be3e7291f0c2e7b9424e4e"
-  integrity sha512-nplqvY86LakS+eeiuWsNWvfmK8pFcOEW7ZtVRt4QH70lL+0x6LG/m1OpJ/tvrbwjmR8HH9/fH2jzW1GlL03TIg==
+"@next/swc-linux-x64-gnu@15.5.18":
+  version "15.5.18"
+  resolved "https://registry.yarnpkg.com/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.5.18.tgz#c5863100284c0182ff546d212c74dc9348d16564"
+  integrity sha512-oUfg2EgJmU3R0OCOWiokGFUTvZiPfXtriXiuF3YNxRoROCdgvTedHIzYoeKH34gsZxS/V7mHbfq2hpAHwhH1/A==
 
-"@next/swc-linux-x64-musl@15.5.15":
-  version "15.5.15"
-  resolved "https://registry.yarnpkg.com/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.5.15.tgz#951dab9e9679365cbeb6dd88d3c77e840a4c14ae"
-  integrity sha512-eAgl9NKQ84/sww0v81DQINl/vL2IBxD7sMybd0cWRw6wqgouVI53brVRBrggqBRP/NWeIAE1dm5cbKYoiMlqDQ==
+"@next/swc-linux-x64-musl@15.5.18":
+  version "15.5.18"
+  resolved "https://registry.yarnpkg.com/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.5.18.tgz#26f3fdc26707458481d40649a1420584bf1f3bf7"
+  integrity sha512-JLxSP3KTd9iu/bvUMQxH7RJo9xKSHf55/6RPE4a6FTSZygGn7uvZbCej0AHXydwkggQGSD9UddSjwv6Xz5ESfA==
 
-"@next/swc-win32-arm64-msvc@15.5.15":
-  version "15.5.15"
-  resolved "https://registry.yarnpkg.com/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.5.15.tgz#36d4c6df0ac194a5d3cc2e7f16c62a5b31ab0671"
-  integrity sha512-GJVZC86lzSquh0MtvZT+L7G8+jMnJcldloOjA8Kf3wXvBrvb6OGe2MzPuALxFshSm/IpwUtD2mIoof39ymf52A==
+"@next/swc-win32-arm64-msvc@15.5.18":
+  version "15.5.18"
+  resolved "https://registry.yarnpkg.com/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.5.18.tgz#8acdb2aeec6d768bffa3043485d22ecdf48a6e4c"
+  integrity sha512-ir1v7enP52K2HNz3tQQvwF+x7VNxBk1ciiZ18WBPvxf4C59IqdfmHPJYK3vH7rSxpuCVw/8C712wTXNAtEp+NA==
 
-"@next/swc-win32-x64-msvc@15.5.15":
-  version "15.5.15"
-  resolved "https://registry.yarnpkg.com/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.5.15.tgz#d2ad3b9506c761ed07297acaeb00fb2c694c41f8"
-  integrity sha512-nFucjVdwlFqxh/JG3hWSJ4p8+YJV7Ii8aPDuBQULB6DzUF4UNZETXLfEUk+oI2zEznWWULPt7MeuTE6xtK1HSA==
+"@next/swc-win32-x64-msvc@15.5.18":
+  version "15.5.18"
+  resolved "https://registry.yarnpkg.com/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.5.18.tgz#beac6228e60e3ee08ce7a20b7f61b3dc516d4b10"
+  integrity sha512-LIu5me6QTANCd25E7I5uIEfvgQ06RK7tvHAbYo3zCb3VpxQEPvMcSpd87NwUABDT6MbGPdEGR5VRiK4PPTJhQg==
 
 "@nicolo-ribaudo/eslint-scope-5-internals@5.1.1-v1":
   version "5.1.1-v1"
@@ -5044,25 +5044,25 @@ next-sitemap@4.2.3:
     fast-glob "^3.2.12"
     minimist "^1.2.8"
 
-next@15.5.15:
-  version "15.5.15"
-  resolved "https://registry.yarnpkg.com/next/-/next-15.5.15.tgz#b25a59a232bd992a83da045fa289ee803c23c836"
-  integrity sha512-VSqCrJwtLVGwAVE0Sb/yikrQfkwkZW9p+lL/J4+xe+G3ZA+QnWPqgcfH1tDUEuk9y+pthzzVFp4L/U8JerMfMQ==
+next@15.5.18:
+  version "15.5.18"
+  resolved "https://registry.yarnpkg.com/next/-/next-15.5.18.tgz#b0a9d82763f7358938fe4732bb6f605f7e941815"
+  integrity sha512-eKL8zUJkX9Y5lE+RX/2YJoItVdGlIscyVyboeD9wSpp0PaGqjoA4tTpT2qPqz9ax+5IzGESyLSeZ/RCwbSZ2uQ==
   dependencies:
-    "@next/env" "15.5.15"
+    "@next/env" "15.5.18"
     "@swc/helpers" "0.5.15"
     caniuse-lite "^1.0.30001579"
     postcss "8.4.31"
     styled-jsx "5.1.6"
   optionalDependencies:
-    "@next/swc-darwin-arm64" "15.5.15"
-    "@next/swc-darwin-x64" "15.5.15"
-    "@next/swc-linux-arm64-gnu" "15.5.15"
-    "@next/swc-linux-arm64-musl" "15.5.15"
-    "@next/swc-linux-x64-gnu" "15.5.15"
-    "@next/swc-linux-x64-musl" "15.5.15"
-    "@next/swc-win32-arm64-msvc" "15.5.15"
-    "@next/swc-win32-x64-msvc" "15.5.15"
+    "@next/swc-darwin-arm64" "15.5.18"
+    "@next/swc-darwin-x64" "15.5.18"
+    "@next/swc-linux-arm64-gnu" "15.5.18"
+    "@next/swc-linux-arm64-musl" "15.5.18"
+    "@next/swc-linux-x64-gnu" "15.5.18"
+    "@next/swc-linux-x64-musl" "15.5.18"
+    "@next/swc-win32-arm64-msvc" "15.5.18"
+    "@next/swc-win32-x64-msvc" "15.5.18"
     sharp "^0.34.3"
 
 node-fetch@^2.7.0:


### PR DESCRIPTION
## Summary
- Adds proper vertical rhythm to the blog post page: container padding (`py-8 md:py-10`), header image gap (`mb-12`), tighter title↔date pairing (`mb-3` / `mb-8`), and a clear break before the body.
- Updates the shared `markdownComponents` so paragraphs, lists, blockquotes, `pre`, and images have consistent bottom margin; headings get section-break top margin with `first:mt-0` so the first child sits flush. `h2` uses a larger `mt-12` for top-level section breaks; other headings keep `mt-8`/`mt-6`/`mt-4`.
- Switches `ul`/`ol` to `list-outside pl-6`; ordered lists use purple markers, unordered lists inherit the surrounding text color (no more purple bullets). Stray `<br/>` after `ul` removed.
- Bumps `h6` from `text-sm` to `text-base` so it's no smaller than body text, and gives all headings explicit `text-gray-900` so they stay dark when the wrapper has a lighter body color.
- Blog body typography set to `text-lg text-gray-700 leading-relaxed` for higher-contrast, comfortably-spaced reading.
- Markdown link color aligned with the rest of the site: `text-purple-700 hover:text-purple-800`.
- Adds `./styles/**/*.{js,jsx,ts,tsx}` to Tailwind's `content` globs so new variants used only in `styles/globals.tsx` are generated.

### Audit fix (bundled)
- Bumps `next` 15.5.15 → 15.5.18 to clear the 7 high-severity advisories the `Dependency audit` job was failing on (DoS, SSRF, middleware/proxy bypasses). Patch-level bump within 15.5.x; `yarn build` verified locally.
- One moderate remains (postcss <8.5.10), but it's pinned upstream by Next itself (`next` depends directly on `postcss "8.4.31"`). CI policy fails only on high/critical, so the audit job will now pass.

Shared changes (`styles/globals.tsx`) also affect the education article page, Trustee quote cards, and TimelinePage accordions — all use the same `markdownComponents`. `last:mb-0` is used throughout to keep compact-card uses tight.

## Test plan
- [ ] Visit a blog post — verify clear gaps between header image, title, date, and body; section headings (`##`) have a visible break above and tight binding to the content below.
- [ ] Check a blog post with bullet or numbered lists — multi-line items wrap under text (not under marker); ul bullets are neutral, ol numbers are purple.
- [ ] Check a blog post with an inline image — image has breathing room above and below.
- [ ] Click a link inside a post — purple-700 resting, purple-800 hover (matches site).
- [ ] Visit an education article (`/learn/education-articles/[id]`) — headings now darker (gray-900); body unchanged.
- [ ] Homepage Trustee quote cards still look correct (no extra trailing whitespace).
- [ ] Timeline accordion content (`/timeline`) still renders cleanly.
- [ ] CI `Dependency audit` job passes (no high/critical advisories).

🤖 Generated with [Claude Code](https://claude.com/claude-code)