### PR TITLE
feat(polystrat): [BDMARK-2181] restore polystrat

### DIFF
--- a/components/Layout/PageWrapper.tsx
+++ b/components/Layout/PageWrapper.tsx
@@ -1,5 +1,6 @@
 import Footer from './Footer';
 import Header from './Header';
+import PolystratBanner from './PolystratBanner';
 
 type PageWrapperProps = {
   children: React.ReactNode;
@@ -7,7 +8,7 @@ type PageWrapperProps = {
 
 const PageWrapper = ({ children }: PageWrapperProps) => (
   <>
-    {/* <PolystratBanner /> */}
+    <PolystratBanner />
     <Header />
 
     {children}

--- a/data/useCases.json
+++ b/data/useCases.json
@@ -17,8 +17,7 @@
         "description": "Trades Polymarket prediction markets for you while you do something else.",
         "image": "/images/agents/polystrat.png",
         "link": "https://www.pearl.you/polystrat",
-        "isExternal": true,
-        "isUnderConstruction": true
+        "isExternal": true
       },
       {
         "title": "BabyDegen",


### PR DESCRIPTION
## Summary
- Re-enable the `PolystratBanner` in `PageWrapper` (it was commented out).
- Remove the `isUnderConstruction` flag from the Polystrat entry in `data/useCases.json` so the under-construction tag no longer renders for Polystrat.

## Notes
The remaining `isUnderConstruction` instances belong to other agents (BabyDegen, Optimus, Agents.fun, Modius) and were intentionally left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)