### PR TITLE
feat(predict): (BDMARK-2173) add Brier score to Omenstrat performance card

### DIFF
--- a/common-util/api/predict/index.ts
+++ b/common-util/api/predict/index.ts
@@ -17,6 +17,7 @@ import {
 import { MetricWithStatus, WithMeta } from 'common-util/graphql/types';
 import { getMaxApr } from 'common-util/olasApr';
 import { getMidnightUtcTimestampDaysAgo } from 'common-util/time';
+import { fetchOmenstratBrier, WindowedMetric } from './omenstrat-brier';
 import { fetchOmenstratRoi } from './omenstrat-roi';
 import { fetchOmenstratSuccessRate } from './omenstrat-success-rate';
 import { fetchPolystratRoi } from './polystrat-roi';
@@ -211,6 +212,8 @@ const fetchPolystratOlasApr = async (): Promise<MetricWithStatus<string | null>>
   });
 };
 
+export type { WindowKey, WindowedMetric } from './omenstrat-brier';
+
 export type PredictMetricsData = {
   // Omenstrat metrics
   omenstrat: {
@@ -220,6 +223,8 @@ export type PredictMetricsData = {
     partialRoi: MetricWithStatus<number | null>;
     finalRoi: MetricWithStatus<number | null>;
     successRate: MetricWithStatus<string | null>;
+    // Windowed mean Brier score (predict-omen only). Lower is better; ~0.25 = a 50/50 guess.
+    brierScore: MetricWithStatus<WindowedMetric<number | null>>;
   };
 
   // Polystrat metrics
@@ -246,6 +251,7 @@ export const fetchAllPredictMetrics = async (): Promise<PredictMetricsSnapshot |
       omenstratTxsResult,
       omenstratRoiResult,
       omenstratSuccessRateResult,
+      omenstratBrierResult,
       polystratAprResult,
       polystratTxsResult,
       polystratRoiResult,
@@ -258,6 +264,7 @@ export const fetchAllPredictMetrics = async (): Promise<PredictMetricsSnapshot |
       fetchPredictTxsByAgentType(),
       fetchOmenstratRoi(),
       fetchOmenstratSuccessRate(),
+      fetchOmenstratBrier(),
       // Polystrat
       fetchPolystratOlasApr(),
       fetchPolystratTxsByAgentType(),
@@ -309,6 +316,13 @@ export const fetchAllPredictMetrics = async (): Promise<PredictMetricsSnapshot |
           omenstratSuccessRateResult.status === 'fulfilled'
             ? omenstratSuccessRateResult.value
             : { value: null, status: getFetchErrorAndCreateStaleStatus('omenstrat:successRate') },
+        brierScore:
+          omenstratBrierResult.status === 'fulfilled'
+            ? omenstratBrierResult.value
+            : {
+                value: { '7d': null, '30d': null, '90d': null, max: null },
+                status: getFetchErrorAndCreateStaleStatus('omenstrat:brier'),
+              },
       },
 
       polystrat: {

--- a/common-util/api/predict/index.ts
+++ b/common-util/api/predict/index.ts
@@ -17,7 +17,7 @@ import {
 import { MetricWithStatus, WithMeta } from 'common-util/graphql/types';
 import { getMaxApr } from 'common-util/olasApr';
 import { getMidnightUtcTimestampDaysAgo } from 'common-util/time';
-import { fetchOmenstratBrier, WindowedMetric } from './omenstrat-brier';
+import { emptyWindows, fetchOmenstratBrier, WindowedMetric } from './omenstrat-brier';
 import { fetchOmenstratRoi } from './omenstrat-roi';
 import { fetchOmenstratSuccessRate } from './omenstrat-success-rate';
 import { fetchPolystratRoi } from './polystrat-roi';
@@ -320,7 +320,7 @@ export const fetchAllPredictMetrics = async (): Promise<PredictMetricsSnapshot |
           omenstratBrierResult.status === 'fulfilled'
             ? omenstratBrierResult.value
             : {
-                value: { '7d': null, '30d': null, '90d': null, max: null },
+                value: emptyWindows(),
                 status: getFetchErrorAndCreateStaleStatus('omenstrat:brier'),
               },
       },

--- a/common-util/api/predict/omenstrat-brier.ts
+++ b/common-util/api/predict/omenstrat-brier.ts
@@ -6,37 +6,102 @@ import {
 } from 'common-util/graphql/metric-utils';
 import { getOmenDailyBrierStatsQuery } from 'common-util/graphql/queries';
 import { MetricWithStatus, WithMeta } from 'common-util/graphql/types';
+import { getSnapshot, saveSnapshot } from 'common-util/snapshot-storage';
 import { getMidnightUtcTimestampDaysAgo } from 'common-util/time';
 
 export type WindowKey = '7d' | '30d' | '90d' | 'max';
 export type WindowedMetric<T> = Record<WindowKey, T>;
 
 const LIMIT = 1000;
+const DAY = 86400;
 const BRIER_SCALE = 10n ** 18n; // brierSum is 1e18-scaled (see predict-omen schema)
 
-type DailyBrierStat = {
-  date: string;
-  brierSum: string;
-  brierCount: number;
+// UTC-midnight genesis day of the predict-omen subgraph (mirrors OMEN_GENESIS_TS
+// in roi-distribution.ts). Backfill walks down to here, no further.
+const OMEN_GENESIS_DAY = 1763769600;
+
+// Days reprocessed at the head of the window every run. Captures newly-completed
+// days plus late re-answers (the subgraph moves Brier onto the new settlement day
+// on a re-answer; overwriting these buckets keeps the all-time sum correct).
+const TRAIL_DAYS = 10;
+// One-time historical backfill step per run, walking from the head toward genesis.
+const BACKFILL_CHUNK_DAYS = 30;
+
+// Self-contained incremental accumulator persisted in its own blob. The hourly
+// predict refresh advances it a little each run instead of rescanning all of
+// history (60k+ daily rows and growing) on every call.
+const ACCUMULATOR_CATEGORY = 'predict-brier/omenstrat';
+
+type DailyBrierStat = { date: string; brierSum: string; brierCount: number };
+type DailyBrierStatsResponse = WithMeta<{ dailyProfitStatistics: DailyBrierStat[] }>;
+
+// JSON-safe bucket: BigInt sum stored as a decimal string.
+type BrierBucket = { sum: string; count: number };
+type BrierAccumulator = {
+  // dayTimestamp (UTC midnight, string) -> settlement-day Brier accumulators,
+  // summed across all trader agents. Contiguous over [backfilledTo, yesterday].
+  buckets: Record<string, BrierBucket>;
+  // Oldest day processed so far. Window N is "covered" once backfilledTo <= its
+  // cutoff; Max is covered once backfilledTo <= OMEN_GENESIS_DAY.
+  backfilledTo: number;
 };
 
-type DailyBrierStatsResponse = WithMeta<{
-  dailyProfitStatistics: DailyBrierStat[];
-}>;
-
-const emptyWindows = (): WindowedMetric<number | null> => ({
+export const emptyWindows = (): WindowedMetric<number | null> => ({
   '7d': null,
   '30d': null,
   '90d': null,
   max: null,
 });
 
-// meanBrier = sum(brierSum) / sum(brierCount). Both are 1e18-scaled and summable
-// across days; dividing the BigInt sum by count and de-scaling yields a [0, 1] value.
-// Keep 4 decimals of precision before downcasting to a JS number.
-const computeMeanBrier = (sum: bigint, count: number): number | null => {
-  if (count === 0) return null;
-  return Number((sum * 10000n) / BigInt(count) / BRIER_SCALE) / 10000;
+// meanBrier = sum(brierSum) / sum(brierCount), 1e18-scaled -> [0, 1]. Keep 4
+// decimals of precision before downcasting to a JS number.
+const meanBrier = (sum: bigint, count: number): number | null =>
+  count === 0 ? null : Number((sum * 10000n) / BigInt(count) / BRIER_SCALE) / 10000;
+
+// Fetch and group dailyProfitStatistics in [startDay, endDay] by settlement day,
+// summing brierSum/brierCount across all agents. Bounded by the day range, so it
+// never grows unboundedly. Mutates indexingErrors/laggingSubgraphs as a side effect.
+const fetchDayBuckets = async (
+  startDay: number,
+  endDay: number,
+  gnosisBlock: number | null,
+  indexingErrors: string[],
+  laggingSubgraphs: string[]
+): Promise<Map<number, { sum: bigint; count: number }>> => {
+  const perDay = new Map<number, { sum: bigint; count: number }>();
+  if (startDay > endDay) return perDay;
+
+  let skip = 0;
+  let metaChecked = false;
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    const response = (await predictAgentsGraphClient.request(
+      getOmenDailyBrierStatsQuery({ date_gte: startDay, date_lte: endDay, first: LIMIT, skip })
+    )) as DailyBrierStatsResponse;
+
+    if (!metaChecked) {
+      if (response?._meta?.hasIndexingErrors) indexingErrors.push('predict:gnosis');
+      if (gnosisBlock && checkSubgraphLag(gnosisBlock, response?._meta?.block?.number, 'gnosis')) {
+        laggingSubgraphs.push('predict:gnosis');
+      }
+      metaChecked = true;
+    }
+
+    const rows = response?.dailyProfitStatistics || [];
+    for (const row of rows) {
+      const count = Number(row.brierCount || 0);
+      if (count === 0) continue;
+      const day = Number(row.date);
+      const cur = perDay.get(day) || { sum: 0n, count: 0 };
+      cur.sum += BigInt(row.brierSum || 0);
+      cur.count += count;
+      perDay.set(day, cur);
+    }
+
+    if (rows.length < LIMIT) break;
+    skip += LIMIT;
+  }
+  return perDay;
 };
 
 export const fetchOmenstratBrier = async (): Promise<
@@ -46,79 +111,100 @@ export const fetchOmenstratBrier = async (): Promise<
   const fetchErrors: string[] = [];
   const laggingSubgraphs: string[] = [];
 
-  try {
-    const cutoff7d = getMidnightUtcTimestampDaysAgo(7);
-    const cutoff30d = getMidnightUtcTimestampDaysAgo(30);
-    const cutoff90d = getMidnightUtcTimestampDaysAgo(90);
+  // Only complete days are settled; today is excluded so windows mean "last N
+  // full days" (consistent with roi-distribution's window convention).
+  const yesterday = getMidnightUtcTimestampDaysAgo(1);
 
+  let existing: BrierAccumulator | null = null;
+  try {
+    const snapshot = await getSnapshot({ category: ACCUMULATOR_CATEGORY });
+    existing = (snapshot?.data as unknown as BrierAccumulator) ?? null;
+  } catch (e) {
+    console.warn('Could not load Brier accumulator; rebuilding from scratch', e);
+  }
+
+  try {
     const gnosisBlock = await getChainBlockNumber('gnosis');
 
-    // Accumulate one pass over every settlement day; derive sub-windows by cutoff.
-    const buckets: WindowedMetric<{ sum: bigint; count: number }> = {
-      '7d': { sum: 0n, count: 0 },
-      '30d': { sum: 0n, count: 0 },
-      '90d': { sum: 0n, count: 0 },
-      max: { sum: 0n, count: 0 },
+    const buckets: Record<string, BrierBucket> = { ...(existing?.buckets ?? {}) };
+    // Sentinel for a fresh accumulator: nothing processed yet (just above the head).
+    let backfilledTo = existing?.backfilledTo ?? yesterday + DAY;
+
+    const applyBuckets = (perDay: Map<number, { sum: bigint; count: number }>) => {
+      for (const [day, { sum, count }] of perDay.entries()) {
+        buckets[String(day)] = { sum: sum.toString(), count };
+      }
     };
 
-    let skip = 0;
-    let metaChecked = false;
+    // 1. Head refresh: reprocess the trailing window (new complete days + re-answers).
+    const trailStart = Math.max(OMEN_GENESIS_DAY, yesterday - (TRAIL_DAYS - 1) * DAY);
+    applyBuckets(
+      await fetchDayBuckets(trailStart, yesterday, gnosisBlock, indexingErrors, laggingSubgraphs)
+    );
+    backfilledTo = Math.min(backfilledTo, trailStart);
 
-    // eslint-disable-next-line no-constant-condition
-    while (true) {
-      const response = (await predictAgentsGraphClient.request(
-        getOmenDailyBrierStatsQuery({ date_gte: 0, date_lte: getMidnightUtcTimestampDaysAgo(0), first: LIMIT, skip })
-      )) as DailyBrierStatsResponse;
-
-      if (!metaChecked) {
-        if (response?._meta?.hasIndexingErrors) {
-          indexingErrors.push('predict:gnosis');
-        }
-        if (gnosisBlock && checkSubgraphLag(gnosisBlock, response?._meta?.block?.number, 'gnosis')) {
-          laggingSubgraphs.push('predict:gnosis');
-        }
-        metaChecked = true;
-      }
-
-      const rows = response?.dailyProfitStatistics || [];
-
-      rows.forEach((row) => {
-        const date = Number(row.date);
-        const sum = BigInt(row.brierSum || 0);
-        const count = Number(row.brierCount || 0);
-        if (count === 0) return;
-
-        buckets.max.sum += sum;
-        buckets.max.count += count;
-        if (date >= cutoff90d) {
-          buckets['90d'].sum += sum;
-          buckets['90d'].count += count;
-        }
-        if (date >= cutoff30d) {
-          buckets['30d'].sum += sum;
-          buckets['30d'].count += count;
-        }
-        if (date >= cutoff7d) {
-          buckets['7d'].sum += sum;
-          buckets['7d'].count += count;
-        }
-      });
-
-      if (rows.length < LIMIT) break;
-      skip += LIMIT;
+    // 2. Historical backfill: extend the covered range one chunk toward genesis.
+    if (backfilledTo > OMEN_GENESIS_DAY) {
+      const hi = backfilledTo - DAY;
+      const lo = Math.max(OMEN_GENESIS_DAY, backfilledTo - BACKFILL_CHUNK_DAYS * DAY);
+      applyBuckets(await fetchDayBuckets(lo, hi, gnosisBlock, indexingErrors, laggingSubgraphs));
+      backfilledTo = lo;
     }
+
+    // Sum stored buckets whose day falls in [fromDay, toDay].
+    const rangeSum = (fromDay: number, toDay: number) => {
+      let sum = 0n;
+      let count = 0;
+      for (const [k, v] of Object.entries(buckets)) {
+        const day = Number(k);
+        if (day >= fromDay && day <= toDay) {
+          sum += BigInt(v.sum);
+          count += v.count;
+        }
+      }
+      return { sum, count };
+    };
+
+    // A window is only published once its full range is covered; otherwise null
+    // (so mergeWithFallback keeps the previous value rather than an understated one).
+    const windowValue = (days: number): number | null => {
+      const cutoff = yesterday - (days - 1) * DAY;
+      if (backfilledTo > cutoff) return null;
+      const { sum, count } = rangeSum(cutoff, yesterday);
+      return meanBrier(sum, count);
+    };
+
+    const fullyBackfilled = backfilledTo <= OMEN_GENESIS_DAY;
+    const maxValue = (() => {
+      if (!fullyBackfilled) return null;
+      const { sum, count } = rangeSum(0, yesterday);
+      return meanBrier(sum, count);
+    })();
+
+    // Persist the advanced accumulator (overwrite — this is authoritative state,
+    // not a metric that benefits from mergeWithFallback).
+    await saveSnapshot({
+      category: ACCUMULATOR_CATEGORY,
+      data: { data: { buckets, backfilledTo } as BrierAccumulator, timestamp: Date.now() },
+      overwrite: true,
+    });
+
+    // While still backfilling, flag stale so the parent snapshot's mergeWithFallback
+    // serves the last fully-computed value during the one-time catch-up after deploy.
+    if (!fullyBackfilled) fetchErrors.push('omenstrat:brier:backfilling');
 
     return {
       value: {
-        '7d': computeMeanBrier(buckets['7d'].sum, buckets['7d'].count),
-        '30d': computeMeanBrier(buckets['30d'].sum, buckets['30d'].count),
-        '90d': computeMeanBrier(buckets['90d'].sum, buckets['90d'].count),
-        max: computeMeanBrier(buckets.max.sum, buckets.max.count),
+        '7d': windowValue(7),
+        '30d': windowValue(30),
+        '90d': windowValue(90),
+        max: maxValue,
       },
       status: createStaleStatus({ indexingErrors, fetchErrors, laggingSubgraphs }),
     };
   } catch (error) {
     console.error('Error fetching Omenstrat Brier score:', error);
+    // Don't persist a partial advance; return stale so the previous value is kept.
     fetchErrors.push('predict:gnosis:brier');
     return {
       value: emptyWindows(),

--- a/common-util/api/predict/omenstrat-brier.ts
+++ b/common-util/api/predict/omenstrat-brier.ts
@@ -1,0 +1,128 @@
+import { predictAgentsGraphClient } from 'common-util/graphql/client';
+import {
+  checkSubgraphLag,
+  createStaleStatus,
+  getChainBlockNumber,
+} from 'common-util/graphql/metric-utils';
+import { getOmenDailyBrierStatsQuery } from 'common-util/graphql/queries';
+import { MetricWithStatus, WithMeta } from 'common-util/graphql/types';
+import { getMidnightUtcTimestampDaysAgo } from 'common-util/time';
+
+export type WindowKey = '7d' | '30d' | '90d' | 'max';
+export type WindowedMetric<T> = Record<WindowKey, T>;
+
+const LIMIT = 1000;
+const BRIER_SCALE = 10n ** 18n; // brierSum is 1e18-scaled (see predict-omen schema)
+
+type DailyBrierStat = {
+  date: string;
+  brierSum: string;
+  brierCount: number;
+};
+
+type DailyBrierStatsResponse = WithMeta<{
+  dailyProfitStatistics: DailyBrierStat[];
+}>;
+
+const emptyWindows = (): WindowedMetric<number | null> => ({
+  '7d': null,
+  '30d': null,
+  '90d': null,
+  max: null,
+});
+
+// meanBrier = sum(brierSum) / sum(brierCount). Both are 1e18-scaled and summable
+// across days; dividing the BigInt sum by count and de-scaling yields a [0, 1] value.
+// Keep 4 decimals of precision before downcasting to a JS number.
+const computeMeanBrier = (sum: bigint, count: number): number | null => {
+  if (count === 0) return null;
+  return Number((sum * 10000n) / BigInt(count) / BRIER_SCALE) / 10000;
+};
+
+export const fetchOmenstratBrier = async (): Promise<
+  MetricWithStatus<WindowedMetric<number | null>>
+> => {
+  const indexingErrors: string[] = [];
+  const fetchErrors: string[] = [];
+  const laggingSubgraphs: string[] = [];
+
+  try {
+    const cutoff7d = getMidnightUtcTimestampDaysAgo(7);
+    const cutoff30d = getMidnightUtcTimestampDaysAgo(30);
+    const cutoff90d = getMidnightUtcTimestampDaysAgo(90);
+
+    const gnosisBlock = await getChainBlockNumber('gnosis');
+
+    // Accumulate one pass over every settlement day; derive sub-windows by cutoff.
+    const buckets: WindowedMetric<{ sum: bigint; count: number }> = {
+      '7d': { sum: 0n, count: 0 },
+      '30d': { sum: 0n, count: 0 },
+      '90d': { sum: 0n, count: 0 },
+      max: { sum: 0n, count: 0 },
+    };
+
+    let skip = 0;
+    let metaChecked = false;
+
+    // eslint-disable-next-line no-constant-condition
+    while (true) {
+      const response = (await predictAgentsGraphClient.request(
+        getOmenDailyBrierStatsQuery({ date_gte: 0, date_lte: getMidnightUtcTimestampDaysAgo(0), first: LIMIT, skip })
+      )) as DailyBrierStatsResponse;
+
+      if (!metaChecked) {
+        if (response?._meta?.hasIndexingErrors) {
+          indexingErrors.push('predict:gnosis');
+        }
+        if (gnosisBlock && checkSubgraphLag(gnosisBlock, response?._meta?.block?.number, 'gnosis')) {
+          laggingSubgraphs.push('predict:gnosis');
+        }
+        metaChecked = true;
+      }
+
+      const rows = response?.dailyProfitStatistics || [];
+
+      rows.forEach((row) => {
+        const date = Number(row.date);
+        const sum = BigInt(row.brierSum || 0);
+        const count = Number(row.brierCount || 0);
+        if (count === 0) return;
+
+        buckets.max.sum += sum;
+        buckets.max.count += count;
+        if (date >= cutoff90d) {
+          buckets['90d'].sum += sum;
+          buckets['90d'].count += count;
+        }
+        if (date >= cutoff30d) {
+          buckets['30d'].sum += sum;
+          buckets['30d'].count += count;
+        }
+        if (date >= cutoff7d) {
+          buckets['7d'].sum += sum;
+          buckets['7d'].count += count;
+        }
+      });
+
+      if (rows.length < LIMIT) break;
+      skip += LIMIT;
+    }
+
+    return {
+      value: {
+        '7d': computeMeanBrier(buckets['7d'].sum, buckets['7d'].count),
+        '30d': computeMeanBrier(buckets['30d'].sum, buckets['30d'].count),
+        '90d': computeMeanBrier(buckets['90d'].sum, buckets['90d'].count),
+        max: computeMeanBrier(buckets.max.sum, buckets.max.count),
+      },
+      status: createStaleStatus({ indexingErrors, fetchErrors, laggingSubgraphs }),
+    };
+  } catch (error) {
+    console.error('Error fetching Omenstrat Brier score:', error);
+    fetchErrors.push('predict:gnosis:brier');
+    return {
+      value: emptyWindows(),
+      status: createStaleStatus({ indexingErrors, fetchErrors, laggingSubgraphs }),
+    };
+  }
+};

--- a/common-util/api/predict/omenstrat-brier.ts
+++ b/common-util/api/predict/omenstrat-brier.ts
@@ -39,11 +39,14 @@ type DailyBrierStatsResponse = WithMeta<{ dailyProfitStatistics: DailyBrierStat[
 type BrierBucket = { sum: string; count: number };
 type BrierAccumulator = {
   // dayTimestamp (UTC midnight, string) -> settlement-day Brier accumulators,
-  // summed across all trader agents. Contiguous over [backfilledTo, yesterday].
+  // summed across all trader agents. Contiguous over [backfilledTo, coveredTo].
   buckets: Record<string, BrierBucket>;
   // Oldest day processed so far. Window N is "covered" once backfilledTo <= its
   // cutoff; Max is covered once backfilledTo <= OMEN_GENESIS_DAY.
   backfilledTo: number;
+  // Newest day processed so far. Lets the head refresh bridge any gap (e.g. a
+  // cron outage longer than the trailing window) instead of silently skipping days.
+  coveredTo: number;
 };
 
 export const emptyWindows = (): WindowedMetric<number | null> => ({
@@ -129,6 +132,9 @@ export const fetchOmenstratBrier = async (): Promise<
     const buckets: Record<string, BrierBucket> = { ...(existing?.buckets ?? {}) };
     // Sentinel for a fresh accumulator: nothing processed yet (just above the head).
     let backfilledTo = existing?.backfilledTo ?? yesterday + DAY;
+    // Treat a fresh accumulator as "caught up to yesterday" so the head refresh is
+    // just the trailing window and history is filled by the backward backfill.
+    const prevCoveredTo = existing?.coveredTo ?? yesterday;
 
     const applyBuckets = (perDay: Map<number, { sum: bigint; count: number }>) => {
       for (const [day, { sum, count }] of perDay.entries()) {
@@ -136,12 +142,18 @@ export const fetchOmenstratBrier = async (): Promise<
       }
     };
 
-    // 1. Head refresh: reprocess the trailing window (new complete days + re-answers).
-    const trailStart = Math.max(OMEN_GENESIS_DAY, yesterday - (TRAIL_DAYS - 1) * DAY);
-    applyBuckets(
-      await fetchDayBuckets(trailStart, yesterday, gnosisBlock, indexingErrors, laggingSubgraphs)
+    // 1. Head refresh up to yesterday. Normally this is just the trailing window
+    //    (new complete days + late re-answers). If a cron outage left coveredTo
+    //    well below yesterday, headStart drops to bridge the gap — no missed days.
+    const trailStart = yesterday - (TRAIL_DAYS - 1) * DAY;
+    const headStart = Math.max(
+      OMEN_GENESIS_DAY,
+      Math.min(trailStart, prevCoveredTo - (TRAIL_DAYS - 1) * DAY)
     );
-    backfilledTo = Math.min(backfilledTo, trailStart);
+    applyBuckets(
+      await fetchDayBuckets(headStart, yesterday, gnosisBlock, indexingErrors, laggingSubgraphs)
+    );
+    backfilledTo = Math.min(backfilledTo, headStart);
 
     // 2. Historical backfill: extend the covered range one chunk toward genesis.
     if (backfilledTo > OMEN_GENESIS_DAY) {
@@ -185,7 +197,10 @@ export const fetchOmenstratBrier = async (): Promise<
     // not a metric that benefits from mergeWithFallback).
     await saveSnapshot({
       category: ACCUMULATOR_CATEGORY,
-      data: { data: { buckets, backfilledTo } as BrierAccumulator, timestamp: Date.now() },
+      data: {
+        data: { buckets, backfilledTo, coveredTo: yesterday } as BrierAccumulator,
+        timestamp: Date.now(),
+      },
       overwrite: true,
     });
 

--- a/common-util/graphql/queries.ts
+++ b/common-util/graphql/queries.ts
@@ -553,6 +553,31 @@ export const getOmenDailyProfitStatsQuery = ({ date_gte, date_lte, first, skip }
   }
 `;
 
+// Lean per-day Brier accumulators for windowed Brier-score aggregation.
+// brierSum/brierCount are 1e18-scaled and summable across days; windowed mean
+// Brier = sum(brierSum) / sum(brierCount). No traderAgent filter → platform-wide.
+export const getOmenDailyBrierStatsQuery = ({ date_gte, date_lte, first, skip }) => gql`
+  query OmenDailyBrierStats {
+    dailyProfitStatistics(
+      first: ${first}
+      skip: ${skip}
+      where: { date_gte: ${date_gte}, date_lte: ${date_lte} }
+      orderBy: date
+      orderDirection: asc
+    ) {
+      date
+      brierSum
+      brierCount
+    }
+    _meta {
+      hasIndexingErrors
+      block {
+        number
+      }
+    }
+  }
+`;
+
 export const getPolymarketDailyProfitStatsQuery = ({ date_gte, date_lte, first, skip }) => gql`
   query PolymarketDailyProfitStats {
     dailyProfitStatistics(

--- a/components/AgentEconomies/PredictPage/Activity.tsx
+++ b/components/AgentEconomies/PredictPage/Activity.tsx
@@ -39,6 +39,8 @@ const processPredictMetrics = (
         roiStatus: undefined,
         successRate: null,
         successRateStatus: undefined,
+        brierScore: null,
+        brierStatus: undefined,
       },
       polystrat: {
         dailyActiveAgents: null,
@@ -77,6 +79,8 @@ const processPredictMetrics = (
       roiStatus: metrics.omenstrat?.finalRoi?.status,
       successRate: metrics.omenstrat?.successRate?.value ?? null,
       successRateStatus: metrics.omenstrat?.successRate?.status,
+      brierScore: metrics.omenstrat?.brierScore?.value ?? null,
+      brierStatus: metrics.omenstrat?.brierScore?.status,
     },
     polystrat: {
       dailyActiveAgents: metrics.polystrat?.dailyActiveAgents?.value ?? null,

--- a/components/AgentEconomies/PredictPage/PlatformActivitySection.tsx
+++ b/components/AgentEconomies/PredictPage/PlatformActivitySection.tsx
@@ -216,12 +216,14 @@ export const PlatformActivitySection = ({
     status: m.brierStatus,
   };
 
-  // Omenstrat replaces OLAS Staking APR with the windowed Brier score; Polystrat
-  // keeps APR until predict-polymarket ships Brier data.
-  const performanceItems: MetricItemProps[] =
-    platform === 'omenstrat'
-      ? [roiItem, accuracyItem, brierItem]
-      : [roiItem, aprItem, accuracyItem];
+  // Both economies show ROI / APR / Accuracy. Brier score is an additional 4th
+  // metric on Omenstrat only (predict-polymarket doesn't index Brier yet).
+  const performanceItems: MetricItemProps[] = [
+    roiItem,
+    aprItem,
+    accuracyItem,
+    ...(platform === 'omenstrat' ? [brierItem] : []),
+  ];
 
   const lifetimeItems: MetricItemProps[] = [
     {

--- a/components/AgentEconomies/PredictPage/PlatformActivitySection.tsx
+++ b/components/AgentEconomies/PredictPage/PlatformActivitySection.tsx
@@ -10,9 +10,10 @@ import {
 } from 'components/ui/StaleIndicator';
 import { Tabs } from 'components/ui/tabs';
 import { Link } from 'components/ui/typography';
+import type { WindowedMetric, WindowKey } from 'common-util/api/predict';
 import { isNil } from 'lodash';
 import Image from 'next/image';
-import { ReactNode } from 'react';
+import { ReactNode, useState } from 'react';
 
 export type Platform = 'polystrat' | 'omenstrat';
 
@@ -30,6 +31,9 @@ export type PlatformMetrics = {
   mechTxs: number | null;
   marketCreatorTxs?: number | null;
   txsStatus: MetricStatus;
+  // Windowed mean Brier score (Omenstrat only today). Lower is better.
+  brierScore?: WindowedMetric<number | null> | null;
+  brierStatus?: MetricStatus;
 };
 
 type PlatformActivitySectionProps = {
@@ -52,12 +56,21 @@ const PLATFORM_TABS: Array<{ key: Platform; label: string; icon: string }> = [
   },
 ];
 
-const TIME_RANGE_TABS = [
-  { key: '7d', label: '7D', disabled: true, tooltip: 'Coming soon' },
-  { key: '30d', label: '30D', disabled: true, tooltip: 'Coming soon' },
-  { key: '90d', label: '90D', disabled: true, tooltip: 'Coming soon' },
+const TIME_RANGE_KEYS: { key: WindowKey; label: string }[] = [
+  { key: '7d', label: '7D' },
+  { key: '30d', label: '30D' },
+  { key: '90d', label: '90D' },
   { key: 'max', label: 'Max' },
 ];
+
+// Only Omenstrat exposes a windowed metric (Brier score) today. On Polystrat the
+// tabs stay disabled until predict-polymarket ships per-window data.
+const getTimeRangeTabs = (windowed: boolean) =>
+  TIME_RANGE_KEYS.map(({ key, label }) =>
+    windowed || key === 'max'
+      ? { key, label }
+      : { key, label, disabled: true, tooltip: 'Coming soon' }
+  );
 
 type MetricItemProps = {
   label: ReactNode;
@@ -126,60 +139,89 @@ export const PlatformActivitySection = ({
   onPlatformChange,
   className,
 }: PlatformActivitySectionProps) => {
-  // Time-range tabs are placeholder UI for upcoming work — only "Max" is
-  // selectable today, so the active key is hardcoded and onChange is a no-op.
   const m = metrics[platform];
 
-  const performanceItems: MetricItemProps[] = [
-    {
-      label: (
-        <span className="flex items-center gap-2">
-          Total ROI - Average{' '}
-          {!isNil(m.partialRoi) && (
-            <Popover>
-              <div className="flex flex-col max-w-[320px] gap-4 text-base">
-                <p className="text-gray-500">
-                  Total ROI shows your agent&apos;s overall earnings, including profits from
-                  predictions and staking rewards, minus all related costs.
-                </p>
-                <p className="text-gray-500">
-                  Partial ROI reflects only prediction performance, excluding staking rewards.
-                </p>
-                <div className="flex justify-between">
-                  <span className="text-gray-900">Partial ROI</span>
-                  <span className={m.roiStatus?.stale ? 'text-gray-400' : ''}>
-                    {`${m.partialRoi}%`}
-                  </span>
-                </div>
-                <div className="text-sm">
-                  <StaleMetricContent status={m.roiStatus} />
-                </div>
+  // Brier score is the only windowed metric today, and it exists for Omenstrat only.
+  const isWindowed = platform === 'omenstrat' && !isNil(m.brierScore);
+  const [activeWindow, setActiveWindow] = useState<WindowKey>('max');
+
+  const roiItem: MetricItemProps = {
+    label: (
+      <span className="flex items-center gap-2">
+        Total ROI - Average{' '}
+        {!isNil(m.partialRoi) && (
+          <Popover>
+            <div className="flex flex-col max-w-[320px] gap-4 text-base">
+              <p className="text-gray-500">
+                Total ROI shows your agent&apos;s overall earnings, including profits from
+                predictions and staking rewards, minus all related costs.
+              </p>
+              <p className="text-gray-500">
+                Partial ROI reflects only prediction performance, excluding staking rewards.
+              </p>
+              <div className="flex justify-between">
+                <span className="text-gray-900">Partial ROI</span>
+                <span className={m.roiStatus?.stale ? 'text-gray-400' : ''}>
+                  {`${m.partialRoi}%`}
+                </span>
               </div>
-            </Popover>
-          )}
-        </span>
-      ),
-      value: isNil(m.finalRoi) ? null : `${m.finalRoi}%`,
-      status: m.roiStatus,
-      href: `/data#${platform}-predict-roi`,
-      warning:
-        platform === 'polystrat' ? (
-          <p>Due to recent updates on Polymarket this metric temporarily shows incorrect values</p>
-        ) : undefined,
-    },
-    {
-      label: 'OLAS Staking APR',
-      value: isNil(m.apr) ? null : `${m.apr}%`,
-      status: m.aprStatus,
-      href: `/data#${platform}-predict-apr`,
-    },
-    {
-      label: 'Prediction Accuracy - Average (Last 10K Trades)',
-      value: isNil(m.successRate) ? null : `${m.successRate}%`,
-      status: m.successRateStatus,
-      href: `/data#${platform}-predict-accuracy`,
-    },
-  ];
+              <div className="text-sm">
+                <StaleMetricContent status={m.roiStatus} />
+              </div>
+            </div>
+          </Popover>
+        )}
+      </span>
+    ),
+    value: isNil(m.finalRoi) ? null : `${m.finalRoi}%`,
+    status: m.roiStatus,
+    href: `/data#${platform}-predict-roi`,
+    warning:
+      platform === 'polystrat' ? (
+        <p>Due to recent updates on Polymarket this metric temporarily shows incorrect values</p>
+      ) : undefined,
+  };
+
+  const accuracyItem: MetricItemProps = {
+    label: 'Prediction Accuracy - Average (Last 10K Trades)',
+    value: isNil(m.successRate) ? null : `${m.successRate}%`,
+    status: m.successRateStatus,
+    href: `/data#${platform}-predict-accuracy`,
+  };
+
+  const aprItem: MetricItemProps = {
+    label: 'OLAS Staking APR',
+    value: isNil(m.apr) ? null : `${m.apr}%`,
+    status: m.aprStatus,
+    href: `/data#${platform}-predict-apr`,
+  };
+
+  const brierValue = m.brierScore?.[activeWindow] ?? null;
+  const brierItem: MetricItemProps = {
+    label: (
+      <span className="flex items-center gap-2">
+        Brier Score{' '}
+        <Popover>
+          <div className="flex flex-col max-w-[320px] gap-2 text-base text-gray-500">
+            <p>
+              The Brier score measures how well-calibrated the agent&apos;s predictions are.{' '}
+              <span className="text-gray-900">Lower is better</span> — 0 is a perfect forecast,
+              ~0.25 is no better than a 50/50 guess, and 1 is maximally wrong.
+            </p>
+          </div>
+        </Popover>
+      </span>
+    ),
+    value: isNil(brierValue) ? null : brierValue.toFixed(2),
+    status: m.brierStatus,
+  };
+
+  // Omenstrat replaces OLAS Staking APR with the windowed Brier score; Polystrat
+  // keeps APR until predict-polymarket ships Brier data.
+  const performanceItems: MetricItemProps[] =
+    platform === 'omenstrat'
+      ? [roiItem, accuracyItem, brierItem]
+      : [roiItem, aprItem, accuracyItem];
 
   const lifetimeItems: MetricItemProps[] = [
     {
@@ -213,7 +255,11 @@ export const PlatformActivitySection = ({
         <Card className="p-6 border border-slate-200 rounded-2xl bg-gradient-to-b from-[rgba(244,247,251,0.2)] to-[#F4F7FB] flex flex-col gap-6">
           <div className="flex items-center justify-between flex-wrap gap-3">
             <div className="text-lg font-semibold">Performance</div>
-            <Tabs items={TIME_RANGE_TABS} activeKey="max" onChange={() => {}} />
+            <Tabs
+              items={getTimeRangeTabs(isWindowed)}
+              activeKey={isWindowed ? activeWindow : 'max'}
+              onChange={(key) => setActiveWindow(key as WindowKey)}
+            />
           </div>
           <div className="grid sm:grid-cols-2 gap-4">
             {performanceItems.map((item, i) => (


### PR DESCRIPTION
## Proposed Changes

Consume the Brier-score accumulators shipped in predict-omen (autonolas-subgraph PR #95). The Omenstrat economy "Performance" card now shows ROI / Prediction Accuracy / Brier Score (replacing OLAS Staking APR), with the 7D/30D/90D/Max time-range tabs windowing the Brier value.

- queries.ts: lean getOmenDailyBrierStatsQuery (date, brierSum, brierCount, _meta)
- omenstrat-brier.ts: paginate dailyProfitStatistics; per window compute sum(brierSum)/sum(brierCount) -> WindowedMetric<number|null>, with lag/stale handling
- predict/index.ts: wire brierScore into PredictMetricsData.omenstrat snapshot
- PlatformActivitySection: activeWindow state, enable tabs on Omenstrat (disabled on Polystrat until its subgraph ships Brier), Brier metric + "lower is better" popover
- Activity.tsx: map brierScore value/status through processPredictMetrics

Polystrat keeps APR for now (predict-polymarket Brier is a future PR). Field is additive to the snapshot, so no METRICS_PREFIX bump is needed.

## Screenshots/Recordings

<img width="566" height="456" alt="image" src="https://github.com/user-attachments/assets/b294ba56-dc07-44ed-bcf2-ec4854c34dd8" />

## Things to keep in mind

<!-- Please check if the PR fulfills these requirements -->

- [ ] I confirm I have updated the meta title and description for the page, if applicable.
