### PR TITLE
Copy: neutral bonding wording and staking/token info notes

### DIFF
--- a/components/BondsPage/Hero.tsx
+++ b/components/BondsPage/Hero.tsx
@@ -19,14 +19,14 @@ const ProvideLiquidity = (
   <div>
     Provide liquidity,
     <br />
-    get discounted OLAS
+    get OLAS in return
   </div>
 );
 
 const StartBonding = () => (
   <Button variant="default" size="xl" asChild className="w-full lg:w-auto">
     <SubsiteLink href={BOND_URL} isInButton>
-      Start bonding now
+      View bonding programs
     </SubsiteLink>
   </Button>
 );
@@ -36,7 +36,7 @@ export const Hero = () => (
     HeroImage={HeroImage}
     pageName="OLAS BOND"
     title={ProvideLiquidity}
-    description="Join the Olas ecosystem as a Bonder & get discounted OLAS."
+    description="Join the Olas ecosystem as a Bonder & receive OLAS in return for LP tokens, when bonding programs are open."
     PrimaryButton={StartBonding}
   />
 );

--- a/components/BondsPage/HowBondingWorks.tsx
+++ b/components/BondsPage/HowBondingWorks.tsx
@@ -16,17 +16,18 @@ const steps = [
     title: 'Provide liquidity',
     description: (
       <>
-        As a Bonder, you exchange your LP tokens for discounted OLAS to help the Olas ecosystem
-        operate smoothly and sustainably. Simply deposit your LP tokens to your chosen{' '}
+        As a Bonder, you exchange your LP tokens for OLAS to help the Olas ecosystem operate
+        smoothly and sustainably. Simply deposit your LP tokens to an open{' '}
         <SubsiteLink href={BONDING_PROGRAMS_URL}>bonding program</SubsiteLink>, exchanging your LP
-        tokens for discounted OLAS, available after the predetermined vesting period.
+        tokens for OLAS, claimable after the predetermined vesting period. Bonding is
+        self-custodial, and program availability varies — at times, no programs may be open.
       </>
     ),
   },
   {
     title: 'Receive benefits',
     description:
-      'In return for providing liquidity, Olas Bonders receive OLAS tokens at a discounted price.',
+      'In return for providing liquidity, Olas Bonders receive OLAS tokens at the rate quoted by the program at the time of deposit. OLAS is a crypto asset — its value can go down as well as up, including during the vesting period.',
   },
   {
     title: 'Support the ecosystem',
@@ -60,7 +61,7 @@ export const HowBondingWorks = () => (
       <div className="self-center">
         <Button variant="default" size="xl" asChild className="mt-4 md:mt-10">
           <SubsiteLink href={BOND_URL} isInButton>
-            Start bonding now
+            View bonding programs
           </SubsiteLink>
         </Button>
       </div>

--- a/components/BondsPage/UnlockBenefits.tsx
+++ b/components/BondsPage/UnlockBenefits.tsx
@@ -35,8 +35,8 @@ export const UnlockBenefits = () => (
       <p>
         Join as an Olas Bonder to strengthen the network. An Olas Bonder provides liquidity to the
         Olas ecosystem by participating in bonding programs. By bonding your assets, you help grow
-        the network and in return, receive OLAS. It’s a simple way to support the growth of the
-        Olas ecosystem.
+        the network and in return, receive OLAS. It’s a simple way to support the growth of the Olas
+        ecosystem.
       </p>
 
       <div id="why-bond">

--- a/components/BondsPage/UnlockBenefits.tsx
+++ b/components/BondsPage/UnlockBenefits.tsx
@@ -12,7 +12,7 @@ import SectionWrapper from 'components/Layout/SectionWrapper';
 const list = [
   {
     title: 'Get more OLAS',
-    desc: 'You get OLAS tokens at a discount.',
+    desc: 'Receive OLAS in return for your LP tokens, at the rate quoted by the program.',
     icon: <BadgePercent size={30} />,
   },
   {
@@ -35,8 +35,8 @@ export const UnlockBenefits = () => (
       <p>
         Join as an Olas Bonder to strengthen the network. An Olas Bonder provides liquidity to the
         Olas ecosystem by participating in bonding programs. By bonding your assets, you help grow
-        the network and in return, receive OLAS at preferential rates. It’s a simple way to support
-        and benefit from the growth of the Olas ecosystem.
+        the network and in return, receive OLAS. It’s a simple way to support the growth of the
+        Olas ecosystem.
       </p>
 
       <div id="why-bond">

--- a/components/DataPage/ProtocolOwnedLiquidity.tsx
+++ b/components/DataPage/ProtocolOwnedLiquidity.tsx
@@ -15,7 +15,7 @@ export const ProtocolOwnedLiquidityInfo = () => {
         <p>
           Tracks the total USD value of LP tokens held by the Olas Treasury across all chains. The
           Treasury acquires LP tokens permanently through the bonding mechanism, where participants
-          deposit LP tokens in exchange for discounted OLAS.
+          deposit LP tokens in exchange for OLAS.
         </p>
 
         <p>

--- a/components/OlasTokenPage/GetInvolved.tsx
+++ b/components/OlasTokenPage/GetInvolved.tsx
@@ -43,8 +43,9 @@ const GET_INVOLVED_DATA = [
   {
     id: 5,
     imageSrc: '/images/homepage/olas-bond.png',
-    title: 'Provide liquidity, get discounted OLAS',
-    description: 'A bonding mechanism rewards providers of liquidity with discounted OLAS.',
+    title: 'Provide liquidity, get OLAS',
+    description:
+      'A bonding mechanism rewards providers of liquidity with OLAS, when bonding programs are open.',
     ctaText: 'Bond',
     href: '/bond',
   },

--- a/components/OlasTokenPage/Hero.tsx
+++ b/components/OlasTokenPage/Hero.tsx
@@ -24,7 +24,7 @@ export const Hero = () => (
     HeroImage={HeroImage}
     pageName="OLAS TOKEN"
     title="Unlock the Olas Network"
-    description="OLAS token provides access to the core functions of the network."
+    description="OLAS token provides access to the core functions of the network. OLAS is a crypto asset — its value can go down as well as up. Nothing on this page is financial advice."
     PrimaryButton={GetOlas}
   />
 );

--- a/components/OlasTokenPage/TokenDetails.tsx
+++ b/components/OlasTokenPage/TokenDetails.tsx
@@ -28,6 +28,10 @@ export const TokenDetails = () => (
         >
           Token Details
         </SectionHeading>
+        <p className="text-center text-sm text-gray-500 mt-4">
+          For information only — not financial advice. OLAS is a crypto asset; its value can go
+          down as well as up.
+        </p>
         <div className="hidden md:block">
           <Table className="mt-6">
             <TableHeader>

--- a/components/OlasTokenPage/TokenDetails.tsx
+++ b/components/OlasTokenPage/TokenDetails.tsx
@@ -29,8 +29,8 @@ export const TokenDetails = () => (
           Token Details
         </SectionHeading>
         <p className="text-center text-sm text-gray-500 mt-4">
-          For information only — not financial advice. OLAS is a crypto asset; its value can go
-          down as well as up.
+          For information only — not financial advice. OLAS is a crypto asset; its value can go down
+          as well as up.
         </p>
         <div className="hidden md:block">
           <Table className="mt-6">

--- a/components/StakingPage/FAQ.tsx
+++ b/components/StakingPage/FAQ.tsx
@@ -50,7 +50,7 @@ const faq = [
   },
   {
     title: 'Who can participate in staking?',
-    desc: 'Anyone. You can stake OLAS to run an agent or support a specific staking program.',
+    desc: 'Anyone. You can stake OLAS to run an agent or support a specific staking program. Rewards depend on agent activity and performance and are not guaranteed, and staked OLAS is locked under the terms of the staking contract.',
   },
   {
     title: 'Can I create my own staking contract?',

--- a/components/StakingPage/ForOlasHolders.tsx
+++ b/components/StakingPage/ForOlasHolders.tsx
@@ -9,7 +9,7 @@ const list = [
   {
     title: 'Stake Your OLAS',
     description:
-      'Put your tokens to work by running an agent through Pearl — the AI agent app store. Earn staking rewards by participating in agent-based staking contracts tied to real performance.',
+      'Put your tokens to work by running an agent through Pearl — the AI agent app store. Earn staking rewards by participating in agent-based staking contracts tied to real performance. Rewards depend on agent activity and are not guaranteed.',
     url: `${PEARL_YOU_URL_WITH_UTM_SOURCE}&utm_campaign=staking&utm_content=staking-link`,
     urlText: 'Own your AI agent via Pearl',
     cardWidth: 'col-span-2',

--- a/components/StakingPage/Hero.tsx
+++ b/components/StakingPage/Hero.tsx
@@ -14,6 +14,10 @@ export const Hero = () => (
       />
       <h1 className={`${MAIN_TITLE_CLASS} xl:mb-6`}>Olas Staking</h1>
       <span>The Engine of the Agentic Economy.</span>
+      <span className="mt-2 text-sm text-gray-500 text-center">
+        Staking rewards depend on agent activity and are not guaranteed. OLAS is a crypto asset —
+        its value can go down as well as up.
+      </span>
     </div>
   </SectionWrapper>
 );

--- a/pages/agents-unleashed.tsx
+++ b/pages/agents-unleashed.tsx
@@ -6,7 +6,7 @@ const AUPage = () => (
   <PageWrapper>
     <Meta
       pageTitle="Agents Unleashed"
-      description="Join Olas as a Bonder, get discounted OLAS tokens, provide liquidity, grow the network, and earn rewards in AI and crypto."
+      description="Join Olas as a Bonder: provide liquidity to support the network and receive OLAS in return, subject to program availability and vesting."
       ogPath="agents-unleashed"
     />
     <AU />

--- a/pages/bond.tsx
+++ b/pages/bond.tsx
@@ -8,7 +8,7 @@ const BondPage = ({ metrics }) => (
   <PageWrapper>
     <Meta
       pageTitle="Bond"
-      description="Join the Olas ecosystem as a Bonder to get discounted OLAS tokens. Provide liquidity, grow the crypto network, and earn rewards in the world of AI and blockchain. Start bonding and benefiting today!"
+      description="Join the Olas ecosystem as a Bonder. Provide liquidity to support the network and receive OLAS in return, subject to program availability and vesting periods."
     />
     <Bond metrics={metrics} />
   </PageWrapper>


### PR DESCRIPTION
## Summary

Copy tidy-up across the bond, staking, token, and data pages:

- **Bond page**: reword "get discounted OLAS" / "preferential rates" to neutral "receive OLAS in return" phrasing, since actual pricing depends on the program quoted at deposit time. Change "Start bonding now" CTAs to "View bonding programs" — accurate whether or not programs are currently open — and note that program availability varies and that bonding is self-custodial with a vesting period. Same wording updates in the bond/agents-unleashed meta descriptions, the token-page GetInvolved card, and the data-page POL description.
- **Staking page**: add a short note under the hero and to the "Who can participate" FAQ and holders card that rewards depend on agent activity and are not guaranteed, and that staked OLAS is locked under the staking contract's terms.
- **Token page**: add a one-line informational note to the hero and above the Token Details table ("For information only — not financial advice. OLAS is a crypto asset; its value can go down as well as up.").

No layout or functional changes — strings plus two small text elements only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
