### PR TITLE
feat(explorer): label DAA tile "Latest DAAs" with dated popover

### DIFF
--- a/components/ExplorerPage/MetricSelector.tsx
+++ b/components/ExplorerPage/MetricSelector.tsx
@@ -1,3 +1,4 @@
+import { Popover } from 'components/ui/popover';
 import { cn } from 'lib/utils';
 
 export type ExplorerMetric = {
@@ -7,6 +8,8 @@ export type ExplorerMetric = {
   value: string;
   /** Only metrics with a real daily series can drive the heatmap. */
   selectable: boolean;
+  /** Optional hover tooltip (e.g. the date the headline value is for). */
+  tooltip?: string;
 };
 
 type MetricSelectorProps = {
@@ -33,15 +36,25 @@ export const MetricSelector = ({
     <div className="flex w-full max-w-[872px] flex-col border-x border-[#e8eaee] md:flex-row">
       {metrics.map((metric, i) => {
         const isActive = metric.key === activeKey;
+        const select = () => metric.selectable && onChange(metric.key);
         return (
-          <button
+          // A div (not a button) so the info Popover — itself a button — can nest inside
+          // the label row without invalid button-in-button markup. Keyboard support is
+          // wired manually to keep tab/Enter/Space selection.
+          <div
             key={metric.key}
-            type="button"
             role="tab"
             aria-selected={isActive}
             aria-disabled={!metric.selectable || undefined}
+            tabIndex={metric.selectable ? 0 : undefined}
             title={metric.selectable ? undefined : 'Daily series coming soon'}
-            onClick={() => metric.selectable && onChange(metric.key)}
+            onClick={select}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter' || e.key === ' ') {
+                e.preventDefault();
+                select();
+              }
+            }}
             className={cn(
               'flex flex-1 flex-col items-start justify-center gap-2 p-6 text-left transition-colors',
               // Stacked on mobile → divider runs along the bottom; row on md+ → divider on the right.
@@ -49,8 +62,13 @@ export const MetricSelector = ({
               metric.selectable ? 'cursor-pointer hover:bg-slate-100' : 'cursor-default'
             )}
           >
-            <span className="text-[14px] leading-5 tracking-[0.14px] text-[#78879c]">
+            <span className="flex items-center gap-1 text-[14px] leading-5 tracking-[0.14px] text-[#78879c]">
               {metric.label}
+              {metric.tooltip && (
+                <Popover side="top" contentClassName="whitespace-nowrap">
+                  {metric.tooltip}
+                </Popover>
+              )}
             </span>
             <span className="relative inline-block">
               <span
@@ -68,7 +86,7 @@ export const MetricSelector = ({
                 />
               )}
             </span>
-          </button>
+          </div>
         );
       })}
     </div>

--- a/components/ExplorerPage/index.tsx
+++ b/components/ExplorerPage/index.tsx
@@ -388,8 +388,8 @@ const Explorer = ({ economies }: ExplorerProps) => {
           valueKind={metricConfig.kind}
           colorScale={metricConfig.scale}
           levelColors={rampColors}
-          markerDate={agentMeta.phaseOutDate ?? null}
-          markerLabel={agentMeta.phaseOutDate ? `${agentMeta.label} phased out` : undefined}
+          markerDate={agentMeta.marker?.date ?? null}
+          markerLabel={agentMeta.marker?.label}
         />
       </div>
 

--- a/components/ExplorerPage/index.tsx
+++ b/components/ExplorerPage/index.tsx
@@ -57,6 +57,10 @@ type MetricDef = {
   headline: (series: DaaSeriesPoint[]) => string;
   /** Whether the tile is selectable — false dims it + shows "coming soon". */
   selectable: (series: DaaSeriesPoint[]) => boolean;
+  /** Tile label override (defaults to `label`); lets the tile read differently from the heatmap header. */
+  tileLabel?: string;
+  /** Optional hover tooltip for the tile (e.g. the date the headline value is for). */
+  tooltip?: (series: DaaSeriesPoint[]) => string | undefined;
 };
 
 // Metric → the noun used in the header/tooltip, how the tooltip value reads, the heatmap
@@ -64,11 +68,19 @@ type MetricDef = {
 const METRIC_CONFIG: Record<string, MetricDef> = {
   daa: {
     label: 'Daily Active Agents',
+    // Tile shows the latest day's value, so label it "Latest DAAs"; the heatmap header
+    // keeps the descriptive "Daily Active Agents" (it plots the full daily history).
+    tileLabel: 'Latest DAAs',
     unit: 'active agents',
     kind: 'count',
     scale: 'sequential',
     // Latest day's active-agent count.
     headline: (s) => formatCount(s.length ? s[s.length - 1].count : 0),
+    // Spell out the day the headline value is for, e.g. "Daily Active Agents of June 29, 2026".
+    tooltip: (s) =>
+      s.length
+        ? `Daily Active Agents as of ${dayjs(s[s.length - 1].date).format('MMMM D, YYYY')}`
+        : undefined,
     selectable: () => true,
   },
   transactions: {
@@ -249,9 +261,10 @@ const Explorer = ({ economies }: ExplorerProps) => {
     const metricSeries = series[key] ?? [];
     return {
       key,
-      label: config.label,
+      label: config.tileLabel ?? config.label,
       value: config.headline(metricSeries),
       selectable: config.selectable(metricSeries),
+      tooltip: config.tooltip?.(metricSeries),
     };
   });
 
@@ -375,8 +388,8 @@ const Explorer = ({ economies }: ExplorerProps) => {
           valueKind={metricConfig.kind}
           colorScale={metricConfig.scale}
           levelColors={rampColors}
-          markerDate={agentMeta.marker?.date ?? null}
-          markerLabel={agentMeta.marker?.label}
+          markerDate={agentMeta.phaseOutDate ?? null}
+          markerLabel={agentMeta.phaseOutDate ? `${agentMeta.label} phased out` : undefined}
         />
       </div>
 


### PR DESCRIPTION
## What & why

On the Agent Economy Explorer, the **Daily Active Agents** headline tile shows the *latest day's* active-agent count (`series[last].count`), but was labeled the same as the full-history heatmap below it. This relabels the tile to **"Latest DAAs"** and adds a popover that spells out exactly which day the number is for.

## Screenshot

<img width="482" height="237" alt="image" src="https://github.com/user-attachments/assets/a99b1e5c-7704-4868-96f8-3a9dc19b896f" />


## Changes

- **Tile label → "Latest DAAs"** via a new `tileLabel` override on the `daa` metric config. The heatmap section header keeps the descriptive **"Daily Active Agents"** since it plots the full daily series (calling that "Latest" would be misleading).
- **Dated popover** on the tile, e.g. *"Daily Active Agents as of June 29, 2026"*, built from the latest series point via `dayjs(...).format('MMMM D, YYYY')`. Uses the shared `Popover` (Radix tooltip) component, rendered on a single line (`whitespace-nowrap`).
- Wired an optional `tooltip` field through `ExplorerMetric` / `MetricSelector`.

Applies to every economy's DAA tile (Predict, Babydegen, Mech), since they share the `daa` config — the tile is always the latest day.

## Notes

- The `/agent-economies/predict` economy page is intentionally **not** changed (its DAA cards remain the 7-day average).

🤖 Generated with [Claude Code](https://claude.com/claude-code)