### PR TITLE
fix: update external links for creator.bid, nevermined, and AIP-5

### DIFF
--- a/components/BuildPage/WhatBuildersAreSaying.tsx
+++ b/components/BuildPage/WhatBuildersAreSaying.tsx
@@ -39,7 +39,7 @@ const quotes = [
   },
   {
     projectImage: 'creator-bid.png',
-    projectUrl: 'https://creator.bid/',
+    projectUrl: 'https://og.creator.bid/agents',
     quote:
       "We're building Creator.bid on the cutting-edge Olas Stack to be one the first Olas-powered project en-route to deliver no-code ACA (AI Creator Agents) at scale. The Olas Stack has proven to be a fantastic choice for us to run our agents in a decentralized fashion with off-chain consensus at scale.",
     name: 'Philipp Kothe',
@@ -60,7 +60,7 @@ const quotes = [
   },
   {
     projectImage: 'nevermined.png',
-    projectUrl: 'https://nevermined.io/',
+    projectUrl: 'https://nevermined.ai/',
     quote:
       'We are building on Olas to allow AI agents to get paid across the different networks that agents are deployed to. Nevermined will work to bring Olas AI agents to life through R&D and mutual integrations. The Olas Stack enables all agents to be interoperable and composable with one another so that our payment mechanism can work seamlessly.',
     name: 'Don Gossen',

--- a/components/HomepageSection/Activity.tsx
+++ b/components/HomepageSection/Activity.tsx
@@ -116,7 +116,7 @@ const OlasIsBurnedArrow = ({ pointsDown = false, className = '' }: OlasIsBurnedA
         Fees collected can be turned on or off by the Governors of the Olas Protocol. Currently,
         fees are turned off to encourage early adoption and growth of the marketplace.
         <ExternalLink
-          href={`${VALORY_GIT_URL}/autonolas-aip/blob/aip-5/content/aips/automate_relayer_marketplace.md`}
+          href={`${VALORY_GIT_URL}/autonolas-aip/blob/main/content/aips/aip-5/automate_relayer_marketplace.md`}
           className="mt-2 cursor-pointer"
         >
           More about Mech Marketplace fees in AIP-5


### PR DESCRIPTION
## Summary

Updates three outdated external links surfaced on the marketing site.

| Link | File | Change |
|------|------|--------|
| Creator.bid | `components/BuildPage/WhatBuildersAreSaying.tsx` | `https://creator.bid/` → `https://og.creator.bid/agents` |
| Nevermined | `components/BuildPage/WhatBuildersAreSaying.tsx` | `https://nevermined.io/` → `https://nevermined.ai/` |
| AIP-5 doc | `components/HomepageSection/Activity.tsx` | `…/blob/aip-5/content/aips/automate_relayer_marketplace.md` → `…/blob/main/content/aips/aip-5/automate_relayer_marketplace.md` |

Note: the Mode explorer link in `data/tokens.json` already points to `https://explorer.mode.network/`, so no change was needed there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)