### PR TITLE
feat: mech-analytics fallback for incremental mech-request feed

### DIFF
--- a/common-util/api/predict/mech-analytics.ts
+++ b/common-util/api/predict/mech-analytics.ts
@@ -1,0 +1,127 @@
+/**
+ * mech-analytics client for the mech-request incremental fetch.
+ *
+ * Off-chain migration context: mech requests are moving off-chain,
+ * which stops the marketplace subgraph from creating individual
+ * `Request` / `ParsedRequest` entities for post-switch requests. The
+ * blob-backed `additions[questionTitle][agentId] = [ts, ...]` map
+ * built by `fetchIncrementalMechRequests` in `roi-distribution.ts`
+ * relies on those entities for `question_title`, and it goes empty
+ * for off-chain activity if we keep reading the subgraph.
+ *
+ * mech-analytics is the new public read path for that data. It reads
+ * from the predict-api data lake (which continues to accumulate
+ * off-chain requests via a private write path) and exposes
+ * `/v1/data/scored-rows` — one row per scored mech request with
+ * `requester`, `requested_at`, `question_title` on it. This module
+ * pages that endpoint and returns rows in the same shape the caller
+ * expects.
+ *
+ * Everything downstream of `fetchIncrementalMechRequests` (the
+ * `openQmr` map, `normalizeTitle` matching, `settledMechRequests =
+ * senderTotal - openRequestCount` computation in `fetchAllTimeAgents`)
+ * stays exactly as-is — mech-analytics only replaces the subgraph
+ * call inside `fetchIncrementalMechRequests`, nothing else.
+ */
+
+const MECH_ANALYTICS_URL = process.env.MECH_ANALYTICS_URL;
+const CHAIN_ID_BY_KEY: Record<'gnosis' | 'polygon', number> = {
+  gnosis: 100,
+  polygon: 137,
+};
+const PAGE_SIZE = 5000; // matches the endpoint's DEFAULT_LIMIT
+
+/** Shape returned by `/v1/data/scored-rows`. Only the fields the mech-request
+ *  path uses are named — the endpoint returns more, and extras are ignored. */
+type ScoredRow = {
+  request_id: string;
+  requester: string | null;
+  requested_at: string; // ISO 8601, timezone-aware
+  question_title: string | null;
+  // ...plus fields the caller does not use (tool, platform, brier, etc.)
+};
+
+type ScoredRowsPage = {
+  rows: ScoredRow[];
+  next_cursor: string | null;
+};
+
+/**
+ * Page mech-analytics for mech requests newer than `lastTimestamp`.
+ *
+ * Returns the same shape as the marketplace-subgraph path so the
+ * downstream `fetchAllTimeAgents` needs no changes:
+ *   { additions: {[title]: {[agentId]: [ts, ...]}}, lastTimestamp, ok }
+ *
+ * `lastTimestamp` is a unix-seconds cutoff (matching the existing
+ * subgraph path's `blockTimestamp_gt`). Rows without a `requester`
+ * or a `question_title` are skipped (mirrors `roi-distribution.ts:241`).
+ *
+ * If MECH_ANALYTICS_URL is not set, returns `ok=false` so the caller
+ * can fall back to the subgraph path without partial data being merged.
+ */
+export const fetchIncrementalMechRequestsFromAnalytics = async (
+  chain: 'gnosis' | 'polygon',
+  lastTimestamp: number
+): Promise<{
+  additions: Record<string, Record<string, number[]>>;
+  lastTimestamp: number;
+  ok: boolean;
+}> => {
+  const additions: Record<string, Record<string, number[]>> = {};
+  let latestTs = lastTimestamp;
+
+  if (!MECH_ANALYTICS_URL) {
+    console.error('MECH_ANALYTICS_URL not set — cannot fetch mech-requests from mech-analytics');
+    return { additions, lastTimestamp: latestTs, ok: false };
+  }
+
+  const chainId = CHAIN_ID_BY_KEY[chain];
+  // `since` is an ISO 8601 timestamp on the endpoint; convert from unix seconds.
+  // Use `> lastTimestamp` semantics (the subgraph path uses `blockTimestamp_gt`)
+  // by adding 1 second — the endpoint's `since` filter is `>=`.
+  const since = new Date((lastTimestamp + 1) * 1000).toISOString();
+
+  let cursor: string | null = null;
+  while (true) {
+    const url = new URL(`${MECH_ANALYTICS_URL.replace(/\/$/, '')}/v1/data/scored-rows`);
+    url.searchParams.set('chain_id', String(chainId));
+    url.searchParams.set('since', since);
+    url.searchParams.set('limit', String(PAGE_SIZE));
+    if (cursor) url.searchParams.set('cursor', cursor);
+
+    let page: ScoredRowsPage;
+    try {
+      const response = await fetch(url.toString());
+      if (!response.ok) {
+        console.error(
+          `mech-analytics /v1/data/scored-rows returned ${response.status} for ${chain}`
+        );
+        return { additions, lastTimestamp: latestTs, ok: false };
+      }
+      page = (await response.json()) as ScoredRowsPage;
+    } catch (e) {
+      console.error(`Error fetching mech-analytics scored-rows for ${chain}`, e);
+      // Partial additions are safe to keep: latestTs only reflects rows actually
+      // fetched, so the next run resumes from there. Report the failure so it
+      // isn't invisible. Matches the subgraph path's error semantics.
+      return { additions, lastTimestamp: latestTs, ok: false };
+    }
+
+    for (const row of page.rows) {
+      const agentId = row.requester?.toLowerCase();
+      const questionTitle = row.question_title;
+      const ts = Math.floor(new Date(row.requested_at).getTime() / 1000);
+      if (!agentId || !questionTitle || !Number.isFinite(ts) || ts <= 0) continue;
+      if (!additions[questionTitle]) additions[questionTitle] = {};
+      if (!additions[questionTitle][agentId]) additions[questionTitle][agentId] = [];
+      additions[questionTitle][agentId].push(ts);
+      if (ts > latestTs) latestTs = ts;
+    }
+
+    if (!page.next_cursor) break;
+    cursor = page.next_cursor;
+  }
+
+  return { additions, lastTimestamp: latestTs, ok: true };
+};

