### PR TITLE
geo: restrict selected pages for GB visitors

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -7,6 +7,11 @@ const BLOCKED_COUNTRIES = ['CU', 'IR', 'KP', 'SY', 'RU', 'BY'];
 // Ukrainian regions: Donetsk (14), Luhansk (09), Crimea (43/65), Sevastopol (23)
 const BLOCKED_REGIONS = ['UA-14', 'UA-09', 'UA-43', 'UA-65', 'UA-23'];
 
+// Pages not shown to visitors from these countries due to local marketing restrictions.
+// The rest of the site remains accessible.
+const PAGE_RESTRICTED_COUNTRIES = ['GB'];
+const RESTRICTED_PAGES = ['/olas-token', '/bond', '/staking', '/operate', '/build'];
+
 export function middleware(request) {
   const country = request.headers.get('x-vercel-ip-country');
   const region = request.headers.get('x-vercel-ip-country-region');
@@ -18,6 +23,14 @@ export function middleware(request) {
   if (
     (country && BLOCKED_COUNTRIES.includes(country)) ||
     (region && BLOCKED_REGIONS.includes(region))
+  ) {
+    return NextResponse.redirect(new URL('/restricted', request.url));
+  }
+
+  if (
+    country &&
+    PAGE_RESTRICTED_COUNTRIES.includes(country) &&
+    RESTRICTED_PAGES.includes(request.nextUrl.pathname)
   ) {
     return NextResponse.redirect(new URL('/restricted', request.url));
   }


### PR DESCRIPTION
Extends the existing geo middleware: GB visitors are redirected to /restricted on /olas-token, /bond, /staking, /operate and /build only. All other pages remain fully accessible. Uses the same x-vercel-ip-country mechanism and /restricted page as the existing country blocks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)