### PR TITLE
refactor: [BDMARK-2221] move olas-token tokenomics metrics to server-side snapshot pipeline

### DIFF
--- a/common-util/api/other-metrics/index.ts
+++ b/common-util/api/other-metrics/index.ts
@@ -4,6 +4,7 @@ import { fetchGovernMetrics } from './govern';
 import { fetchProtocolMetrics } from './protocol';
 import { fetchOlasTotalSupplyWei } from './token-supply';
 import { fetchTokenHolders } from './token-holders';
+import { fetchTokenomicsMetrics } from './tokenomics';
 
 export type OtherMetricsData = {
   build: Awaited<ReturnType<typeof fetchBuildMetrics>>;
@@ -12,6 +13,7 @@ export type OtherMetricsData = {
   tokenHolders: Awaited<ReturnType<typeof fetchTokenHolders>>;
   protocol: Awaited<ReturnType<typeof fetchProtocolMetrics>>;
   olasTotalSupplyWei: Awaited<ReturnType<typeof fetchOlasTotalSupplyWei>>;
+  tokenomics: Awaited<ReturnType<typeof fetchTokenomicsMetrics>>;
 };
 
 export type OtherMetricsSnapshot = {
@@ -20,16 +22,16 @@ export type OtherMetricsSnapshot = {
 };
 
 export const fetchAllOtherMetrics = async (): Promise<OtherMetricsSnapshot> => {
-  const [build, contribute, govern, tokenHolders, protocol, olasTotalSupplyWei] = await Promise.all(
-    [
+  const [build, contribute, govern, tokenHolders, protocol, olasTotalSupplyWei, tokenomics] =
+    await Promise.all([
       fetchBuildMetrics(),
       fetchContributeMetrics(),
       fetchGovernMetrics(),
       fetchTokenHolders(),
       fetchProtocolMetrics(),
       fetchOlasTotalSupplyWei(),
-    ]
-  );
+      fetchTokenomicsMetrics(),
+    ]);
 
   return {
     data: {
@@ -39,6 +41,7 @@ export const fetchAllOtherMetrics = async (): Promise<OtherMetricsSnapshot> => {
       tokenHolders,
       protocol,
       olasTotalSupplyWei,
+      tokenomics,
     },
     timestamp: Date.now(),
   };

--- a/common-util/api/other-metrics/tokenomics.ts
+++ b/common-util/api/other-metrics/tokenomics.ts
@@ -1,0 +1,266 @@
+import { OLAS_API_URL, OLAS_SUPPLY_DISTRIBUTION_ADDRESSES } from 'common-util/constants';
+import { STAKING_GRAPH_CLIENTS, TOKENOMICS_GRAPH_CLIENTS } from 'common-util/graphql/client';
+import {
+  checkSubgraphLag,
+  createStaleStatus,
+  getChainBlockNumber,
+  getFetchErrorAndCreateStaleStatus,
+} from 'common-util/graphql/metric-utils';
+import { emissionsQuery, rewardUpdates } from 'common-util/graphql/queries';
+import { MetricWithStatus, WithMeta } from 'common-util/graphql/types';
+import { readOlasContract, readTokenomicsContract } from 'common-util/web3';
+import { isNil } from 'lodash';
+import { formatEther } from 'viem';
+
+// Years 0-12 of the max emission schedule shown on the /olas-token bar chart
+// (10y capped schedule + the first years of the 2%/yr tail).
+const INFLATION_YEARS = 13;
+
+type SupplyDistribution = {
+  totalSupplyWei: string;
+  veOlasWei: string;
+  daoWei: string;
+  valoryWei: string;
+  circulatingSupplyWei: string;
+};
+
+type EmissionSchedule = {
+  timeLaunch: number;
+  currentYear: number;
+  inflationForYear: (string | null)[];
+};
+
+type EpochDistribution = {
+  epoch: number;
+  split: {
+    staking: number;
+    bonders: number;
+    developers: number;
+  };
+};
+
+type SubgraphEpoch = {
+  id: string;
+  counter: number;
+  blockTimestamp: string;
+  availableDevIncentives: string;
+  devIncentivesTotalTopUp: string;
+  availableStakingIncentives: string;
+  totalStakingIncentives: string;
+  totalBondsClaimable: string;
+  totalBondsClaimed: string;
+};
+
+export type EmissionEpoch = SubgraphEpoch & {
+  totalClaimableStakingRewards: string;
+  totalClaimedStakingRewards: string;
+};
+
+type EmissionsResult = WithMeta<{ epoches?: SubgraphEpoch[] }>;
+type RewardUpdate = { id: string; amount: string; type: string };
+type RewardUpdatesResult = WithMeta<Record<string, RewardUpdate[]>>;
+
+const fetchSupplyDistribution = async (): Promise<MetricWithStatus<SupplyDistribution | null>> => {
+  try {
+    const [totalSupplyResponse, veOlas, dao, valory] = await Promise.all([
+      fetch(`${OLAS_API_URL}/total_supply`),
+      readOlasContract<bigint>('balanceOf', [OLAS_SUPPLY_DISTRIBUTION_ADDRESSES.veOlas]),
+      readOlasContract<bigint>('balanceOf', [OLAS_SUPPLY_DISTRIBUTION_ADDRESSES.dao]),
+      readOlasContract<bigint>('balanceOf', [OLAS_SUPPLY_DISTRIBUTION_ADDRESSES.valory]),
+    ]);
+
+    if (!totalSupplyResponse.ok) {
+      throw new Error(`OLAS total_supply HTTP ${totalSupplyResponse.status}`);
+    }
+    const json = (await totalSupplyResponse.json()) as {
+      data?: { totalSupply?: string | number };
+    };
+    const raw = json?.data?.totalSupply;
+    if (isNil(raw)) {
+      throw new Error('OLAS total_supply: missing data.totalSupply');
+    }
+
+    const totalSupply = BigInt(raw);
+    const circulatingSupply =
+      totalSupply > 0n ? totalSupply - (veOlas + dao + valory) : 0n;
+
+    return {
+      value: {
+        totalSupplyWei: String(totalSupply),
+        veOlasWei: String(veOlas),
+        daoWei: String(dao),
+        valoryWei: String(valory),
+        circulatingSupplyWei: String(circulatingSupply),
+      },
+      status: createStaleStatus({ indexingErrors: [], fetchErrors: [], laggingSubgraphs: [] }),
+    };
+  } catch (error) {
+    console.error('Error fetching OLAS supply distribution:', error);
+    return {
+      value: null,
+      status: getFetchErrorAndCreateStaleStatus('tokenomics:supply-distribution'),
+    };
+  }
+};
+
+const fetchEmissionSchedule = async (): Promise<MetricWithStatus<EmissionSchedule | null>> => {
+  try {
+    const [timeLaunch, currentYear, inflationForYear] = await Promise.all([
+      readTokenomicsContract<bigint>('timeLaunch'),
+      readTokenomicsContract<bigint>('currentYear'),
+      Promise.all(
+        Array.from({ length: INFLATION_YEARS }, (_, year) =>
+          readTokenomicsContract<bigint>('getActualInflationForYear', [year])
+            .then((result) => formatEther(BigInt(result)))
+            .catch((error) => {
+              console.error(`Error in getActualInflationForYear for year ${year}:`, error);
+              return null;
+            })
+        )
+      ),
+    ]);
+
+    return {
+      value: {
+        timeLaunch: Number(timeLaunch),
+        currentYear: Number(currentYear),
+        inflationForYear,
+      },
+      status: createStaleStatus({
+        indexingErrors: [],
+        fetchErrors: inflationForYear.some(isNil) ? ['tokenomics:inflation-for-year'] : [],
+        laggingSubgraphs: [],
+      }),
+    };
+  } catch (error) {
+    console.error('Error fetching OLAS emission schedule:', error);
+    return {
+      value: null,
+      status: getFetchErrorAndCreateStaleStatus('tokenomics:emission-schedule'),
+    };
+  }
+};
+
+const fetchEpochDistribution = async (): Promise<MetricWithStatus<EpochDistribution | null>> => {
+  try {
+    const epoch = await readTokenomicsContract<bigint>('epochCounter');
+
+    // A single named-tuple output (mapEpochTokenomics) decodes to an object keyed
+    // by struct field names; multiple outputs (mapEpochStakingPoints) decode to an
+    // array — index 3 is stakingFraction. See common-util/web3.ts.
+    const [tokenomicsPoints, stakingPoints] = await Promise.all([
+      readTokenomicsContract<{ maxBondFraction: number | bigint }>('mapEpochTokenomics', [epoch]),
+      readTokenomicsContract<Array<number | bigint>>('mapEpochStakingPoints', [epoch]),
+    ]);
+
+    const bonders = Number(tokenomicsPoints.maxBondFraction);
+    const staking = Number(stakingPoints[3]);
+    const developers = 100 - (staking + bonders);
+
+    return {
+      value: {
+        epoch: Number(epoch),
+        split: { staking, bonders, developers },
+      },
+      status: createStaleStatus({ indexingErrors: [], fetchErrors: [], laggingSubgraphs: [] }),
+    };
+  } catch (error) {
+    console.error('Error fetching OLAS epoch distribution:', error);
+    return {
+      value: null,
+      status: getFetchErrorAndCreateStaleStatus('tokenomics:epoch-distribution'),
+    };
+  }
+};
+
+const fetchEmissions = async (): Promise<MetricWithStatus<EmissionEpoch[] | null>> => {
+  const indexingErrors: string[] = [];
+  const fetchErrors: string[] = [];
+  const laggingSubgraphs: string[] = [];
+
+  try {
+    const [emissionsData, ethereumBlock] = await Promise.all([
+      TOKENOMICS_GRAPH_CLIENTS.ethereum.request(emissionsQuery) as Promise<EmissionsResult>,
+      getChainBlockNumber('ethereum'),
+    ]);
+
+    if (emissionsData._meta?.hasIndexingErrors) {
+      indexingErrors.push('emissions:tokenomics:ethereum');
+    }
+    if (checkSubgraphLag(ethereumBlock, emissionsData._meta?.block?.number, 'ethereum')) {
+      laggingSubgraphs.push('emissions:tokenomics:ethereum');
+    }
+
+    const epoches = emissionsData.epoches || [];
+    const query = rewardUpdates(epoches);
+
+    const stakingResults = await Promise.all(
+      Object.entries(STAKING_GRAPH_CLIENTS).map(async ([chain, client]) => {
+        try {
+          const [rewards, chainBlock] = await Promise.all([
+            client.request(query) as Promise<RewardUpdatesResult>,
+            getChainBlockNumber(chain),
+          ]);
+          if (rewards._meta?.hasIndexingErrors) {
+            indexingErrors.push(`emissions:staking:${chain}`);
+          }
+          if (checkSubgraphLag(chainBlock, rewards._meta?.block?.number, chain)) {
+            laggingSubgraphs.push(`emissions:staking:${chain}`);
+          }
+          return rewards;
+        } catch (error) {
+          console.error(`Error fetching reward updates from ${chain}:`, error);
+          fetchErrors.push(`emissions:staking:${chain}`);
+          return null;
+        }
+      })
+    );
+
+    const value = epoches.map((epoch) => {
+      let totalClaimableStakingRewards = 0n;
+      let totalClaimedStakingRewards = 0n;
+
+      stakingResults.forEach((rewards) => {
+        if (!rewards) return;
+        const epochRewards = rewards[`_${epoch.counter}`] || [];
+        epochRewards.forEach((item) => {
+          if (item.type === 'Claimable') {
+            totalClaimableStakingRewards += BigInt(item.amount);
+          } else if (item.type === 'Claimed') {
+            totalClaimedStakingRewards += BigInt(item.amount);
+          }
+        });
+      });
+
+      return {
+        ...epoch,
+        totalClaimableStakingRewards: String(totalClaimableStakingRewards),
+        totalClaimedStakingRewards: String(totalClaimedStakingRewards),
+      };
+    });
+
+    return {
+      value,
+      status: createStaleStatus({ indexingErrors, fetchErrors, laggingSubgraphs }),
+    };
+  } catch (error) {
+    console.error('Error fetching emissions data:', error);
+    return {
+      value: null,
+      status: getFetchErrorAndCreateStaleStatus('emissions:tokenomics:ethereum'),
+    };
+  }
+};
+
+export const fetchTokenomicsMetrics = async () => {
+  const [supplyDistribution, emissionSchedule, epochDistribution, emissions] = await Promise.all([
+    fetchSupplyDistribution(),
+    fetchEmissionSchedule(),
+    fetchEpochDistribution(),
+    fetchEmissions(),
+  ]);
+
+  return { supplyDistribution, emissionSchedule, epochDistribution, emissions };
+};
+
+export type TokenomicsMetrics = Awaited<ReturnType<typeof fetchTokenomicsMetrics>>;

--- a/common-util/constants.ts
+++ b/common-util/constants.ts
@@ -162,6 +162,14 @@ export const TELEGRAM_INVITE_URL = 'https://t.me/olaschat';
 export const COINGECKO_URL = 'https://www.coingecko.com';
 export const ETHERSCAN_URL = 'https://etherscan.io';
 
+// Ethereum addresses holding non-circulating OLAS, shown on the /olas-token
+// supply distribution pie chart. Keys match the ids in SupplyPieChart's DATA config.
+export const OLAS_SUPPLY_DISTRIBUTION_ADDRESSES = {
+  veOlas: '0x7e01A500805f8A52Fad229b3015AD130A332B7b3',
+  dao: '0x3C1fF68f5aa342D296d4DEe4Bb1cACCA912D95fE',
+  valory: '0x87cc0d34f6111c8A7A4Bdf758a9a715A3675f941',
+} as const;
+
 // Balancer pools used for on-chain OLAS USD pricing for Predict ROI.
 // - Gnosis: OLAS-WXDAI (WXDAI ≈ 1 USD)
 // - Polygon: OLAS-WMATIC (WMATIC -> USD conversion is done via Polygon POL/USD Chainlink feed)

--- a/common-util/graphql/queries.ts
+++ b/common-util/graphql/queries.ts
@@ -2,6 +2,12 @@ import { gql } from 'graphql-request';
 
 export const emissionsQuery = gql`
   {
+    _meta {
+      hasIndexingErrors
+      block {
+        number
+      }
+    }
     epoches(orderBy: startBlock) {
       id
       counter
@@ -29,6 +35,12 @@ export const balancerGetPoolQuery = (poolId: string) => gql`
 
 export const rewardUpdates = (epochs) => gql`
   query RewardUpdates {
+    _meta {
+      hasIndexingErrors
+      block {
+        number
+      }
+    }
     ${epochs.map(
       (epoch, index) => `
         _${epoch.counter}: rewardUpdates(

--- a/common-util/snapshot-storage.ts
+++ b/common-util/snapshot-storage.ts
@@ -8,7 +8,7 @@ import { isMetricWithStatus, MetricWithStatus } from 'common-util/graphql/types'
 import { isNil, isPlainObject } from 'lodash';
 
 // Update this prefix when making breaking changes to the metrics schema.
-const METRICS_PREFIX = `metrics-${process.env.NODE_ENV}`;
+const METRICS_PREFIX = `metrics-${process.env.NODE_ENV}-20260708`;
 const CONTENT_TYPE = 'application/json';
 
 const getSnapshotFilename = (category: string) => `${METRICS_PREFIX}-${category}.json`;

--- a/common-util/web3.ts
+++ b/common-util/web3.ts
@@ -3,7 +3,9 @@ import { mainnet } from 'viem/chains';
 import olasAbi from '../data/ABIs/Olas.json';
 import tokenomicsAbi from '../data/ABIs/Tokenomics.json';
 
-const ETHEREUM_RPC = 'https://ethereum-rpc.publicnode.com';
+// Contract reads only run server-side (snapshot builders / cron), so the
+// server-only ETHEREUM_RPC env var is preferred; the public node is a fallback.
+const ETHEREUM_RPC = process.env.ETHEREUM_RPC || 'https://ethereum-rpc.publicnode.com';
 
 export const olasAddress: `0x${string}` = '0x0001A500A6B18995B03f44bb040A5fFc28E45CB0';
 export const tokenomicsAddress: `0x${string}` = '0xc096362fa6f4A4B1a9ea68b1043416f3381ce300';

--- a/components/OlasTokenPage/EmissionScheduleChart.tsx
+++ b/components/OlasTokenPage/EmissionScheduleChart.tsx
@@ -42,7 +42,7 @@ const OlasMintInfo = () => (
 );
 
 type EmissionScheduleChartProps = {
-  inflationForYear?: string[];
+  inflationForYear?: (string | null)[];
   timeLaunch?: unknown;
   currentYear?: unknown;
   loading: boolean;

--- a/components/OlasTokenPage/SupplyPieChart.tsx
+++ b/components/OlasTokenPage/SupplyPieChart.tsx
@@ -1,57 +1,58 @@
 import { ArcElement, Chart } from 'chart.js';
-import { COINGECKO_URL, ETHERSCAN_URL } from 'common-util/constants';
-import { olasAddress, readOlasContract } from 'common-util/web3';
+import {
+  COINGECKO_URL,
+  ETHERSCAN_URL,
+  OLAS_SUPPLY_DISTRIBUTION_ADDRESSES,
+} from 'common-util/constants';
+import { MetricWithStatus } from 'common-util/graphql/types';
+import { olasAddress } from 'common-util/web3';
 import { Popover } from 'components/ui/popover';
+import { StaleIndicator } from 'components/ui/StaleIndicator';
 import { ExternalLink } from 'components/ui/typography';
+import { isNil } from 'lodash';
 import PropTypes from 'prop-types';
-import { useEffect, useState } from 'react';
 import { Pie } from 'react-chartjs-2';
 import Verify from '../Verify';
 
 // manually register arc element – required due to chart.js tree shaking
 Chart.register(ArcElement);
 
-const daoAddress = '0x3C1fF68f5aa342D296d4DEe4Bb1cACCA912D95fE';
-const veOlasAddress = '0x7e01A500805f8A52Fad229b3015AD130A332B7b3';
-const valoryAddress = '0x87cc0d34f6111c8A7A4Bdf758a9a715A3675f941';
-
 const DATA = [
   {
     id: 'veOlas',
     label: 'veOLAS (vote escrow)',
-    address: veOlasAddress,
+    address: OLAS_SUPPLY_DISTRIBUTION_ADDRESSES.veOlas,
+    weiKey: 'veOlasWei',
     tailwindColor: 'bg-purple-500',
     rgbColor: '#A755F7',
   },
   {
     id: 'dao',
     label: 'DAO Treasury',
-    address: daoAddress,
+    address: OLAS_SUPPLY_DISTRIBUTION_ADDRESSES.dao,
+    weiKey: 'daoWei',
     tailwindColor: 'bg-pink-500',
     rgbColor: '#E964C4',
   },
   {
     id: 'valory',
     label: 'Valory (core contributor)',
-    address: valoryAddress,
+    address: OLAS_SUPPLY_DISTRIBUTION_ADDRESSES.valory,
+    weiKey: 'valoryWei',
     tailwindColor: 'bg-green-400',
     rgbColor: '#3FE681',
   },
   {
     id: 'circulatingSupply',
     label: 'Circulating supply',
+    weiKey: 'circulatingSupplyWei',
     tailwindColor: 'bg-cyan-500',
     rgbColor: '#09B4D7',
   },
 ];
 
-const IDS = DATA.map((item) => item.id);
 const LABELS = DATA.map((item) => item.label);
-const ADDRESSES = DATA.map((item) => item.address).filter(Boolean);
-const TAILWIND_COLORS = DATA.map((item) => item.tailwindColor);
 const RGB_COLORS = DATA.map((item) => item.rgbColor);
-
-const CIRCULATING_SUPPLY_INDEX = DATA.findIndex((item) => item.id === 'circulatingSupply');
 
 function getAddressPrefix(address) {
   return address.slice(0, 6);
@@ -126,88 +127,37 @@ function formatNumber(number) {
   return number.toLocaleString();
 }
 
-function formatEthers(value) {
-  const weiValue = value;
+function formatEthers(value: bigint) {
   const divisor = 1000000000000000000n;
-  const etherValue = weiValue / divisor;
-  return Number(etherValue);
+  return Number(value / divisor);
 }
 
-export const SupplyPieChart = () => {
-  const [data, setData] = useState<
-    Array<{
-      id: string;
-      label: string;
-      address?: string;
-      color: string;
-      value: number;
-    }>
-  >([]);
-  const [totalSupply, setTotalSupply] = useState<number | undefined>(undefined);
-  const [loading, setLoading] = useState(true);
+type SupplyDistributionValue = {
+  totalSupplyWei: string;
+  veOlasWei: string;
+  daoWei: string;
+  valoryWei: string;
+  circulatingSupplyWei: string;
+};
 
-  useEffect(() => {
-    const fetchData = async () => {
-      try {
-        const promises = [
-          fetch('/api/olas/total_supply'),
-          ...ADDRESSES.map((address) => readOlasContract('balanceOf', [address])),
-        ];
+type SupplyPieChartProps = {
+  supplyDistribution?: MetricWithStatus<SupplyDistributionValue | null>;
+};
 
-        const result = await Promise.allSettled(promises);
+export const SupplyPieChart = ({ supplyDistribution }: SupplyPieChartProps) => {
+  const distribution = supplyDistribution?.value;
+  const status = supplyDistribution?.status;
+  const loading = isNil(distribution);
 
-        const firstResult = result[0];
-        if (firstResult.status !== 'fulfilled') {
-          throw new Error('Failed to fetch total supply');
-        }
-        const response = firstResult.value as Response;
-        const totalSupplyResult = (await response.json()) as {
-          data: { totalSupply: string | number };
-        };
+  const data = loading
+    ? []
+    : DATA.map((item) => ({
+        ...item,
+        color: item.tailwindColor,
+        value: formatEthers(BigInt(distribution[item.weiKey] ?? 0)),
+      }));
 
-        const totalSupply = BigInt(totalSupplyResult.data.totalSupply);
-        const distributions = result.slice(1, result.length).map((item) => {
-          if (item.status === 'fulfilled') {
-            const value = item.value as unknown;
-            if (typeof value === 'bigint') {
-              return value;
-            }
-            if (typeof value === 'string' || typeof value === 'number') {
-              return BigInt(String(value));
-            }
-          }
-          return 0n;
-        });
-
-        const circulatingSupply =
-          totalSupply > 0 ? totalSupply - distributions.reduce((sum, item) => sum + item, 0n) : 0n;
-
-        setTotalSupply(formatEthers(totalSupply));
-        setData([
-          ...distributions.map((item, index) => ({
-            id: IDS[index],
-            label: LABELS[index],
-            address: ADDRESSES[index],
-            color: TAILWIND_COLORS[index],
-            value: formatEthers(item),
-          })),
-          {
-            id: IDS[CIRCULATING_SUPPLY_INDEX],
-            label: LABELS[CIRCULATING_SUPPLY_INDEX],
-            color: TAILWIND_COLORS[CIRCULATING_SUPPLY_INDEX],
-            value: formatEthers(circulatingSupply),
-          },
-        ]);
-
-        setLoading(false);
-      } catch (error) {
-        console.error('Error fetching data:', error);
-      }
-    };
-
-    fetchData();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  const totalSupply = loading ? undefined : formatEthers(BigInt(distribution.totalSupplyWei));
 
   return (
     <>
@@ -216,8 +166,11 @@ export const SupplyPieChart = () => {
           <h2 className="text-sm text-slate-500 font-bold tracking-widest uppercase">
             Total Supply
           </h2>
-          <div className="text-gradient text-4xl font-extrabold">
-            {loading ? '--' : formatNumber(totalSupply)}
+          <div className="flex items-center gap-2">
+            <div className="text-gradient text-4xl font-extrabold">
+              {loading ? '--' : formatNumber(totalSupply)}
+            </div>
+            <StaleIndicator status={status} />
           </div>
           <div className="mb-4">
             <Popover
@@ -234,8 +187,13 @@ export const SupplyPieChart = () => {
           <h2 className="text-sm text-slate-500 font-bold tracking-widest uppercase">
             Circulating Supply
           </h2>
-          <div className="text-gradient text-4xl font-extrabold">
-            {loading ? '--' : formatNumber(data[data.length - 1].value)}
+          <div className="flex items-center gap-2">
+            <div className="text-gradient text-4xl font-extrabold">
+              {loading
+                ? '--'
+                : formatNumber(formatEthers(BigInt(distribution.circulatingSupplyWei)))}
+            </div>
+            <StaleIndicator status={status} />
           </div>
           <div className="mb-4">
             <Verify url={`${COINGECKO_URL}/en/coins/autonolas`} />

--- a/components/OlasTokenPage/TokenomicsSummaryTable.tsx
+++ b/components/OlasTokenPage/TokenomicsSummaryTable.tsx
@@ -1,0 +1,81 @@
+import { formatEthNumber, formatWeiNumber } from 'common-util/numberFormatter';
+import { isNil } from 'lodash';
+
+// Full (non-compact) numbers so the values are unambiguous when read as text.
+const FULL_NUMBER: Intl.NumberFormatOptions = {
+  notation: 'standard',
+  maximumFractionDigits: 0,
+};
+
+const SUPPLY_ROWS = [
+  { label: 'Total supply', key: 'totalSupplyWei' },
+  { label: 'Circulating supply', key: 'circulatingSupplyWei' },
+  { label: 'veOLAS (vote escrow)', key: 'veOlasWei' },
+  { label: 'DAO treasury', key: 'daoWei' },
+  { label: 'Valory (core contributor)', key: 'valoryWei' },
+];
+
+/**
+ * Screen-reader-only semantic tables mirroring the tokenomics charts, so the
+ * key numbers exist as plain DOM text (the charts render to <canvas>, which
+ * is invisible to fetchers, crawlers, and assistive technology).
+ */
+export const TokenomicsSummaryTable = ({ tokenomics }) => {
+  const supply = tokenomics?.supplyDistribution?.value;
+  const schedule = tokenomics?.emissionSchedule?.value;
+  const epochDistribution = tokenomics?.epochDistribution?.value;
+
+  if (!supply && !schedule && !epochDistribution) return null;
+
+  return (
+    <section aria-label="OLAS tokenomics summary" className="sr-only">
+      {supply && (
+        <table>
+          <caption>OLAS supply</caption>
+          <tbody>
+            {SUPPLY_ROWS.map(({ label, key }) => (
+              <tr key={key}>
+                <th scope="row">{label}</th>
+                <td>{formatWeiNumber(supply[key], FULL_NUMBER)} OLAS</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+      {epochDistribution && (
+        <table>
+          <caption>{`Current emission split (epoch ${epochDistribution.epoch})`}</caption>
+          <tbody>
+            <tr>
+              <th scope="row">Staking (operators)</th>
+              <td>{epochDistribution.split.staking}%</td>
+            </tr>
+            <tr>
+              <th scope="row">Bonders</th>
+              <td>{epochDistribution.split.bonders}%</td>
+            </tr>
+            <tr>
+              <th scope="row">Developers (builders)</th>
+              <td>{epochDistribution.split.developers}%</td>
+            </tr>
+          </tbody>
+        </table>
+      )}
+      {schedule && (
+        <table>
+          <caption>{`Max emission schedule — annual inflation cap in OLAS (currently year ${schedule.currentYear})`}</caption>
+          <tbody>
+            {schedule.inflationForYear.map((inflation, year) => (
+              <tr key={year}>
+                <th scope="row">{`Year ${year}`}</th>
+                <td>
+                  {isNil(inflation) ? '—' : `${formatEthNumber(inflation, FULL_NUMBER)} OLAS`}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+    </section>
+  );
+};

--- a/components/OlasTokenPage/index.tsx
+++ b/components/OlasTokenPage/index.tsx
@@ -16,6 +16,7 @@ import { LearnMoreAboutTokenomics } from './LearnMoreAboutTokenomics';
 import { OlasProtocol } from './OlasProtocol';
 import { SupplyPieChart } from './SupplyPieChart';
 import { TokenDetails } from './TokenDetails';
+import { TokenomicsSummaryTable } from './TokenomicsSummaryTable';
 import { TokenHoldersMetric } from './TokenHoldersMetric';
 import { UsagePieChart } from './UsagePieChart';
 
@@ -38,6 +39,7 @@ const Supply = ({ metrics }) => {
     <div className="text-black border-b" id="supply">
       <SectionWrapper id="supply">
         <div className="text-5xl font-bold mb-16 tracking-tight text-black text-center">Supply</div>
+        <TokenomicsSummaryTable tokenomics={tokenomics} />
         <div className="flex-row lg:grid grid-cols-1 lg:grid-cols-2 gap-8">
           <div className="border rounded-lg mb-8 lg:mb-0">
             <div id="token-supply" />

--- a/components/OlasTokenPage/index.tsx
+++ b/components/OlasTokenPage/index.tsx
@@ -1,12 +1,8 @@
 import { BarElement, CategoryScale, Chart, LinearScale } from 'chart.js';
+import { isNil } from 'lodash';
 import Link from 'next/link';
-import { useEffect, useState } from 'react';
-import { formatEther } from 'viem';
 
 import { COINGECKO_URL, OLAS_API_URL } from 'common-util/constants';
-import { STAKING_GRAPH_CLIENTS, TOKENOMICS_GRAPH_CLIENTS } from 'common-util/graphql/client';
-import { emissionsQuery, rewardUpdates } from 'common-util/graphql/queries';
-import { readTokenomicsContract } from 'common-util/web3';
 import { GetInvolved } from 'components/OlasTokenPage/GetInvolved';
 import { ProtocolAudits } from 'components/ProtocolPage/ProtocolAudits';
 import SectionWrapper from '../Layout/SectionWrapper';
@@ -27,138 +23,16 @@ import { UsagePieChart } from './UsagePieChart';
 // and bar element – required due to chart.js tree shaking
 Chart.register(CategoryScale, LinearScale, BarElement);
 
-const Supply = () => {
-  const [epoch, setEpoch] = useState(null);
-  const [split, setSplit] = useState({});
-  const [timeLaunch, setTimeLaunch] = useState(null);
-  const [currentYear, setCurrentYear] = useState(null);
-  const [inflationForYear, setInflationForYear] = useState([]);
-  const [emissions, setEmissions] = useState([]);
-  const [loading, setLoading] = useState(false);
+const Supply = ({ metrics }) => {
+  const tokenomics = metrics?.tokenomics;
 
-  useEffect(() => {
-    const fetchData = async () => {
-      try {
-        setLoading(true);
+  const schedule = tokenomics?.emissionSchedule?.value;
+  const epochDistribution = tokenomics?.epochDistribution?.value;
+  const emissions = tokenomics?.emissions?.value ?? [];
 
-        const newTimeLaunch = await readTokenomicsContract('timeLaunch');
-        setTimeLaunch(newTimeLaunch);
-
-        // Call getActualInflationForYear method repeatedly for 0 through 12
-        const newInflationForYear = Array.from({ length: 12 }, () => null);
-        const promises = [];
-
-        for (let i = 0; i <= 12; i += 1) {
-          promises.push(
-            readTokenomicsContract('getActualInflationForYear', [i])
-              .then((result) => {
-                const resultValue = result as unknown;
-                if (
-                  typeof resultValue === 'string' ||
-                  typeof resultValue === 'number' ||
-                  typeof resultValue === 'bigint'
-                ) {
-                  newInflationForYear[i] = formatEther(BigInt(resultValue));
-                }
-                return result;
-              })
-              .catch((error) => {
-                newInflationForYear.push(undefined); // Push undefined if promise fails
-                console.error(`Error in getActualInflationForYear for year ${i}:`, error);
-              })
-          );
-        }
-
-        await Promise.all(promises);
-        setInflationForYear(newInflationForYear);
-
-        const newCurrentYear = await readTokenomicsContract('currentYear');
-        setCurrentYear(newCurrentYear);
-
-        // Call epochCounter to get the current epoch
-        const newEpoch = await readTokenomicsContract('epochCounter');
-        setEpoch(newEpoch);
-        // Use the result as the parameter for mapEpochTokenomics.
-        // A single named-tuple output decodes to an object keyed by struct field
-        // names; `maxBondFraction` is the bonders % value (index 6 in the struct).
-        const tokenomicsResult = await readTokenomicsContract<{
-          maxBondFraction: number | bigint;
-        }>('mapEpochTokenomics', [newEpoch]);
-        const bonders = Number(tokenomicsResult.maxBondFraction);
-
-        // staking — multiple outputs decode to an array; index 3 is stakingFraction
-        const stakingResult = await readTokenomicsContract<Array<number | bigint>>(
-          'mapEpochStakingPoints',
-          [newEpoch]
-        );
-        const staking = Number(stakingResult[3]);
-
-        // subtract bonders % from 100 to get developers %
-        const developers = 100 - (staking + bonders);
-        setSplit({
-          staking,
-          bonders,
-          developers,
-        });
-
-        // emissions
-        const emissionsData = (await TOKENOMICS_GRAPH_CLIENTS.ethereum?.request(
-          emissionsQuery
-        )) as {
-          epoches?: Array<{ counter?: number; [key: string]: unknown }>;
-        };
-
-        // Fetch rewards updates from all staking subgraphs
-        const stakingRewardsPromises = Object.entries(STAKING_GRAPH_CLIENTS).map(
-          async ([chain, client]) => {
-            try {
-              const rewards = await client.request(rewardUpdates(emissionsData.epoches || []));
-              return { chain, rewards };
-            } catch (error) {
-              console.error(`Error fetching rewards from ${chain}:`, error);
-              return { chain, rewards: null };
-            }
-          }
-        );
-
-        const stakingRewardsResults = await Promise.allSettled(stakingRewardsPromises);
-
-        const emissions = (emissionsData.epoches || []).map((epoch, index) => {
-          let totalClaimableStakingRewards = BigInt(0);
-          let totalClaimedStakingRewards = BigInt(0);
-
-          // Accumulate rewards from all chains
-          stakingRewardsResults.forEach((result) => {
-            if (result.status === 'fulfilled' && result.value.rewards) {
-              const epochRewards = result.value.rewards[`_${index + 1}`] || [];
-              totalClaimableStakingRewards += epochRewards.reduce(
-                (acc, item) => (item.type === 'Claimable' ? acc + BigInt(item.amount) : acc),
-                BigInt(0)
-              );
-              totalClaimedStakingRewards += epochRewards.reduce(
-                (acc, item) => (item.type === 'Claimed' ? acc + BigInt(item.amount) : acc),
-                BigInt(0)
-              );
-            }
-          });
-
-          return {
-            ...epoch,
-            totalClaimableStakingRewards,
-            totalClaimedStakingRewards,
-          };
-        });
-
-        setEmissions(emissions);
-      } catch (error) {
-        console.error('Error fetching data:', error);
-      } finally {
-        setLoading(false);
-      }
-    };
-
-    fetchData();
-  }, []);
+  const scheduleLoading = isNil(schedule);
+  const epochLoading = isNil(epochDistribution);
+  const emissionsLoading = isNil(tokenomics?.emissions?.value);
 
   return (
     <div className="text-black border-b" id="supply">
@@ -170,7 +44,7 @@ const Supply = () => {
             <div className="p-4 border-b">
               <h2 className="text-xl font-bold">Token Supply</h2>
             </div>
-            <SupplyPieChart />
+            <SupplyPieChart supplyDistribution={tokenomics?.supplyDistribution} />
           </div>
 
           <div id="max-emission-schedule" className="border rounded-lg mb-12 lg:mb-0 mb-8 lg:mb-0">
@@ -182,10 +56,10 @@ const Supply = () => {
               </p>
             </div>
             <EmissionScheduleChart
-              inflationForYear={inflationForYear}
-              timeLaunch={timeLaunch}
-              currentYear={currentYear}
-              loading={loading}
+              inflationForYear={schedule?.inflationForYear}
+              timeLaunch={schedule?.timeLaunch}
+              currentYear={schedule?.currentYear}
+              loading={scheduleLoading}
             />
           </div>
 
@@ -196,7 +70,11 @@ const Supply = () => {
               <p className="text-slate-500">What are newly minted tokens used for right now?</p>
             </div>
             <div className="p-4">
-              <UsagePieChart epoch={epoch} split={split} loading={loading} />
+              <UsagePieChart
+                epoch={epochDistribution?.epoch}
+                split={epochDistribution?.split ?? {}}
+                loading={epochLoading}
+              />
             </div>
           </div>
 
@@ -207,7 +85,7 @@ const Supply = () => {
               <p className="text-slate-500">What are the OLAS emissions per epoch</p>
             </div>
             <div className="p-4">
-              <ActualEmissionsChart emissions={emissions} loading={loading} />
+              <ActualEmissionsChart emissions={emissions} loading={emissionsLoading} />
             </div>
           </div>
 
@@ -216,7 +94,7 @@ const Supply = () => {
             <div className="p-4 border-b">
               <h2 className="text-xl mb-2 font-bold">Emissions to Builders</h2>
             </div>
-            <EmissionsToBuilders emissions={emissions} loading={loading} />
+            <EmissionsToBuilders emissions={emissions} loading={emissionsLoading} />
           </div>
 
           <div className="flex flex-col border rounded-lg mb-8 lg:mb-0">
@@ -224,7 +102,7 @@ const Supply = () => {
             <div className="p-4 border-b">
               <h2 className="text-xl mb-2 font-bold">Emissions to Bonders</h2>
             </div>
-            <EmissionsToBonders emissions={emissions} loading={loading} />
+            <EmissionsToBonders emissions={emissions} loading={emissionsLoading} />
           </div>
 
           <div className="flex flex-col border rounded-lg mb-8 lg:mb-0">
@@ -232,7 +110,7 @@ const Supply = () => {
             <div className="p-4 border-b">
               <h2 className="text-xl mb-2 font-bold">Emissions to Operators</h2>
             </div>
-            <EmissionsToOperators emissions={emissions} loading={loading} />
+            <EmissionsToOperators emissions={emissions} loading={emissionsLoading} />
           </div>
 
           <div className="flex flex-col col-span-2 border rounded-lg py-6 px-4">
@@ -300,7 +178,7 @@ const OlasToken = ({ metrics }) => (
   <>
     <Hero />
     <TokenHoldersMetric metrics={metrics} />
-    <Supply />
+    <Supply metrics={metrics} />
     <OlasProtocol />
     <GetInvolved />
     <TokenDetails />


### PR DESCRIPTION
## Summary

Makes all website metrics available server-side. The `/olas-token` page was the last one fetching metrics in the browser (supply pie chart + emissions charts via client-side contract reads and subgraph queries); those now come from the `other` snapshot (cron → Vercel Blob → `getStaticProps`), like every other metrics page.

**What this buys, by widget:**

- **Machine-readable numbers** — a new `sr-only` semantic `<table>` section (`TokenomicsSummaryTable`) renders the supply distribution, current epoch emission split, and the year-by-year max emission schedule as plain DOM text. The charts render to `<canvas>` (invisible to fetchers/crawlers/assistive tech); this table is what makes the page's key figures readable from raw HTML.
- **Perf/consistency** — the emissions series and schedule SSR removes ~30 per-visitor RPC/subgraph calls (previously every visitor hit the tokenomics contract 17× and 9 subgraphs from their browser), and gives these metrics the same staleness semantics (`mergeWithFallback`, `StaleIndicator`) as the rest of the site.

**Changes:**

- New `common-util/api/other-metrics/tokenomics.ts` builder with four `MetricWithStatus` fetchers: supply distribution (total/circulating supply + veOLAS/DAO/Valory balances), emission schedule (launch date, current year, inflation years 0–12), epoch distribution (epoch + staking/bonders/developers split), and cross-chain emissions (tokenomics epochs joined with `rewardUpdates` across all 8 staking subgraphs, with per-chain lag detection)
- New `TokenomicsSummaryTable` (sr-only) fed from the same snapshot props
- `_meta` added to `emissionsQuery` and `rewardUpdates` so staleness/lag tracking works (their only consumer was the client-side code being replaced)
- Reward buckets keyed by `_${epoch.counter}` to match the query aliases (previously looked up by `_${index + 1}`; verified against the production subgraph that counters are contiguous 1–44, so rendered output is unchanged)
- `SupplyPieChart` and the `Supply` section are now presentational, fed from snapshot props; stale indicators added to the headline supply numbers
- `web3.ts` prefers the server-only `ETHEREUM_RPC` env var (public node as fallback) since contract reads now only run in the cron
- `METRICS_PREFIX` bumped to `metrics-<env>-20260708` so the new schema writes to fresh blobs

## Rollout

The prefix bump means **all** snapshot categories start from empty blobs. Before relying on the preview/production pages, trigger each refresh endpoint once:

- `/api/refresh-metrics/main`
- `/api/refresh-metrics/predict`
- `/api/refresh-metrics/agent-economies`
- `/api/refresh-metrics/other`
- `/api/refresh-metrics/explorer`
- `/api/refresh-metrics/predict-roi-distribution?agent=omenstrat`
- `/api/refresh-metrics/predict-roi-distribution?agent=polystrat`
- `/api/refresh-metrics/predict-tool-accuracy`

Previews share the production blob store and prefix, so triggering these on the preview pre-populates the blobs production will read after merge. Clean up the old `metrics-production-*` blobs from the Vercel Blob dashboard after rollout.

## Behavior notes

- Emissions is all-or-nothing per refresh: if any staking subgraph is lagging/unreachable, the whole series is flagged stale and `mergeWithFallback` keeps the previous complete snapshot. This is a deliberate change from the old client behavior (which silently showed partial data with missing chains counted as zero) — a complete-but-≤6h-old series over a fresh-but-undercounted one.

## Test plan

- [x] `yarn lint` and `yarn build` pass
- [x] `/api/refresh-metrics/other` returns valid values locally (total supply ≈473.66M, circulating ≈223.3M, epoch 44, 75/25/0 split, 44 emission epochs) and writes to the new-prefix blob (`metrics-development-20260708-other.json`)
- [x] Updated queries verified against production subgraphs (gnosis staking returns ~1.93M OLAS claimable / ~1.80M claimed; epoch counters contiguous 1–44)
- [x] `/olas-token` renders all metrics in SSR HTML — no client-side fetches, no loading placeholders
- [x] `TokenomicsSummaryTable` values verified present as plain text in curl'd HTML (supply, split, 13 schedule years)
- [x] Graceful degradation verified: unreachable staking subgraphs produce `fetchErrors` + `stale` while keeping the value
- [ ] On preview: trigger all refresh endpoints above, confirm empty `fetchErrors` on `other`, compare `/olas-token` against production

🤖 Generated with [Claude Code](https://claude.com/claude-code)
