### PR TITLE
fix(predict): colour the Brier value to match other performance metrics

### DIFF
--- a/components/AgentEconomies/PredictPage/PlatformActivitySection.tsx
+++ b/components/AgentEconomies/PredictPage/PlatformActivitySection.tsx
@@ -216,6 +216,7 @@ export const PlatformActivitySection = ({
     ),
     value: isNil(brierValue) ? null : brierValue.toFixed(2),
     status: m.brierStatus,
+    href: `/data#${platform}-predict-brier`,
   };
 
   // Both economies show ROI / APR / Accuracy. Brier score is an additional 4th

--- a/components/AgentEconomies/PredictPage/PlatformActivitySection.tsx
+++ b/components/AgentEconomies/PredictPage/PlatformActivitySection.tsx
@@ -81,7 +81,9 @@ type MetricItemProps = {
 };
 
 const MetricItem = ({ label, value, status, href, warning }: MetricItemProps) => {
-  const valueClass = `text-2xl font-bold ${status?.stale ? 'text-gray-400' : ''}`;
+  // Match the brand colour of the linked metrics (Link is text-purple-600) so an
+  // unlinked value (e.g. Brier, which has no /data anchor yet) looks consistent.
+  const valueClass = `text-2xl font-bold ${status?.stale ? 'text-gray-400' : 'text-purple-600'}`;
   return (
     <div className="flex flex-col gap-1">
       <div className="text-sm text-slate-500">{label}</div>

--- a/components/DataPage/OmenstratBrierInfo.tsx
+++ b/components/DataPage/OmenstratBrierInfo.tsx
@@ -1,0 +1,85 @@
+import { SUB_HEADER_LG_CLASS, TEXT_MEDIUM_CLASS } from 'common-util/classes';
+import { getOmenDailyBrierStatsQuery } from 'common-util/graphql/queries';
+import SectionWrapper from 'components/Layout/SectionWrapper';
+import { Check, Copy } from 'lucide-react';
+import { useState } from 'react';
+import { CodeSnippet } from './CodeSnippet';
+
+export const OmenstratBrierInfo = () => {
+  const [copied, setCopied] = useState(false);
+  const dailyBrierStats = getOmenDailyBrierStatsQuery({
+    date_gte: 0,
+    date_lte: 9999999999,
+    first: 1000,
+    skip: 0,
+  });
+
+  const copyEndpointToClipboard = async () => {
+    const url = process.env.NEXT_PUBLIC_OLAS_PREDICT_AGENTS_SUBGRAPH_URL;
+    if (url) {
+      await navigator.clipboard.writeText(url);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    }
+  };
+
+  return (
+    <SectionWrapper id="omenstrat-predict-brier">
+      <h2 className={SUB_HEADER_LG_CLASS}>Omenstrat: Predict Brier Score</h2>
+
+      <div className="space-y-6 mt-4">
+        <p>
+          The Brier score measures how well-calibrated an agent&apos;s predictions are — not just
+          whether it was right, but whether the confidence it implied matched reality. It is the
+          mean squared error between the market-implied probability of the outcome the agent bought
+          (its prediction) and what actually happened (<b>1</b> if that outcome won, <b>0</b> if it
+          lost, or <b>0.5</b> for markets that resolve invalid). <b>Lower is better:</b> 0 is a
+          perfect forecast, ~0.25 is no better than a 50/50 guess, and 1 is maximally wrong.
+        </p>
+
+        <p>
+          Only <b>buy</b> trades on <b>settled</b> markets are scored — sells rebalance a position
+          rather than express a prediction, so they are excluded. Each bet&apos;s implied
+          probability is captured at trade time, and its squared error is accumulated on the day its
+          market resolves.
+        </p>
+
+        <p>
+          The subgraph stores these as per-day accumulators (<code>brierSum</code>,{' '}
+          <code>brierCount</code>). The score shown for a period is the count-weighted mean over
+          that window — <code>sum(brierSum) / sum(brierCount)</code> (1e18-scaled) — so the 7D / 30D
+          / 90D / Max tabs simply sum the daily buckets over the corresponding range.
+        </p>
+
+        <p>The following query is used:</p>
+
+        <h3 className={`${TEXT_MEDIUM_CLASS} font-bold`}>Daily Brier statistics query</h3>
+
+        <p className="max-w-[800px]">
+          Used to fetch the per-day Brier accumulators across all trader agents, summed by
+          settlement day
+        </p>
+        <p className="text-purple-600 flex items-center gap-2 flex-wrap">
+          <span>API endpoint:</span>
+          <code>{process.env.NEXT_PUBLIC_OLAS_PREDICT_AGENTS_SUBGRAPH_URL}</code>
+          <button
+            onClick={copyEndpointToClipboard}
+            className="p-1 border rounded-md border-slate-300 hover:bg-slate-100 transition-colors"
+            title="Copy to clipboard"
+          >
+            {copied ? (
+              <Check size={16} className="text-green-600" />
+            ) : (
+              <Copy size={16} color="black" />
+            )}
+          </button>
+        </p>
+        <CodeSnippet>
+          {`curl -X POST ${process.env.NEXT_PUBLIC_OLAS_PREDICT_AGENTS_SUBGRAPH_URL} \\
+  -H "Content-Type: application/json" \\
+  -d '${JSON.stringify({ query: dailyBrierStats })}'`}
+        </CodeSnippet>
+      </div>
+    </SectionWrapper>
+  );
+};

--- a/components/DataPage/OmenstratBrierInfo.tsx
+++ b/components/DataPage/OmenstratBrierInfo.tsx
@@ -29,26 +29,29 @@ export const OmenstratBrierInfo = () => {
 
       <div className="space-y-6 mt-4">
         <p>
-          The Brier score measures how well-calibrated an agent&apos;s predictions are — not just
-          whether it was right, but whether the confidence it implied matched reality. It is the
-          mean squared error between the market-implied probability of the outcome the agent bought
-          (its prediction) and what actually happened (<b>1</b> if that outcome won, <b>0</b> if it
-          lost, or <b>0.5</b> for markets that resolve invalid). <b>Lower is better:</b> 0 is a
-          perfect forecast, ~0.25 is no better than a 50/50 guess, and 1 is maximally wrong.
+          The Brier score shows how well-calibrated your agent&apos;s predictions are — it rewards
+          being confident when right and cautious when wrong, not just being right on average. For
+          every trade it compares the probability the market implied for the outcome your agent
+          backed against what actually happened, then averages the result across all resolved
+          markets. Lower is better:
         </p>
 
-        <p>
-          Only <b>buy</b> trades on <b>settled</b> markets are scored — sells rebalance a position
-          rather than express a prediction, so they are excluded. Each bet&apos;s implied
-          probability is captured at trade time, and its squared error is accumulated on the day its
-          market resolves.
-        </p>
+        <ul className="list-disc list-inside space-y-1">
+          <li>
+            <strong>0</strong>: a perfect forecast.
+          </li>
+          <li>
+            <strong>~0.25</strong>: no better than a 50/50 guess.
+          </li>
+          <li>
+            <strong>1</strong>: confidently wrong every time.
+          </li>
+        </ul>
 
         <p>
-          The subgraph stores these as per-day accumulators (<code>brierSum</code>,{' '}
-          <code>brierCount</code>). The score shown for a period is the count-weighted mean over
-          that window — <code>sum(brierSum) / sum(brierCount)</code> (1e18-scaled) — so the 7D / 30D
-          / 90D / Max tabs simply sum the daily buckets over the corresponding range.
+          Only buy trades on resolved markets are counted — selling adjusts a position rather than
+          making a prediction, so sells are excluded. Each time range (7D / 30D / 90D / Max)
+          averages the trades whose markets resolved within that period.
         </p>
 
         <p>The following query is used:</p>

--- a/pages/data/index.tsx
+++ b/pages/data/index.tsx
@@ -16,6 +16,7 @@ import {
 import { OperatorsInfo } from 'components/DataPage/Operators';
 import { OmenstratAccuracyInfo } from 'components/DataPage/OmenstratAccuracy';
 import { OmenstratAprInfo } from 'components/DataPage/OmenstratAprInfo';
+import { OmenstratBrierInfo } from 'components/DataPage/OmenstratBrierInfo';
 import { OmenstratRoiInfo } from 'components/DataPage/OmenstratRoiInfo';
 import { PolystratAccuracyInfo } from 'components/DataPage/PolystratAccuracy';
 import { PolystratAprInfo } from 'components/DataPage/PolystratAprInfo';
@@ -50,6 +51,7 @@ const DataVerifyPage = () => (
       <OmenstratRoiInfo />
       <OmenstratAprInfo />
       <OmenstratAccuracyInfo />
+      <OmenstratBrierInfo />
       <PolystratRoiInfo />
       <PolystratAprInfo />
       <PolystratAccuracyInfo />


### PR DESCRIPTION
The linked metrics render via Link (text-purple-600); the unlinked Brier value fell back to default black. Apply the same brand purple to unlinked metric values so Brier matches ROI / APR / Accuracy.

## Screenshots

<img width="557" height="444" alt="image" src="https://github.com/user-attachments/assets/050797a1-7f05-4ce7-be17-056690f330cc" />

<img width="1345" height="820" alt="image" src="https://github.com/user-attachments/assets/cdb4b74b-e8a0-4ef9-beeb-7fa98bb7b40a" />
