### PR TITLE
fix(predict): guard against null question in polystrat metrics

### DIFF
--- a/common-util/api/predict/polystrat-roi.ts
+++ b/common-util/api/predict/polystrat-roi.ts
@@ -245,8 +245,13 @@ export const fetchPolystratRoi = async (): Promise<
       return hasNoResolution;
     });
 
-    // Get open market titles and sum totalPayout
-    const openMarketTitles = openMarketParticipants.map((p) => p.question.metadata.title);
+    // Get open market titles and sum totalPayout. Guard against participants
+    // whose `question` (or its metadata) is null — the subgraph started
+    // returning these ~2026-05, and an unguarded access throws and fails the
+    // whole ROI computation (manifesting as a frozen/stale ROI value).
+    const openMarketTitles = openMarketParticipants
+      .map((p) => p.question?.metadata?.title)
+      .filter((title): title is string => Boolean(title));
 
     let requestsToSubtract = 0;
     lastFourDaysRequests.forEach((request) => {

--- a/common-util/api/predict/tool-accuracy.ts
+++ b/common-util/api/predict/tool-accuracy.ts
@@ -225,8 +225,10 @@ async function fetchPolymarketResolvedBets(): Promise<PolymarketBet[]> {
     .filter(([key]) => key !== '_meta')
     .flatMap(([, value]) => value) as PolymarketBet[];
 
-  // Only keep resolved bets
-  return allBets.filter((bet) => bet.question.resolution !== null);
+  // Only keep resolved bets. Guard against bets whose `question` is null
+  // (the subgraph started returning these ~2026-05; an unguarded
+  // `bet.question.resolution` throws and the whole snapshot computation fails).
+  return allBets.filter((bet) => bet.question?.resolution != null);
 }
 
 async function fetchPolygonMechRequestsForSender(

--- a/common-util/api/predict/tool-accuracy.ts
+++ b/common-util/api/predict/tool-accuracy.ts
@@ -108,7 +108,9 @@ async function fetchMechRequestsForSender(
 }
 
 function matchBetToMechRequest(bet: Bet, mechRequests: MechRequest[]): string | null {
-  const betQuestion = normalizeQuestion(bet.fixedProductMarketMaker.question);
+  const fpmmQuestion = bet.fixedProductMarketMaker?.question;
+  if (!fpmmQuestion) return null;
+  const betQuestion = normalizeQuestion(fpmmQuestion);
   const betTimestamp = Number(bet.timestamp);
 
   // Find the latest mech request before the bet timestamp whose question matches
@@ -180,6 +182,9 @@ export async function computeOmenstratToolAccuracy(): Promise<ToolAccuracyStat[]
     if (mechRequests.length === 0) continue;
 
     for (const bet of bettorBets) {
+      // Guard against bets with a null `fixedProductMarketMaker` — same
+      // null-nested-entity hazard as the Polymarket `question` field.
+      if (!bet.fixedProductMarketMaker) continue;
       const currentAnswer = bet.fixedProductMarketMaker.currentAnswer;
       if (currentAnswer === INVALID_ANSWER_HEX) continue;
 


### PR DESCRIPTION
## Problem

On the Predict agent-economy page, the **Polystrat** *Tool Accuracy* table shows "No tool accuracy data available", and **Polystrat ROI** has been frozen since ~May 7. Omenstrat is not currently affected.

## Root cause

The Polymarket subgraph began returning `bets` and `marketParticipants` with **`question: null`** around **2026-05-06/07**. The code accessed `.question.*` without null-guarding, so it **threw**:

- `tool-accuracy.ts` — `bet.question.resolution !== null` throws on a null-`question` bet → `computePolystratToolAccuracy` rejects.
- `polystrat-roi.ts` — null-`question` participants pass the `hasNoResolution` filter, then `p.question.metadata.title` throws → `fetchPolystratRoi` rejects.

In both cases the surrounding `Promise.allSettled` **swallowed the rejection silently** (no logging), so the failure surfaced as empty/stale data rather than an error. The May 6-7 onset of null-`question` entities matches the ROI-freeze date exactly.

## Fix

- **tool-accuracy (polystrat):** `bet.question?.resolution != null` — drop null-`question` bets (they have no resolution anyway).
- **polystrat-roi:** guard open-market title extraction (`p.question?.metadata?.title`) and drop entries with no title.
- **tool-accuracy (omenstrat):** same null-nested-entity class — guard against a null `fixedProductMarketMaker` in `matchBetToMechRequest` and `computeOmenstratToolAccuracy` so the Omen side can't hit the same silent-blank trap. (Defensive; not currently firing.)

## Verification

Ran the real computation locally against the **production** subgraph URLs:

| | Polystrat tools |
|---|---|
| Before | **0** (reproduces prod) |
| After | **11** (superforcaster 55.8%, prediction-request-reasoning 59.5%, …) |

## Suggested follow-ups (not in this PR)

- **Stop swallowing errors silently:** log `result.reason` for rejected branches in `computeAllToolAccuracy` / `fetchAllPredictMetrics`. This defect was invisible for ~2 weeks because the rejections were discarded.
- **`predict-tool-accuracy` saves with `overwrite: true`**, bypassing `mergeWithFallback` — a single transient failure blanks the table instead of keeping the last good value. Worth reconsidering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)