### PR TITLE
fix(deps): bump qs, ws, flatted to clear Dependabot

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "next-sitemap": "4.2.3",
     "postcss": "8.5.10",
     "prop-types": "15.8.1",
-    "qs": "6.15.1",
+    "qs": "6.15.2",
     "react": "19.2.5",
     "react-chartjs-2": "5.3.0",
     "react-dom": "19.2.5",
@@ -74,12 +74,13 @@
     "prettier": "3.6.2"
   },
   "resolutions": {
-    "flatted": "3.3.4",
+    "flatted": "3.4.2",
     "mdast-util-to-hast": "13.2.1",
     "yaml": "2.8.3",
     "diff": "5.2.2",
     "postcss": "8.5.10",
-    "@babel/plugin-transform-modules-systemjs": "7.29.4"
+    "@babel/plugin-transform-modules-systemjs": "7.29.4",
+    "ws": "8.20.1"
   },
   "babel": {
     "presets": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -3422,10 +3422,10 @@ flat-cache@^3.0.4:
     keyv "^4.5.3"
     rimraf "^3.0.2"
 
-flatted@3.3.4, flatted@^3.2.9:
-  version "3.3.4"
-  resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.3.4.tgz#0986e681008f0f13f58e18656c47967682db5ff6"
-  integrity sha512-3+mMldrTAPdta5kjX2G2J7iX4zxtnwpdA8Tr2ZSjkyPSanvbZAcy6flmtnXbEybHrDcU9641lxrMfFuUxVz9vA==
+flatted@3.4.2, flatted@^3.2.9:
+  version "3.4.2"
+  resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.4.2.tgz#f5c23c107f0f37de8dbdf24f13722b3b98d52726"
+  integrity sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==
 
 for-each@^0.3.3, for-each@^0.3.5:
   version "0.3.5"
@@ -5523,10 +5523,10 @@ punycode@^2.1.0, punycode@^2.1.1, punycode@^2.3.1:
   resolved "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz"
   integrity sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==
 
-qs@6.15.1:
-  version "6.15.1"
-  resolved "https://registry.yarnpkg.com/qs/-/qs-6.15.1.tgz#bdb55aed06bfac257a90c44a446a73fba5575c8f"
-  integrity sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==
+qs@6.15.2:
+  version "6.15.2"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.15.2.tgz#fd55426d710403ddccc45e0f9eab16db7727ece9"
+  integrity sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==
   dependencies:
     side-channel "^1.1.0"
 
@@ -7050,10 +7050,10 @@ wrappy@1:
   resolved "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
   integrity sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==
 
-ws@^8.13.0, ws@^8.17.1:
-  version "8.18.3"
-  resolved "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz"
-  integrity sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==
+ws@8.20.1, ws@^8.13.0, ws@^8.17.1:
+  version "8.20.1"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.20.1.tgz#91a9ae2b312ccf98e0a85ec499b48cef45ab0ddb"
+  integrity sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==
 
 y18n@^5.0.5:
   version "5.0.8"


### PR DESCRIPTION
Closes the three open Dependabot alerts via targeted version bumps.

| Severity | Package | Scope | Bump | GHSA |
|---|---|---|---|---|
| High | `flatted` | dev | `3.3.4` → `3.4.2` (resolution pin) | [GHSA-rf6f-7fwh-wjgh](https://github.com/advisories/GHSA-rf6f-7fwh-wjgh) |
| Medium | `qs` | runtime | `6.15.1` → `6.15.2` (direct dep) | [GHSA-q8mj-m7cp-5q26](https://github.com/advisories/GHSA-q8mj-m7cp-5q26) |
| Medium | `ws` | runtime | `8.18.3` → `8.20.1` (new resolution; transitive) | [GHSA-58qx-3vcg-4xpx](https://github.com/advisories/GHSA-58qx-3vcg-4xpx) |

All three are minimal version bumps (patch or single-minor) of well-known libraries — risk is low.

## Verification (Node 22, local)
- `yarn install` → only `qs`/`ws`/`flatted` move in `yarn.lock` (24 lines, scoped)
- `yarn why` confirms a single version of each (no vulnerable copies left)
- `yarn lint`, `yarn build`, `yarn audit:prod`, `yarn audit:install-hooks` all pass

Dependabot will close the three alerts automatically on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)