--- a/common-util/api/predict/roi-distribution.ts
+++ b/common-util/api/predict/roi-distribution.ts
@@ -14,6 +14,16 @@ import {
 } from 'common-util/graphql/queries';
 import { getMidnightUtcTimestampDaysAgo } from 'common-util/time';
 
+import { fetchIncrementalMechRequestsFromAnalytics } from './mech-analytics';
+
+// Off-chain migration feature flag. When 'true', the incremental
+// mech-request feed is pulled from mech-analytics instead of the
+// marketplace subgraph (which stops seeing individual off-chain
+// requests post-switch). Defaults off — flip in staging first, then
+// production once mech-analytics is caught up. See PR #11 on
+// valory-xyz/mech-analytics for the migration plan.
+const USE_MECH_ANALYTICS_MECH_REQUESTS = process.env.USE_MECH_ANALYTICS_MECH_REQUESTS === 'true';
+
 const LIMIT = 1000;
 // Process at most this many days per cron run to stay within timeout
 const MAX_DAYS_PER_RUN = 30;
@@ -221,6 +231,21 @@ const fetchIncrementalMechRequests = async (
   lastTimestamp: number;
   ok: boolean;
 }> => {
+  // Off-chain switch: post-switch, the marketplace subgraph stops
+  // creating individual Request / ParsedRequest entities for
+  // off-chain requests (only aggregate counters update, via
+  // MarketplaceDeliveryWithSignatures at settlement time). The
+  // per-request title-keyed feed this function builds goes empty
+  // for off-chain activity if we keep reading the subgraph. The
+  // flag routes the read through mech-analytics's data lake, which
+  // continues to accumulate off-chain requests via a private write
+  // path. Downstream (`fetchAllTimeAgents`, `openQmr`,
+  // `normalizeTitle`, `settledMechRequests` computation) is
+  // shape-compatible and unchanged.
+  if (USE_MECH_ANALYTICS_MECH_REQUESTS) {
+    return fetchIncrementalMechRequestsFromAnalytics(chain, lastTimestamp);
+  }
+
   // FIX-1: additions now stores timestamps per (title, agentId), not just counts.
   const additions: Record<string, Record<string, number[]>> = {};
   let latestTs = lastTimestamp;
@@ -449,7 +474,10 @@ const updateAgentBlueprintData = async (
     additions,
     lastTimestamp: newMechTs,
     ok: mechRequestsOk,
-  } = await fetchIncrementalMechRequests(chain, existingQmr?.lastMechRequestTimestamp ?? mechGenesisTs);
+  } = await fetchIncrementalMechRequests(
+    chain,
+    existingQmr?.lastMechRequestTimestamp ?? mechGenesisTs
+  );
   if (!mechRequestsOk) runFetchErrors.push('mech-requests');
   for (const [title, agentLists] of Object.entries(additions)) {
     if (!qmr[title]) qmr[title] = {};


### PR DESCRIPTION
## Summary

Off-chain migration prep for Partial ROI's mech-request cost side.

Mech requests are moving off-chain. Post-switch, the mech marketplace subgraph stops creating individual `Request` / `ParsedRequest` entities for off-chain requests — only aggregate counters keep updating, via `MarketplaceDeliveryWithSignatures` at settlement time. The blob-backed `additions[questionTitle][agentId]` map built by `fetchIncrementalMechRequests` relies on those entities for `question_title`, so it goes empty for off-chain activity if we keep reading the subgraph. Downstream `settledMechRequests = senderTotal - openRequestCount` then equals the full `senderTotal` and Partial ROI's mech-request cost side ends up overstated.

Adds a mech-analytics fallback path behind a feature flag, default off, current behavior unchanged.

## Changes

- **New file** `common-util/api/predict/mech-analytics.ts` — pages mech-analytics's `/v1/data/scored-rows?since=<X>&chain_id=<Y>` and returns the same `{ additions, lastTimestamp, ok }` shape as the subgraph path
- **`common-util/api/predict/roi-distribution.ts`** — feature flag routes `fetchIncrementalMechRequests` through the new helper when `USE_MECH_ANALYTICS_MECH_REQUESTS=true`. Subgraph path unchanged when off
- **Env vars added:**
  - `MECH_ANALYTICS_URL` — mech-analytics API base URL
  - `USE_MECH_ANALYTICS_MECH_REQUESTS` — feature flag, defaults `false`

## What DOESN'T change

- `senderTotal` reads stay on the marketplace subgraph — aggregate counter, unaffected by the off-chain switch
- Trade data (`totalTraded`, `totalFees`, `totalPayout`) stays on predict-agents subgraph
- DAA, APR, Accuracy, tx breakdowns, Total ROI staking composition all stay on current sources
- `fetchAllTimeAgents`, `openQmr` map, `normalizeTitle` matching, `settledMechRequests` computation — untouched. The helper returns the same shape so downstream needs no changes.

## Rollout

1. Merge with `USE_MECH_ANALYTICS_MECH_REQUESTS` off — production behavior unchanged
2. Flip in staging once mech-analytics is caught up
3. Verify pre-switch that `fetchIncrementalMechRequests` returns matching output (same title/agent count shape) from both paths for the same window
4. Flip in production after Day M

## References

- Migration plan: valory-xyz/mech-analytics#11
- mech-analytics `/v1/data/scored-rows` design: valory-xyz/mech-analytics#9 (merged)
- Off-chain settlement mechanism (`MarketplaceDeliveryWithSignatures`): `contracts/MechMarketplace.sol:209` on autonolas-marketplace
- Subgraph handler that keeps aggregate counters alive post-switch: `autonolas-subgraph/subgraphs/marketplace/src/marketplace/mech-marketplace.ts:280-320`

## Test plan

- [x] Lint clean on changed files (2 pre-existing `no-console` warnings on unchanged lines only)
- [ ] Flag-off path: displayed Partial ROI number matches current production (no code change on that path)
- [ ] Flag-on path in staging: helper returns rows in the expected shape; downstream `openRequestCount` per agent matches subgraph-path count for the same window pre-switch
- [ ] Missing `MECH_ANALYTICS_URL` with flag on: helper returns `ok=false`, blob doesn't advance past unfetched rows