### PR TITLE
fix(explorer): mobile responsive layout for agent economy explorer

### DIFF
--- a/components/ExplorerPage/EconomySelector.tsx
+++ b/components/ExplorerPage/EconomySelector.tsx
@@ -59,13 +59,20 @@ export const EconomySelector = ({ activeKey, onChange, className }: EconomySelec
             className={cn(
               // flex-1 + min-w-0 + truncated label = thirds can never overflow on mobile;
               // tight padding + a smaller icon keep the full "Babydegen" label visible.
-              'flex min-w-0 flex-1 items-center justify-center gap-1 rounded-lg px-1 py-1.5 text-sm transition-colors sm:flex-initial sm:gap-2 sm:px-10 sm:text-base',
+              // min-h-[44px] gives a proper mobile touch target; reset at sm: (pointer).
+              'flex min-h-[44px] min-w-0 flex-1 items-center justify-center gap-1 rounded-lg px-1 py-1.5 text-sm transition-colors sm:min-h-0 sm:flex-initial sm:gap-2 sm:px-10 sm:text-base',
               isActive ? 'bg-[#dfe5ee] text-black' : 'text-[#606f85]',
               disabled ? 'cursor-not-allowed' : !isActive && 'hover:bg-slate-50'
             )}
           >
             <span className="relative size-5 shrink-0 overflow-hidden rounded-md sm:size-7">
-              <Image src={icon} alt="" fill sizes="28px" className="object-cover" />
+              <Image
+                src={icon}
+                alt=""
+                fill
+                sizes="(min-width: 640px) 28px, 20px"
+                className="object-cover"
+              />
             </span>
             <span className="truncate">{label}</span>
           </button>

--- a/components/ExplorerPage/EconomySelector.tsx
+++ b/components/ExplorerPage/EconomySelector.tsx
@@ -40,7 +40,9 @@ export const EconomySelector = ({ activeKey, onChange, className }: EconomySelec
       role="tablist"
       aria-label="Agent economy"
       className={cn(
-        'inline-flex items-center gap-0.5 rounded-[10px] border border-[#d7ddea] bg-white p-0.5',
+        // Mobile: full-width, equal thirds so 3 economies always fit (no overflow).
+        // sm+: revert to the auto-width centered pill from Figma.
+        'flex w-full items-center gap-0.5 rounded-[10px] border border-[#d7ddea] bg-white p-0.5 sm:inline-flex sm:w-auto',
         className
       )}
     >
@@ -55,15 +57,17 @@ export const EconomySelector = ({ activeKey, onChange, className }: EconomySelec
             aria-disabled={disabled || undefined}
             onClick={() => !disabled && onChange(key)}
             className={cn(
-              'flex items-center justify-center gap-2 rounded-lg px-10 py-1.5 text-base transition-colors',
+              // flex-1 + min-w-0 + truncated label = thirds can never overflow on mobile;
+              // tight padding + a smaller icon keep the full "Babydegen" label visible.
+              'flex min-w-0 flex-1 items-center justify-center gap-1 rounded-lg px-1 py-1.5 text-sm transition-colors sm:flex-initial sm:gap-2 sm:px-10 sm:text-base',
               isActive ? 'bg-[#dfe5ee] text-black' : 'text-[#606f85]',
               disabled ? 'cursor-not-allowed' : !isActive && 'hover:bg-slate-50'
             )}
           >
-            <span className="relative size-7 shrink-0 overflow-hidden rounded-md">
+            <span className="relative size-5 shrink-0 overflow-hidden rounded-md sm:size-7">
               <Image src={icon} alt="" fill sizes="28px" className="object-cover" />
             </span>
-            {label}
+            <span className="truncate">{label}</span>
           </button>
         );
 

--- a/components/ExplorerPage/MetricSelector.tsx
+++ b/components/ExplorerPage/MetricSelector.tsx
@@ -30,7 +30,7 @@ export const MetricSelector = ({
   className,
 }: MetricSelectorProps) => (
   <div className={cn('flex w-full justify-center border-y border-[#e8eaee]', className)}>
-    <div className="flex w-full max-w-[872px] border-x border-[#e8eaee]">
+    <div className="flex w-full max-w-[872px] flex-col border-x border-[#e8eaee] md:flex-row">
       {metrics.map((metric, i) => {
         const isActive = metric.key === activeKey;
         return (
@@ -44,7 +44,8 @@ export const MetricSelector = ({
             onClick={() => metric.selectable && onChange(metric.key)}
             className={cn(
               'flex flex-1 flex-col items-start justify-center gap-2 p-6 text-left transition-colors',
-              i < metrics.length - 1 && 'border-r border-[#e8eaee]',
+              // Stacked on mobile → divider runs along the bottom; row on md+ → divider on the right.
+              i < metrics.length - 1 && 'border-b border-[#e8eaee] md:border-b-0 md:border-r',
               metric.selectable ? 'cursor-pointer hover:bg-slate-100' : 'cursor-default'
             )}
           >

--- a/components/ExplorerPage/index.tsx
+++ b/components/ExplorerPage/index.tsx
@@ -150,7 +150,7 @@ const Explorer = ({ series, status }: ExplorerProps) => {
       </div>
 
       {/* Economy selector */}
-      <div className="flex justify-center pb-10 pt-12">
+      <div className="flex justify-center px-3 pb-10 pt-12">
         <EconomySelector activeKey={activeEconomy} onChange={setActiveEconomy} />
       </div>
 
@@ -159,7 +159,7 @@ const Explorer = ({ series, status }: ExplorerProps) => {
 
       {/* Series header + filter pill — centered 872 column (Figma 20754:3512).
           Keyed by metric so the copy re-reveals on a DAA ↔ Transactions switch. */}
-      <div className="flex w-full justify-center px-10 py-8">
+      <div className="flex w-full justify-center px-6 py-8 md:px-10">
         <div
           key={activeMetric}
           className="explorer-reveal flex w-full max-w-[872px] flex-col gap-6"
@@ -193,8 +193,8 @@ const Explorer = ({ series, status }: ExplorerProps) => {
         </div>
       </div>
 
-      {/* Heatmap — full-bleed left; 40px free on the right (past the weekday axis) */}
-      <div className="w-full pr-10">
+      {/* Heatmap — full-bleed left; right gutter past the weekday axis (16px mobile, 40px md+) */}
+      <div className="w-full pr-4 md:pr-10">
         <DaaCalendarHeatmap
           series={activeSeries}
           highlightYear={activeYear}


### PR DESCRIPTION
## What

Mobile-responsive fixes for the Agent Economy Explorer (`/agent-economies/explorer`). Desktop rendering is unchanged.

## Fixes

- **Hero background now covers full width on mobile.** Root cause was *horizontal overflow*: the economy switch (~539px) and the metric-tile row (~571px) pushed the page wider than device-width, so the full-width hero gradient pinned to the viewport and left a white strip on the overflowed side. Removing the overflow (below) makes the gradient span edge-to-edge.
- **Economy switch fits on mobile.** Full-width equal thirds (`flex-1` + `min-w-0` + truncate → can never overflow), reverting to the Figma auto-width centered pill at `sm:`. "Babydegen" stays fully readable down to 360px.
- **Metric tiles stack vertically on mobile** (`flex-col md:flex-row`); dividers flip from right-border to bottom-border.
- **Section side padding** reduced to 24px on mobile (`px-6 md:px-10`).
- **Heatmap right gutter** reduced to 16px on mobile (`pr-4 md:pr-10`).

## Verification

- Headless Chrome at **320 / 360 / 390 / 768 / 1280**: no horizontal overflow at any width, hero covers full width, switch labels fit (graceful ellipsis only at the 320px legacy floor).
- Desktop (`sm+`/`md+`) is confirmed behaviorally identical — every mobile utility is reset by its `sm:`/`md:` counterpart.
- `tsc --noEmit` + ESLint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)