### PR TITLE
Add mech-analytics parity verification script (feed-swap gate)

### DIFF
--- a/.github/workflows/publish-verify-image.yaml
+++ b/.github/workflows/publish-verify-image.yaml
@@ -6,13 +6,15 @@ name: Publish verify image
 # scripts/verify-mech-analytics-parity.mjs).
 #
 # * On release: builds AND pushes tagged image to Docker Hub.
-# * On PR touching Dockerfile.verify, the verify script, the workflow,
-#   or the deps that end up in the image: builds only (no push, no
-#   credentials needed — safe on fork PRs) and runs ``--help`` against
-#   the built image so the entry point wiring is exercised end-to-end.
-#   Prevents shipping a broken Dockerfile (chown ordering, module
-#   resolution, deps drift) whose only signal otherwise is "infra tries
-#   to run it and it crashes".
+# * On PR touching Dockerfile.verify, the verify script, or the
+#   workflow: builds only (no push, no credentials needed — safe on
+#   fork PRs) and runs ``--help`` against the built image so the entry
+#   point wiring is exercised end-to-end. Prevents shipping a broken
+#   Dockerfile (chown ordering, entrypoint wiring) whose only signal
+#   otherwise is "infra tries to run it and it crashes". The image
+#   installs no npm dependencies (the script is node built-ins only),
+#   so package.json / yarn.lock changes cannot affect it and are not
+#   triggers.
 
 on:
   release:
@@ -21,9 +23,6 @@ on:
     paths:
       - 'Dockerfile.verify'
       - 'scripts/verify-mech-analytics-parity.mjs'
-      - 'package.json'
-      - 'yarn.lock'
-      - '.yarnrc'
       - '.github/workflows/publish-verify-image.yaml'
 
 # Least-privilege default for GITHUB_TOKEN (same discipline as main.yml):

--- a/.github/workflows/publish-verify-image.yaml
+++ b/.github/workflows/publish-verify-image.yaml
@@ -1,0 +1,102 @@
+name: Publish verify image
+
+# Builds and pushes valory/olas-website-verify — the image infra runs as
+# a K8s Job for the predict-page / mech-analytics parity verification
+# (Dockerfile.verify, entry point is
+# scripts/verify-mech-analytics-parity.mjs).
+#
+# * On release: builds AND pushes tagged image to Docker Hub.
+# * On PR touching Dockerfile.verify, the verify script, the workflow,
+#   or the deps that end up in the image: builds only (no push, no
+#   credentials needed — safe on fork PRs) and runs ``--help`` against
+#   the built image so the entry point wiring is exercised end-to-end.
+#   Prevents shipping a broken Dockerfile (chown ordering, module
+#   resolution, deps drift) whose only signal otherwise is "infra tries
+#   to run it and it crashes".
+
+on:
+  release:
+    types: [prereleased, released]
+  pull_request:
+    paths:
+      - 'Dockerfile.verify'
+      - 'scripts/verify-mech-analytics-parity.mjs'
+      - 'package.json'
+      - 'yarn.lock'
+      - '.yarnrc'
+      - '.github/workflows/publish-verify-image.yaml'
+
+# Least-privilege default for GITHUB_TOKEN (same discipline as main.yml):
+# both jobs only need to read the repo. Docker Hub pushes authenticate
+# with repo secrets, not GITHUB_TOKEN.
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    if: github.event_name == 'release'
+    runs-on: ubuntu-latest
+    env:
+      IMAGE: valory/olas-website-verify
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Compute image tag
+        id: tag
+        run: |
+          tag="${GITHUB_REF_NAME#v}"
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+          echo "Computed tag: $tag"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+        with:
+          username: ${{ secrets.DOCKER_USER }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Build and push
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
+        with:
+          context: .
+          file: Dockerfile.verify
+          push: true
+          tags: ${{ env.IMAGE }}:${{ steps.tag.outputs.tag }}
+          # Bake the source commit into the image so the verify script's
+          # metadata header can attribute each artifact to a specific
+          # revision without needing git inside the runtime image.
+          build-args: |
+            GIT_SHA=${{ github.sha }}
+
+  build-only:
+    # PR-triggered smoke build — no registry push, no secrets required,
+    # so it runs safely on fork PRs. Load the image into the local
+    # Docker daemon and invoke ``--help`` to catch any regression in
+    # Dockerfile layer ordering, dependency install, or entrypoint that
+    # would otherwise only surface when infra tries to run the released
+    # tag.
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    env:
+      IMAGE: valory/olas-website-verify:pr-${{ github.event.pull_request.number }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+
+      - name: Build (no push)
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
+        with:
+          context: .
+          file: Dockerfile.verify
+          push: false
+          load: true
+          tags: ${{ env.IMAGE }}
+          build-args: |
+            GIT_SHA=${{ github.sha }}
+
+      - name: Smoke-test entrypoint
+        run: docker run --rm ${{ env.IMAGE }} --help

--- a/Dockerfile.verify
+++ b/Dockerfile.verify
@@ -1,0 +1,70 @@
+# syntax=docker/dockerfile:1
+#
+# Image for the olas-website / mech-analytics parity verification script
+# (scripts/verify-mech-analytics-parity.mjs). Used by infra as a K8s Job
+# during the predict-page consumer migration to prove that the two
+# migrating fields (partialRoi, successRate) match between the Vercel
+# Blob snapshot visitors see today and the mech-analytics
+# /v1/metrics/ai-agent endpoints.
+#
+# Published on tag as valory/olas-website-verify:<version> via
+# .github/workflows/publish-verify-image.yaml.
+#
+# Runtime deps come from yarn.lock so the image is reproducible from any
+# commit. Only the parity script rides along — the Next.js app is not
+# built or shipped; the script imports @vercel/blob plus node built-ins.
+#
+# Runtime contract:
+#   * env: BLOB_READ_WRITE_TOKEN (secret), MECH_ANALYTICS_URL
+#   * mount: /reports for --output-dir report artifacts
+#   * exit codes: 0 pass, 1 unexpected error, 3 divergence, 4 missing field
+#
+# Base pinned to the repo's .nvmrc version (22.22.3).
+FROM node:22.22.3-slim AS base
+
+# Bake the source commit into the image at build time. The verify script
+# reads GIT_SHA from the env; without this the ``git rev-parse`` fallback
+# fires and every artifact attributes the run to ``unknown`` since the
+# image ships without a git binary and without a .git directory.
+ARG GIT_SHA=unknown
+ENV GIT_SHA=$GIT_SHA
+
+WORKDIR /app
+
+# Pin Yarn to the same version CI activates via Corepack (main.yml), and
+# prepare the runtime dirs. /reports is the --output-dir mount point
+# infra provides; the image itself only ever writes there, never to /app.
+#
+# The non-root ``node`` user (uid 1000) ships with the base image, so it
+# exists BEFORE the dependency install below — every layer from here on
+# is owned by ``node`` at build time and no recursive chown of the
+# (large) node_modules tree is needed at the end of the build.
+RUN corepack enable \
+    && corepack prepare yarn@1.22.22 --activate \
+    && mkdir -p /reports \
+    && chown node:node /app /reports
+USER node
+
+# Layer dep install ahead of source copy so a script edit doesn't
+# invalidate the (slow) dependency layer. .yarnrc carries the repo's
+# install-time defense (--install.ignore-scripts true); keep it so the
+# image install skips lifecycle scripts exactly like CI does.
+COPY --chown=node:node package.json yarn.lock .yarnrc ./
+
+# --production: the verifier needs runtime deps only (the script imports
+# @vercel/blob); eslint, tailwind, and the rest of devDependencies stay
+# out of the image.
+RUN yarn install --frozen-lockfile --production \
+    && yarn cache clean
+
+# Copy only what the script needs: the entry point itself. It imports
+# @vercel/blob (installed above) and node built-ins, nothing else from
+# the repo.
+COPY --chown=node:node \
+    scripts/verify-mech-analytics-parity.mjs \
+    ./scripts/verify-mech-analytics-parity.mjs
+
+# node_modules sits at /app/node_modules; plain ``node`` resolves
+# @vercel/blob from there. ``docker run --rm <image> --help`` exercises
+# the wiring without secrets.
+ENTRYPOINT ["node", "scripts/verify-mech-analytics-parity.mjs"]

--- a/Dockerfile.verify
+++ b/Dockerfile.verify
@@ -2,22 +2,30 @@
 #
 # Image for the olas-website / mech-analytics parity verification script
 # (scripts/verify-mech-analytics-parity.mjs). Used by infra as a K8s Job
-# during the predict-page consumer migration to prove that the two
-# migrating fields (partialRoi, successRate) match between the Vercel
-# Blob snapshot visitors see today and the mech-analytics
-# /v1/metrics/ai-agent endpoints.
+# during the predict-page consumer migration to gate the mech-request
+# count-source swap (mech-analytics docs/consumer_migration.md §4 /
+# §12 Q4): open-market count parity, scored-rows row parity, and
+# senderTotal parity between the marketplace/predict subgraphs and the
+# mech-analytics endpoints.
 #
 # Published on tag as valory/olas-website-verify:<version> via
 # .github/workflows/publish-verify-image.yaml.
 #
-# Runtime deps come from yarn.lock so the image is reproducible from any
-# commit. Only the parity script rides along — the Next.js app is not
-# built or shipped; the script imports @vercel/blob plus node built-ins.
+# The script uses node built-ins only (fetch, fs, util) — no yarn
+# install, no node_modules. The image is the pinned node base plus the
+# one script file.
 #
 # Runtime contract:
-#   * env: BLOB_READ_WRITE_TOKEN (secret), MECH_ANALYTICS_URL
+#   * env: MECH_ANALYTICS_URL, plus the subgraph URLs (all secrets —
+#     they embed Graph gateway API keys; the script logs presence only,
+#     never the values):
+#       NEXT_PUBLIC_GNOSIS_MARKETPLACE_SUBGRAPH_URL
+#       NEXT_PUBLIC_POLYGON_MARKETPLACE_SUBGRAPH_URL
+#       NEXT_PUBLIC_OLAS_PREDICT_AGENTS_SUBGRAPH_URL
+#       NEXT_PUBLIC_OLAS_POLYMARKET_AGENTS_SUBGRAPH_URL
 #   * mount: /reports for --output-dir report artifacts
-#   * exit codes: 0 pass, 1 unexpected error, 3 divergence, 4 missing field
+#   * exit codes: 0 pass, 1 unexpected error, 2 vacuous, 3 divergence,
+#     4 data gap
 #
 # Base pinned to the repo's .nvmrc version (22.22.3).
 FROM node:22.22.3-slim AS base
@@ -31,40 +39,19 @@ ENV GIT_SHA=$GIT_SHA
 
 WORKDIR /app
 
-# Pin Yarn to the same version CI activates via Corepack (main.yml), and
-# prepare the runtime dirs. /reports is the --output-dir mount point
-# infra provides; the image itself only ever writes there, never to /app.
-#
-# The non-root ``node`` user (uid 1000) ships with the base image, so it
-# exists BEFORE the dependency install below — every layer from here on
-# is owned by ``node`` at build time and no recursive chown of the
-# (large) node_modules tree is needed at the end of the build.
-RUN corepack enable \
-    && corepack prepare yarn@1.22.22 --activate \
-    && mkdir -p /reports \
+# /reports is the --output-dir mount point infra provides; the image
+# itself only ever writes there, never to /app. The non-root ``node``
+# user (uid 1000) ships with the base image.
+RUN mkdir -p /reports \
     && chown node:node /app /reports
 USER node
 
-# Layer dep install ahead of source copy so a script edit doesn't
-# invalidate the (slow) dependency layer. .yarnrc carries the repo's
-# install-time defense (--install.ignore-scripts true); keep it so the
-# image install skips lifecycle scripts exactly like CI does.
-COPY --chown=node:node package.json yarn.lock .yarnrc ./
-
-# --production: the verifier needs runtime deps only (the script imports
-# @vercel/blob); eslint, tailwind, and the rest of devDependencies stay
-# out of the image.
-RUN yarn install --frozen-lockfile --production \
-    && yarn cache clean
-
-# Copy only what the script needs: the entry point itself. It imports
-# @vercel/blob (installed above) and node built-ins, nothing else from
-# the repo.
+# The entry point is the only file the image needs from the repo — it
+# imports node built-ins exclusively.
 COPY --chown=node:node \
     scripts/verify-mech-analytics-parity.mjs \
     ./scripts/verify-mech-analytics-parity.mjs
 
-# node_modules sits at /app/node_modules; plain ``node`` resolves
-# @vercel/blob from there. ``docker run --rm <image> --help`` exercises
-# the wiring without secrets.
+# ``docker run --rm <image> --help`` exercises the wiring without
+# secrets; a no-env run exits 1 with an ERROR verdict.
 ENTRYPOINT ["node", "scripts/verify-mech-analytics-parity.mjs"]

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "audit:install-hooks": "node scripts/audit-install-hooks.mjs",
     "audit:install-hooks:update": "node scripts/audit-install-hooks.mjs --update",
     "license-check": "node scripts/license-check.mjs",
-    "license-check:test": "node --test scripts/license-check.test.mjs"
+    "license-check:test": "node --test scripts/license-check.test.mjs",
+    "verify-mech-analytics-parity": "node scripts/verify-mech-analytics-parity.mjs"
   },
   "dependencies": {
     "@fontsource/inter": "5.2.6",

--- a/scripts/verify-mech-analytics-parity.mjs
+++ b/scripts/verify-mech-analytics-parity.mjs
@@ -107,6 +107,15 @@ const LAG_BUFFER_MINUTES_DEFAULT = 30;
 // are otherwise compared exactly (checks 1 and 2 use zero tolerance).
 const COUNT_TOLERANCE_DEFAULT = 5;
 
+// Mech-analytics keeps a 24h finality gate on Omen: rows only flip to
+// `resolved` 24h after finalization (consumer_migration.md §6). The
+// subgraph's dailyProfitStatistics consumes a market as soon as the
+// day's stats record it, so markets resolved in the last ~24h are
+// consumed on the subgraph side but still `pending` in analytics.
+// Over a 4-day window that's a chronic delta that turns honest runs
+// red. Cap check-1 dailyStats consumption at (now - N h) to align.
+const FINALITY_LAG_HOURS_DEFAULT = 24;
+
 const DAY_SECONDS = 86400;
 const SUBGRAPH_PAGE = 1000;
 // graph-node rejects skip > 5000; a full page at that offset means the
@@ -158,6 +167,7 @@ const { values: args } = parseArgs({
     'output-dir': { type: 'string' },
     'window-days': { type: 'string' },
     'lag-buffer-minutes': { type: 'string' },
+    'finality-lag-hours': { type: 'string' },
     'count-tolerance': { type: 'string' },
     verbose: { type: 'boolean', short: 'v' },
     help: { type: 'boolean', short: 'h' },
@@ -186,6 +196,8 @@ if (args.help) {
       '  --mech-analytics-url <url>   mech-analytics base URL (or MECH_ANALYTICS_URL env)\n' +
       `  --window-days <n>            checks 1+2 window (default ${WINDOW_DAYS_DEFAULT})\n` +
       `  --lag-buffer-minutes <n>     near-edge trim for scoring lag (default ${LAG_BUFFER_MINUTES_DEFAULT})\n` +
+      `  --finality-lag-hours <n>     check 1 consumption cutoff for the analytics 24h\n` +
+      `                               finality gate (default ${FINALITY_LAG_HOURS_DEFAULT})\n` +
       `  --count-tolerance <n>        check 3 absolute tolerance (default ${COUNT_TOLERANCE_DEFAULT})\n` +
       '  --output-dir <dir>           write parity-<ts>.md/.json artifacts here\n' +
       '  -v, --verbose                log per-page fetch progress\n' +
@@ -234,6 +246,11 @@ const lagBufferMinutes = parseNonNegativeInt(
   args['lag-buffer-minutes'],
   'lag-buffer-minutes',
   LAG_BUFFER_MINUTES_DEFAULT
+);
+const finalityLagHours = parseNonNegativeInt(
+  args['finality-lag-hours'],
+  'finality-lag-hours',
+  FINALITY_LAG_HOURS_DEFAULT
 );
 const countTolerance = parseNonNegativeInt(
   args['count-tolerance'],
@@ -298,6 +315,7 @@ const metadata = {
   mech_analytics_url: safeOrigin(mechAnalyticsUrl),
   window_days: windowDays,
   lag_buffer_minutes: lagBufferMinutes,
+  finality_lag_hours: finalityLagHours,
   count_tolerance_abs: countTolerance,
 };
 
@@ -307,6 +325,7 @@ emit(`  script git SHA:       ${metadata.script_git_sha}`);
 emit(`  mech-analytics URL:   ${metadata.mech_analytics_url}`);
 emit(`  window (days):        ${metadata.window_days}`);
 emit(`  lag buffer (min):     ${metadata.lag_buffer_minutes}`);
+emit(`  finality lag (h):     ${metadata.finality_lag_hours} (check 1 only)`);
 emit(`  count tolerance (±):  ${metadata.count_tolerance_abs} (check 3 only)`);
 for (const name of REQUIRED_ENV.slice(1)) {
   // Presence only — the URLs embed API keys.
@@ -373,6 +392,7 @@ const fetchMarketplaceRequests = async (url, windowStartSec, windowEndSec, label
           orderBy: blockTimestamp
           orderDirection: asc
         ) {
+          id
           sender { id }
           blockTimestamp
           parsedRequest { questionTitle }
@@ -408,7 +428,15 @@ const fetchMarketplaceRequests = async (url, windowStartSec, windowEndSec, label
       skippedAfterWindowEnd += 1;
       continue;
     }
-    usable.push({ requester, ts, title });
+    // req.id is the marketplace subgraph's Request.id — same identifier
+    // the mech-analytics lake writes back as `request_id`, so check 2
+    // can match on it when both sides have it (see diffRowSets).
+    usable.push({
+      requester,
+      ts,
+      title,
+      requestId: typeof req.id === 'string' ? req.id.toLowerCase() : null,
+    });
   }
   return { rows: usable, truncated, skippedMissingKey, skippedAfterWindowEnd };
 };
@@ -497,14 +525,17 @@ const fetchJson = async (url, label) => {
 // Pages /v1/data/scored-rows the same way the site's client does
 // (common-util/api/predict/mech-analytics.ts::iterateScoredRows).
 // `since` is >= on requested_at, so windowStart+1s reproduces the
-// subgraph's strict blockTimestamp_gt boundary.
+// subgraph's strict blockTimestamp_gt boundary. `until` is exclusive
+// on the API but the subgraph keeps rows at ts == windowEndSec (only
+// ts > windowEndSec is skipped), so windowEndSec+1 keeps the two
+// sides' inclusive-end semantics symmetric.
 const fetchScoredRows = async (chainId, windowStartSec, windowEndSec, label) => {
   const rows = [];
   let truncated = false;
   const url = new URL(`${mechAnalyticsBase}/v1/data/scored-rows`);
   url.searchParams.set('chain_id', String(chainId));
   url.searchParams.set('since', isoFromUnixSec(windowStartSec + 1));
-  url.searchParams.set('until', isoFromUnixSec(windowEndSec));
+  url.searchParams.set('until', isoFromUnixSec(windowEndSec + 1));
   url.searchParams.set('limit', String(SCORED_ROWS_PAGE));
 
   let cursor = null;
@@ -637,33 +668,54 @@ const classifyAnalyticsRows = (rows) => {
 // Check 2 — row parity
 // ---------------------------------------------------------------------------
 
-// Multiset diff on (requester, unix timestamp, normalizeTitle(title)).
-// normalizeTitle on both sides matches the consumer's own matching
-// discipline and absorbs title truncation differences between the
-// subgraph's parsedRequest and the lake's question_title.
+// Multiset diff. Preferred key is (requester, request_id) — the
+// marketplace subgraph's Request.id is the same identifier the lake
+// writes back as `request_id`, and the consumer's fetcher dedupes on
+// it (common-util/api/predict/mech-analytics.ts). Fallback is
+// (requester, unix ts, normalizeTitle(title)) for rows missing an id
+// on either side; this fallback is only sound while ts equality
+// holds — once live-writer rows land, requested_at (authorization
+// time) can drift seconds-to-minutes from blockTimestamp, so any
+// row that falls back and diverges is called out with a mode label
+// so the operator can tell "real regression" from "expected drift".
 const diffRowSets = (subgraphRows, analyticsRows) => {
-  const keyOf = (requester, ts, title) => `${requester}|${ts}|${normalizeTitle(title)}`;
+  const idKey = (requester, id) => `id|${requester}|${id}`;
+  const tsKey = (requester, ts, title) => `ts|${requester}|${ts}|${normalizeTitle(title)}`;
   const tally = new Map();
-  for (const { requester, ts, title } of subgraphRows) {
-    const key = keyOf(requester, ts, title);
+  const modeById = new Map();
+
+  const bump = (key, side, mode) => {
     const entry = tally.get(key) ?? { subgraph: 0, analytics: 0 };
-    entry.subgraph += 1;
+    entry[side] += 1;
     tally.set(key, entry);
+    modeById.set(key, mode);
+  };
+
+  for (const { requester, ts, title, requestId } of subgraphRows) {
+    bump(
+      requestId ? idKey(requester, requestId) : tsKey(requester, ts, title),
+      'subgraph',
+      requestId ? 'id' : 'ts'
+    );
   }
   for (const { requester, row } of analyticsRows) {
+    const rowId = typeof row.request_id === 'string' ? row.request_id.toLowerCase() : null;
+    if (rowId) {
+      bump(idKey(requester, rowId), 'analytics', 'id');
+      continue;
+    }
     const ts = Math.floor(Date.parse(row.requested_at) / 1000);
     if (!Number.isFinite(ts)) continue;
-    const key = keyOf(requester, ts, row.question_title);
-    const entry = tally.get(key) ?? { subgraph: 0, analytics: 0 };
-    entry.analytics += 1;
-    tally.set(key, entry);
+    bump(tsKey(requester, ts, row.question_title), 'analytics', 'ts');
   }
 
   let missingInAnalytics = 0;
   let extraInAnalytics = 0;
+  let tsFallbackKeys = 0;
   const missingSamples = [];
   const extraSamples = [];
   for (const [key, { subgraph, analytics }] of tally) {
+    if (modeById.get(key) === 'ts') tsFallbackKeys += 1;
     if (subgraph > analytics) {
       missingInAnalytics += subgraph - analytics;
       if (missingSamples.length < SAMPLE_LIMIT) missingSamples.push(key);
@@ -672,7 +724,7 @@ const diffRowSets = (subgraphRows, analyticsRows) => {
       if (extraSamples.length < SAMPLE_LIMIT) extraSamples.push(key);
     }
   }
-  return { missingInAnalytics, extraInAnalytics, missingSamples, extraSamples };
+  return { missingInAnalytics, extraInAnalytics, missingSamples, extraSamples, tsFallbackKeys };
 };
 
 // ---------------------------------------------------------------------------
@@ -707,10 +759,15 @@ try {
     section(`${key} (chain ${chainId}, agent ${agentId}) — data pulls`);
     const [marketplace, dailyStats, scoredRows, aggregate] = await Promise.all([
       fetchMarketplaceRequests(marketplaceUrl, windowStartSec, windowEndSec, `${key}:marketplace`),
+      // date_lte is capped at (now - finality lag) so the subgraph
+      // side doesn't consume settlements still inside the analytics
+      // 24h finality gate — otherwise recent settlements would show as
+      // consumed on the subgraph but pending in analytics and produce
+      // a chronic delta on honest runs.
       fetchDailyStats(
         dailyStatsUrl,
         Math.floor(windowStartSec / DAY_SECONDS) * DAY_SECONDS,
-        nowSec,
+        nowSec - finalityLagHours * 60 * 60,
         platform.participantTitleField,
         `${key}:daily-stats`
       ),
@@ -795,6 +852,14 @@ try {
     );
     emit(`  missing in analytics: ${rowDiff.missingInAnalytics}`);
     emit(`  extra in analytics:   ${rowDiff.extraInAnalytics}`);
+    if (rowDiff.tsFallbackKeys > 0) {
+      emit(
+        `  ${rowDiff.tsFallbackKeys} key(s) matched via (requester, ts, title) fallback ` +
+          '— once live lake writes turn on, requested_at can drift from blockTimestamp ' +
+          'by seconds-to-minutes, so a divergence with a nonzero fallback count may be ' +
+          'ts drift rather than a missing/extra row.'
+      );
+    }
     for (const sample of rowDiff.missingSamples) emit(`    missing: ${sample}`);
     for (const sample of rowDiff.extraSamples) emit(`    extra:   ${sample}`);
 
@@ -827,6 +892,7 @@ try {
       extra_in_analytics: rowDiff.extraInAnalytics,
       missing_samples: rowDiff.missingSamples,
       extra_samples: rowDiff.extraSamples,
+      ts_fallback_keys: rowDiff.tsFallbackKeys,
       truncated: check2Truncated,
     });
 

--- a/scripts/verify-mech-analytics-parity.mjs
+++ b/scripts/verify-mech-analytics-parity.mjs
@@ -1,0 +1,449 @@
+// Copyright 2026 Valory AG
+// SPDX-License-Identifier: Apache-2.0
+//
+// Parity verification: the olas-website predict page's `partialRoi` and
+// `successRate` fields are the two metrics migrating to mech-analytics
+// per the consumer-migration plan (see mech-analytics docs). This
+// script proves that switching those two fields from the current
+// subgraph-derived computation to the mech-analytics API preserves the
+// numbers a visitor sees. Every other field on the predict page keeps
+// its current computation and isn't the script's concern.
+//
+// The script compares 16 cells per run:
+//   2 fields × 4 windows × 2 platforms
+//     fields    = { partialRoi, successRate }
+//     windows   = { 7d, 30d, 90d, max }   (max ↔ mech-analytics 'all')
+//     platforms = { omenstrat, polystrat }
+//
+// The omenstrat side of mech-analytics is a client-side aggregation of
+// agent 14 and agent 25 (both classified as valory_trader on Gnosis) —
+// same weighted-average discipline mech-analytics itself uses in
+// _aggregate_agent for multi-Safe agents. Polystrat is a single agent
+// (137 / 86) so no aggregation is needed.
+//
+// Report shape mirrors mech-predict/scripts/verify_migration_swap.py:
+// metadata header, per-cell PASS/FAIL, aggregate verdict, --output-dir
+// writes <window>.md and <window>.json artifacts for a K8s Job pattern.
+//
+// Exit codes:
+//   0 — every cell within tolerance
+//   1 — unexpected error (sentinel: only success flips to 0)
+//   3 — one or more cells diverge beyond tolerance
+//   4 — required mech-analytics field missing from the response
+//
+// Usage:
+//   BLOB_READ_WRITE_TOKEN=... MECH_ANALYTICS_URL=https://... \
+//     node scripts/verify-mech-analytics-parity.mjs [--output-dir ./out]
+
+import { execSync } from 'node:child_process';
+import { mkdirSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+import { parseArgs } from 'node:util';
+
+import { list } from '@vercel/blob';
+
+// ---------------------------------------------------------------------------
+// Configuration
+// ---------------------------------------------------------------------------
+
+const SNAPSHOT_CATEGORY = 'predict-v2';
+
+// Same versioning discipline snapshot-storage.ts uses. Bump when the
+// upstream constant changes.
+const SCHEMA_VERSION = '20260708';
+
+const OMENSTRAT_AGENTS = [
+  { chainId: 100, agentId: 14 },
+  { chainId: 100, agentId: 25 },
+];
+const POLYSTRAT_AGENT = { chainId: 137, agentId: 86 };
+
+// olas-website window names in `WindowedMetric` -> mech-analytics window
+// names in `AgentWindow`. `max` is the all-time window in both APIs; the
+// names differ.
+const WINDOW_MAP = {
+  '7d': '7d',
+  '30d': '30d',
+  '90d': '90d',
+  max: 'all',
+};
+
+// Default tolerance: relative 1e-4 for percent-valued metrics. Percent
+// scale means a 0.01% delta trips this; anything smaller is
+// float-precision noise. Both sides pull integer counts through
+// float arithmetic so exact equality is not a realistic bar.
+const DEFAULT_TOLERANCE_REL = 1e-4;
+
+// ---------------------------------------------------------------------------
+// CLI
+// ---------------------------------------------------------------------------
+
+const { values: args } = parseArgs({
+  options: {
+    'mech-analytics-url': { type: 'string' },
+    'output-dir': { type: 'string' },
+    tolerance: { type: 'string' },
+    verbose: { type: 'boolean', short: 'v' },
+    help: { type: 'boolean', short: 'h' },
+  },
+});
+
+// --help exits before any env-var requirement so the Docker image's
+// entrypoint can be smoke-tested (`docker run --rm <image> --help`)
+// without secrets. Everything below the CLI block needs real config.
+if (args.help) {
+  process.stdout.write(
+    'Usage: node scripts/verify-mech-analytics-parity.mjs [options]\n' +
+      '\n' +
+      'Parity check: olas-website predict-page partialRoi/successRate vs the\n' +
+      'mech-analytics /v1/metrics/ai-agent endpoints (16 cells per run).\n' +
+      '\n' +
+      'Options:\n' +
+      '  --mech-analytics-url <url>  mech-analytics base URL (or MECH_ANALYTICS_URL env)\n' +
+      '  --output-dir <dir>          write parity-<ts>.md/.json artifacts here\n' +
+      `  --tolerance <rel>           relative tolerance (default ${DEFAULT_TOLERANCE_REL})\n` +
+      '  -v, --verbose               log fetched blob URL\n' +
+      '  -h, --help                  show this help and exit 0\n' +
+      '\n' +
+      'Required env: BLOB_READ_WRITE_TOKEN (Vercel Blob read token, secret).\n' +
+      '\n' +
+      'Exit codes: 0 pass, 1 unexpected error, 3 divergence, 4 missing field.\n'
+  );
+  process.exit(0);
+}
+
+const mechAnalyticsUrl = args['mech-analytics-url'] || process.env.MECH_ANALYTICS_URL;
+if (!mechAnalyticsUrl) {
+  console.error('MECH_ANALYTICS_URL (env or --mech-analytics-url) is required');
+  process.exit(1);
+}
+if (!process.env.BLOB_READ_WRITE_TOKEN) {
+  console.error('BLOB_READ_WRITE_TOKEN is required to read the olas-website snapshot');
+  process.exit(1);
+}
+const outputDir = args['output-dir'] ? path.resolve(args['output-dir']) : null;
+const tolerance = args.tolerance ? Number(args.tolerance) : DEFAULT_TOLERANCE_REL;
+const verbose = Boolean(args.verbose);
+
+// ---------------------------------------------------------------------------
+// stdout capture (mirrors mech-predict's Tee for artifact writing)
+// ---------------------------------------------------------------------------
+
+const reportChunks = [];
+
+const emit = (line = '') => {
+  process.stdout.write(`${line}\n`);
+  reportChunks.push(`${line}\n`);
+};
+
+const section = (title) => {
+  emit('');
+  emit(`=== ${title} ===`);
+};
+
+// ---------------------------------------------------------------------------
+// Provenance header
+// ---------------------------------------------------------------------------
+
+const scriptGitSha = () => {
+  if (process.env.GIT_SHA) return process.env.GIT_SHA;
+  try {
+    return execSync('git rev-parse HEAD', { cwd: import.meta.dirname })
+      .toString()
+      .trim();
+  } catch {
+    return 'unknown';
+  }
+};
+
+const metadata = {
+  run_at_utc: new Date().toISOString(),
+  script_git_sha: scriptGitSha(),
+  mech_analytics_url: mechAnalyticsUrl,
+  tolerance_rel: tolerance,
+  snapshot_category: SNAPSHOT_CATEGORY,
+  snapshot_schema_version: SCHEMA_VERSION,
+};
+
+emit('=== Run metadata ===');
+emit(`  run_at (UTC):        ${metadata.run_at_utc}`);
+emit(`  script git SHA:      ${metadata.script_git_sha}`);
+emit(`  mech-analytics URL:  ${metadata.mech_analytics_url}`);
+emit(`  tolerance (rel):     ${metadata.tolerance_rel}`);
+
+// ---------------------------------------------------------------------------
+// Data pulls
+// ---------------------------------------------------------------------------
+
+// Both metrics live in a Vercel Blob keyed by category + schema version.
+// Fetching the blob directly (over its public URL) is much cheaper than
+// re-running fetchAllPredictMetrics and produces the exact values a
+// visitor sees today — which is the parity question.
+const fetchOlasWebsiteSnapshot = async () => {
+  const envPrefix = `metrics-${process.env.NODE_ENV || 'production'}`;
+  const filename = `${envPrefix}-${SCHEMA_VERSION}-${SNAPSHOT_CATEGORY}.json`;
+  const { blobs } = await list({ prefix: filename, limit: 1 });
+  const blob = (blobs || []).find((b) => b.pathname === filename);
+  if (!blob) {
+    throw new Error(
+      `no snapshot blob found for filename=${filename}; check ` +
+        'BLOB_READ_WRITE_TOKEN environment and NODE_ENV'
+    );
+  }
+  if (verbose) emit(`  fetched blob:        ${blob.url}`);
+  const res = await fetch(blob.url, { cache: 'no-store' });
+  if (!res.ok) throw new Error(`snapshot fetch failed: ${res.status} ${res.statusText}`);
+  const snapshot = await res.json();
+  if (!snapshot?.data?.omenstrat || !snapshot?.data?.polystrat) {
+    throw new Error('snapshot is malformed: missing omenstrat/polystrat blocks');
+  }
+  return snapshot.data;
+};
+
+const fetchMechAnalyticsAgent = async (chainId, agentId) => {
+  const url = `${mechAnalyticsUrl.replace(/\/$/, '')}/v1/metrics/ai-agent/${chainId}/${agentId}`;
+  const res = await fetch(url);
+  if (!res.ok) {
+    throw new Error(`mech-analytics ${chainId}/${agentId}: ${res.status} ${res.statusText}`);
+  }
+  return res.json();
+};
+
+// ---------------------------------------------------------------------------
+// Cross-agent aggregation (omenstrat = agent 14 + agent 25 on Gnosis)
+//
+// mech-analytics itself aggregates multi-Safe agents in
+// _aggregate_agent (etl/api/routes/agent.py:303). It uses:
+//   * ROI:  sum(payout) / sum(cost)  — never mean of ratios
+//   * Accuracy: bet-count-weighted mean of per-Safe accuracy
+// Because the per-agent endpoint returns already-aggregated ROI (not
+// raw payout/cost), a client-side sum can't perfectly reproduce
+// mech-analytics's payout-weighted ROI for the omenstrat pair. We
+// approximate with an n_bets-weighted mean of ROI, which is the
+// best we can do from the exposed fields, and note the caveat in
+// the report. This is one of the gaps the parity script surfaces
+// — a genuine bug in omenstrat parity would blow past the
+// tolerance regardless of this approximation.
+// ---------------------------------------------------------------------------
+
+const weightedMean = (pairs) => {
+  const nonNull = pairs.filter(([value]) => value != null && Number.isFinite(value));
+  if (nonNull.length === 0) return null;
+  const totalWeight = nonNull.reduce((sum, [, weight]) => sum + (weight || 0), 0);
+  if (totalWeight === 0) return null;
+  const weightedSum = nonNull.reduce((sum, [value, weight]) => sum + value * (weight || 0), 0);
+  return weightedSum / totalWeight;
+};
+
+const aggregateOmenstrat = (agentResponses, windowKey) => {
+  // Both agents' window blocks; nulls when the rollup has nothing.
+  const windows = agentResponses.map((r) => r?.windows?.[windowKey] ?? null);
+  const nBetsFor = (w, platform) => (w ? w[`n_bets_${platform}`] || 0 : 0);
+  // Weight ROI and accuracy by the platform-specific bet count. If both
+  // sides are zero-bet, the metric collapses to null (nothing to
+  // compare) which the diff step treats as an unresolved cell.
+  return {
+    roi_omen: weightedMean(windows.map((w) => [w?.roi_omen, nBetsFor(w, 'omen')])),
+    roi_polymarket: weightedMean(
+      windows.map((w) => [w?.roi_polymarket, nBetsFor(w, 'polymarket')])
+    ),
+    tool_accuracy_omen: weightedMean(
+      windows.map((w) => [w?.tool_accuracy_omen, nBetsFor(w, 'omen')])
+    ),
+    tool_accuracy_polymarket: weightedMean(
+      windows.map((w) => [w?.tool_accuracy_polymarket, nBetsFor(w, 'polymarket')])
+    ),
+  };
+};
+
+// ---------------------------------------------------------------------------
+// Field extraction
+//
+// olas-website stores percent values (e.g. 12.5 for 12.5%). mech-analytics
+// stores ratios (e.g. 0.125 for 12.5%). The diff step converts before
+// comparing.
+// ---------------------------------------------------------------------------
+
+const olasPartialRoi = (data, platform, olasWindow) => {
+  const wm = data?.[platform]?.partialRoi?.value?.[olasWindow];
+  return wm == null ? null : Number(wm);
+};
+
+const olasAccuracy = (data, platform, olasWindow) => {
+  const wm = data?.[platform]?.successRate?.value?.[olasWindow];
+  return wm == null ? null : Number(wm);
+};
+
+// mech-analytics returns ROI as a ratio; multiply by 100 for percent.
+// The specific platform (omen vs polymarket) is inferred from the
+// consumer platform key: omenstrat -> omen, polystrat -> polymarket.
+const MECH_PLATFORM_MAP = { omenstrat: 'omen', polystrat: 'polymarket' };
+
+const mechRoiPercent = (windowFields, consumerPlatform) => {
+  const key = `roi_${MECH_PLATFORM_MAP[consumerPlatform]}`;
+  const value = windowFields?.[key];
+  return value == null ? null : value * 100;
+};
+
+const mechAccuracyPercent = (windowFields, consumerPlatform) => {
+  const key = `tool_accuracy_${MECH_PLATFORM_MAP[consumerPlatform]}`;
+  const value = windowFields?.[key];
+  return value == null ? null : value * 100;
+};
+
+// ---------------------------------------------------------------------------
+// Diff logic
+// ---------------------------------------------------------------------------
+
+const compareCell = (oldValue, newValue) => {
+  if (oldValue == null && newValue == null) return { status: 'both-null' };
+  if (oldValue == null || newValue == null) {
+    return { status: 'null-mismatch', oldValue, newValue };
+  }
+  if (!Number.isFinite(oldValue) || !Number.isFinite(newValue)) {
+    return { status: 'non-finite', oldValue, newValue };
+  }
+  const denom = Math.max(Math.abs(oldValue), 1e-6);
+  const relDiff = Math.abs(oldValue - newValue) / denom;
+  return {
+    status: relDiff <= tolerance ? 'pass' : 'fail',
+    oldValue,
+    newValue,
+    relDiff,
+  };
+};
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+let exitCode = 1; // sentinel: any unexpected exit stays 1
+let verdict = 'ERROR';
+const cellResults = [];
+
+try {
+  section('Data pulls');
+  emit('  pulling olas-website snapshot from Vercel Blob...');
+  const olasData = await fetchOlasWebsiteSnapshot();
+  emit(
+    `  snapshot fetched (timestamp: ${olasData.omenstrat?.partialRoi?.status?.checkedAt || 'unknown'})`
+  );
+
+  emit('  pulling mech-analytics agent responses...');
+  const [omenstratAgent14, omenstratAgent25, polystratAgent] = await Promise.all([
+    fetchMechAnalyticsAgent(OMENSTRAT_AGENTS[0].chainId, OMENSTRAT_AGENTS[0].agentId),
+    fetchMechAnalyticsAgent(OMENSTRAT_AGENTS[1].chainId, OMENSTRAT_AGENTS[1].agentId),
+    fetchMechAnalyticsAgent(POLYSTRAT_AGENT.chainId, POLYSTRAT_AGENT.agentId),
+  ]);
+
+  section('Per-cell diff');
+  emit(
+    '  platform     window   field         old (olas)   new (mech-analytics)   rel diff   status'
+  );
+  for (const [platform, mechResponse] of [
+    ['omenstrat', null], // aggregated below
+    ['polystrat', polystratAgent],
+  ]) {
+    for (const [olasWindow, mechWindow] of Object.entries(WINDOW_MAP)) {
+      const mechWindowFields =
+        platform === 'omenstrat'
+          ? aggregateOmenstrat([omenstratAgent14, omenstratAgent25], mechWindow)
+          : mechResponse?.windows?.[mechWindow];
+
+      if (!mechWindowFields) {
+        cellResults.push({
+          platform,
+          window: olasWindow,
+          field: 'partialRoi',
+          status: 'missing-field',
+        });
+        cellResults.push({
+          platform,
+          window: olasWindow,
+          field: 'successRate',
+          status: 'missing-field',
+        });
+        emit(`  ${platform.padEnd(12)} ${olasWindow.padEnd(8)} (mech-analytics window missing)`);
+        continue;
+      }
+
+      for (const [fieldName, olasGetter, mechGetter] of [
+        ['partialRoi', olasPartialRoi, mechRoiPercent],
+        ['successRate', olasAccuracy, mechAccuracyPercent],
+      ]) {
+        const oldValue = olasGetter(olasData, platform, olasWindow);
+        const newValue = mechGetter(mechWindowFields, platform);
+        const result = compareCell(oldValue, newValue);
+        cellResults.push({ platform, window: olasWindow, field: fieldName, ...result });
+        const oldStr = oldValue == null ? 'null' : oldValue.toFixed(4);
+        const newStr = newValue == null ? 'null' : newValue.toFixed(4);
+        const relStr = result.relDiff == null ? '-' : result.relDiff.toExponential(2);
+        emit(
+          `  ${platform.padEnd(12)} ${olasWindow.padEnd(8)} ${fieldName.padEnd(13)} ${oldStr.padStart(10)}   ${newStr.padStart(18)}   ${relStr.padStart(9)}   ${result.status}`
+        );
+      }
+    }
+  }
+
+  section('Verdict');
+  const failures = cellResults.filter(
+    (r) => r.status === 'fail' || r.status === 'null-mismatch' || r.status === 'non-finite'
+  );
+  const missing = cellResults.filter((r) => r.status === 'missing-field');
+  emit(`  cells checked:       ${cellResults.length}`);
+  emit(`  cells passed:        ${cellResults.filter((r) => r.status === 'pass').length}`);
+  emit(`  cells both-null:     ${cellResults.filter((r) => r.status === 'both-null').length}`);
+  emit(`  cells failed:        ${failures.length}`);
+  emit(`  cells missing field: ${missing.length}`);
+
+  if (missing.length > 0) {
+    emit('');
+    emit(
+      `FAIL (missing field): ${missing.length} cell(s) — mech-analytics response is missing the expected window/field.`
+    );
+    exitCode = 4;
+    verdict = 'FAIL';
+  } else if (failures.length > 0) {
+    emit('');
+    emit(`FAIL (divergence): ${failures.length} cell(s) diverged beyond tolerance ${tolerance}.`);
+    for (const f of failures) {
+      emit(
+        `  - ${f.platform}/${f.window}/${f.field}: old=${f.oldValue}, new=${f.newValue}, status=${f.status}`
+      );
+    }
+    exitCode = 3;
+    verdict = 'FAIL';
+  } else {
+    emit('');
+    emit('PASS: every cell within tolerance.');
+    exitCode = 0;
+    verdict = 'PASS';
+  }
+} catch (err) {
+  emit('');
+  emit(`ERROR: ${err.message}`);
+  if (err.stack) emit(err.stack);
+  // exitCode remains 1 (sentinel)
+} finally {
+  emit('');
+  emit(`verdict: ${verdict}  exit_code: ${exitCode}`);
+  if (outputDir) {
+    mkdirSync(outputDir, { recursive: true });
+    const slug = `parity-${metadata.run_at_utc.replace(/[:.]/g, '-')}`;
+    const mdPath = path.join(outputDir, `${slug}.md`);
+    const jsonPath = path.join(outputDir, `${slug}.json`);
+    writeFileSync(mdPath, reportChunks.join(''), 'utf8');
+    writeFileSync(
+      jsonPath,
+      `${JSON.stringify(
+        { metadata, cells: cellResults, verdict, exit_code: exitCode },
+        null,
+        2
+      )}\n`,
+      'utf8'
+    );
+    emit(`\nwrote ${mdPath}`);
+    emit(`wrote ${jsonPath}`);
+  }
+  process.exit(exitCode);
+}

--- a/scripts/verify-mech-analytics-parity.mjs
+++ b/scripts/verify-mech-analytics-parity.mjs
@@ -282,10 +282,20 @@ const scriptGitSha = () => {
   }
 };
 
+// Origin only: the artifact gets posted on the cutover PR, and a
+// signed URL or ?token= query must never travel with it.
+const safeOrigin = (url) => {
+  try {
+    return new URL(url).origin;
+  } catch {
+    return '<invalid-url>';
+  }
+};
+
 const metadata = {
   run_at_utc: new Date().toISOString(),
   script_git_sha: scriptGitSha(),
-  mech_analytics_url: mechAnalyticsUrl,
+  mech_analytics_url: safeOrigin(mechAnalyticsUrl),
   window_days: windowDays,
   lag_buffer_minutes: lagBufferMinutes,
   count_tolerance_abs: countTolerance,
@@ -946,5 +956,10 @@ try {
     emit(`\nwrote ${mdPath}`);
     emit(`wrote ${jsonPath}`);
   }
-  process.exit(exitCode);
+  // The explicit exit is needed because undici keep-alive sockets would
+  // otherwise hold the event loop open — but stdout writes are async
+  // when piped (docker logs, K8s), and a bare process.exit() discards
+  // whatever is still buffered, including the verdict line. Queue the
+  // exit behind a final zero-byte write so the buffer drains first.
+  process.stdout.write('', () => process.exit(exitCode));
 }

--- a/scripts/verify-mech-analytics-parity.mjs
+++ b/scripts/verify-mech-analytics-parity.mjs
@@ -1,78 +1,152 @@
 // Copyright 2026 Valory AG
 // SPDX-License-Identifier: Apache-2.0
 //
-// Parity verification: the olas-website predict page's `partialRoi` and
-// `successRate` fields are the two metrics migrating to mech-analytics
-// per the consumer-migration plan (see mech-analytics docs). This
-// script proves that switching those two fields from the current
-// subgraph-derived computation to the mech-analytics API preserves the
-// numbers a visitor sees. Every other field on the predict page keeps
-// its current computation and isn't the script's concern.
+// Parity verification for the olas-website / mech-analytics consumer
+// migration (mech-analytics docs/consumer_migration.md §4, §12 Q4).
 //
-// The script compares 16 cells per run:
-//   2 fields × 4 windows × 2 platforms
-//     fields    = { partialRoi, successRate }
-//     windows   = { 7d, 30d, 90d, max }   (max ↔ mech-analytics 'all')
-//     platforms = { omenstrat, polystrat }
+// Corrected frame (this replaces the script's original partialRoi /
+// successRate diff): partialRoi and successRate do NOT migrate to
+// mech-analytics. The website keeps its own formulas. The migration
+// (merged behind the USE_MECH_ANALYTICS flag, PR #548) only swaps
+//   * the per-request mech-request feed inside
+//     fetchIncrementalMechRequests (roi-distribution.ts:469) and the
+//     tool-accuracy per-request pull (tool-accuracy.ts:148) to
+//     /v1/data/scored-rows, and
+//   * the senderTotal aggregate to agent_aggregates.n_mech_requests.
+// Comparing the two independent ROI implementations end-to-end fails on
+// definitional gaps (different populations, mech fees on one side,
+// settlement-vs-placement bucketing) even when the migration is
+// correct. What this script gates instead is the count-source swap
+// itself, per consumer_migration.md §4 "Manual diff before
+// parallel-run" and §12 Q4:
 //
-// The omenstrat side of mech-analytics is a client-side aggregation of
-// agent 14 and agent 25 (both classified as valory_trader on Gnosis) —
-// same weighted-average discipline mech-analytics itself uses in
-// _aggregate_agent for multi-Safe agents. Polystrat is a single agent
-// (137 / 86) so no aggregation is needed.
+// Check 1 — open-market count parity (the core gate).
+//   mech-analytics's last-4-days count of rows with
+//   resolution_status='pending' AND market_id present (via
+//   /v1/data/scored-rows) must equal the title-normalised open-market
+//   count computed the way roi-distribution.ts computes it today:
+//   requests from the marketplace subgraph's incremental feed, minus
+//   the ones consumed by settlement (normalizeTitle matching against
+//   dailyProfitStatistics.profitParticipants). The mech-analytics side
+//   is broken out into (a) pending+market_id, (b) invalid, (c) no
+//   market_id — the consumer counts only (a); (b) and (c) are reported
+//   so a naive resolved=false count overshooting is visible.
 //
-// Report shape mirrors mech-predict/scripts/verify_migration_swap.py:
-// metadata header, per-cell PASS/FAIL, aggregate verdict, --output-dir
-// writes <window>.md and <window>.json artifacts for a K8s Job pattern.
+// Check 2 — scored-rows row parity.
+//   For the same window, the row set from
+//   getMechRequestsIncrementalQuery (requester, blockTimestamp,
+//   questionTitle) must match the rows from /v1/data/scored-rows
+//   (requester, requested_at, question_title). Missing / extra rows
+//   are reported per side.
+//
+// Check 3 — senderTotal parity.
+//   agent_aggregates.n_mech_requests (window 'all', via
+//   /v1/metrics/ai-agent/{chain}/{agent}) vs the marketplace
+//   subgraph's Sender.totalLegacyRequests + totalMarketplaceRequests
+//   summed over the same registered Safes (from the /instances
+//   endpoint). Compared with a small absolute tolerance — see
+//   COUNT_TOLERANCE_DEFAULT below for why exact equality is not the
+//   bar on this one check.
+//
+// NOT in this script — flag-on vs flag-off openRequestCount (§12 Q4's
+// framing). Exercising the site's own fetchIncrementalMechRequests /
+// fetchAllTimeAgents path twice (USE_MECH_ANALYTICS on/off) requires
+// the Next.js runtime plus the Vercel Blob QMR state; a standalone
+// node script cannot honestly reproduce it. That comparison is the
+// staging parallel-run check, done by ops on the deployed site, not
+// by this script.
 //
 // Exit codes:
-//   0 — every cell within tolerance
-//   1 — unexpected error (sentinel: only success flips to 0)
-//   3 — one or more cells diverge beyond tolerance
-//   4 — required mech-analytics field missing from the response
+//   0 — every check passed
+//   1 — unexpected error (sentinel: only success paths overwrite it)
+//   2 — vacuous run: every check had nothing to compare on either side
+//   3 — divergence on one or more checks (outranks 4: a data gap on
+//       one check must not mask a real divergence on another)
+//   4 — data gap: a required field was null/missing on one side, or a
+//       fetch was truncated, with no divergence found elsewhere
 //
 // Usage:
-//   BLOB_READ_WRITE_TOKEN=... MECH_ANALYTICS_URL=https://... \
+//   MECH_ANALYTICS_URL=https://... \
+//   NEXT_PUBLIC_GNOSIS_MARKETPLACE_SUBGRAPH_URL=... \
+//   NEXT_PUBLIC_POLYGON_MARKETPLACE_SUBGRAPH_URL=... \
+//   NEXT_PUBLIC_OLAS_PREDICT_AGENTS_SUBGRAPH_URL=... \
+//   NEXT_PUBLIC_OLAS_POLYMARKET_AGENTS_SUBGRAPH_URL=... \
 //     node scripts/verify-mech-analytics-parity.mjs [--output-dir ./out]
+//
+// Subgraph URLs embed API keys — they are secrets. This script never
+// prints them (presence is logged as yes/no; HTTP errors carry status
+// codes only, never the URL).
 
 import { execSync } from 'node:child_process';
 import { mkdirSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
 import { parseArgs } from 'node:util';
 
-import { list } from '@vercel/blob';
-
 // ---------------------------------------------------------------------------
 // Configuration
 // ---------------------------------------------------------------------------
 
-const SNAPSHOT_CATEGORY = 'predict-v2';
+// Window for checks 1 and 2. consumer_migration.md §4 "Manual diff
+// before parallel-run" gates on the last-4-days open-market count
+// (markets resolve in ~4 days at steady state).
+const WINDOW_DAYS_DEFAULT = 4;
 
-// Same versioning discipline snapshot-storage.ts uses. Bump when the
-// upstream constant changes.
-const SCHEMA_VERSION = '20260708';
+// Rows requested in the last few minutes may exist on the subgraph but
+// not yet in per_request_scores (score_new_rows runs on a 5-minute
+// tick). Trim the near edge of the window on BOTH sides so scoring lag
+// doesn't show up as fake missing rows.
+const LAG_BUFFER_MINUTES_DEFAULT = 30;
 
-const OMENSTRAT_AGENTS = [
-  { chainId: 100, agentId: 14 },
-  { chainId: 100, agentId: 25 },
+// Check 3 absolute tolerance. Both sides ultimately read the same
+// subgraph Sender counters, but mech-analytics caches them at rollup
+// time (etl/readers/marketplace_subgraph.py::fetch_sender_request_counts)
+// while this script reads the subgraph live — and the counters
+// increment at settlement, not at request time (documented semantics,
+// consumer_migration.md §4). A handful of requests settling between
+// the rollup tick and this run is expected, not a divergence. Counts
+// are otherwise compared exactly (checks 1 and 2 use zero tolerance).
+const COUNT_TOLERANCE_DEFAULT = 5;
+
+const DAY_SECONDS = 86400;
+const SUBGRAPH_PAGE = 1000;
+// graph-node rejects skip > 5000; a full page at that offset means the
+// fetch is truncated and the affected checks degrade to a data gap.
+const SUBGRAPH_MAX_SKIP = 5000;
+const SCORED_ROWS_PAGE = 1000;
+const SCORED_ROWS_MAX_PAGES = 500;
+const SENDER_ID_CHUNK = 100;
+const SAMPLE_LIMIT = 10;
+
+// One platform = one (marketplace-subgraph chain, daily-stats subgraph,
+// mech-analytics chain_id/agent_id) triple. Agent ids per
+// consumer_migration.md §4: omenstrat /100/14, polystrat /137/86.
+const PLATFORMS = [
+  {
+    key: 'omenstrat',
+    chainId: 100,
+    agentId: 14,
+    marketplaceUrlEnv: 'NEXT_PUBLIC_GNOSIS_MARKETPLACE_SUBGRAPH_URL',
+    dailyStatsUrlEnv: 'NEXT_PUBLIC_OLAS_PREDICT_AGENTS_SUBGRAPH_URL',
+    // getOmenDailyProfitStatsQuery (queries.ts:721) exposes the title
+    // as `question` on profitParticipants.
+    participantTitleField: 'question',
+  },
+  {
+    key: 'polystrat',
+    chainId: 137,
+    agentId: 86,
+    marketplaceUrlEnv: 'NEXT_PUBLIC_POLYGON_MARKETPLACE_SUBGRAPH_URL',
+    dailyStatsUrlEnv: 'NEXT_PUBLIC_OLAS_POLYMARKET_AGENTS_SUBGRAPH_URL',
+    // getPolymarketDailyProfitStatsQuery (queries.ts:790) nests the
+    // title under `metadata.title`.
+    participantTitleField: 'metadata.title',
+  },
 ];
-const POLYSTRAT_AGENT = { chainId: 137, agentId: 86 };
 
-// olas-website window names in `WindowedMetric` -> mech-analytics window
-// names in `AgentWindow`. `max` is the all-time window in both APIs; the
-// names differ.
-const WINDOW_MAP = {
-  '7d': '7d',
-  '30d': '30d',
-  '90d': '90d',
-  max: 'all',
-};
-
-// Default tolerance: relative 1e-4 for percent-valued metrics. Percent
-// scale means a 0.01% delta trips this; anything smaller is
-// float-precision noise. Both sides pull integer counts through
-// float arithmetic so exact equality is not a realistic bar.
-const DEFAULT_TOLERANCE_REL = 1e-4;
+const REQUIRED_ENV = [
+  'MECH_ANALYTICS_URL',
+  ...PLATFORMS.flatMap((p) => [p.marketplaceUrlEnv, p.dailyStatsUrlEnv]),
+];
 
 // ---------------------------------------------------------------------------
 // CLI
@@ -82,7 +156,9 @@ const { values: args } = parseArgs({
   options: {
     'mech-analytics-url': { type: 'string' },
     'output-dir': { type: 'string' },
-    tolerance: { type: 'string' },
+    'window-days': { type: 'string' },
+    'lag-buffer-minutes': { type: 'string' },
+    'count-tolerance': { type: 'string' },
     verbose: { type: 'boolean', short: 'v' },
     help: { type: 'boolean', short: 'h' },
   },
@@ -95,35 +171,78 @@ if (args.help) {
   process.stdout.write(
     'Usage: node scripts/verify-mech-analytics-parity.mjs [options]\n' +
       '\n' +
-      'Parity check: olas-website predict-page partialRoi/successRate vs the\n' +
-      'mech-analytics /v1/metrics/ai-agent endpoints (16 cells per run).\n' +
+      'Gates the mech-request count-source swap of the olas-website predict-page\n' +
+      'migration (consumer_migration.md §4 / §12 Q4). Three checks per platform\n' +
+      '(omenstrat=gnosis/100/14, polystrat=polygon/137/86):\n' +
+      '  1. open-market count parity: scored-rows pending+market_id count vs the\n' +
+      '     normalizeTitle-based open count over the marketplace-subgraph feed\n' +
+      '  2. scored-rows row parity: (requester, timestamp, title) row sets match\n' +
+      '  3. senderTotal parity: agent_aggregates.n_mech_requests vs subgraph\n' +
+      '     Sender.totalLegacyRequests + totalMarketplaceRequests per Safe\n' +
+      'Flag-on/off openRequestCount comparison is the staging parallel-run\n' +
+      'check done by ops on the deployed site — it is NOT run here.\n' +
       '\n' +
       'Options:\n' +
-      '  --mech-analytics-url <url>  mech-analytics base URL (or MECH_ANALYTICS_URL env)\n' +
-      '  --output-dir <dir>          write parity-<ts>.md/.json artifacts here\n' +
-      `  --tolerance <rel>           relative tolerance (default ${DEFAULT_TOLERANCE_REL})\n` +
-      '  -v, --verbose               log fetched blob URL\n' +
-      '  -h, --help                  show this help and exit 0\n' +
+      '  --mech-analytics-url <url>   mech-analytics base URL (or MECH_ANALYTICS_URL env)\n' +
+      `  --window-days <n>            checks 1+2 window (default ${WINDOW_DAYS_DEFAULT})\n` +
+      `  --lag-buffer-minutes <n>     near-edge trim for scoring lag (default ${LAG_BUFFER_MINUTES_DEFAULT})\n` +
+      `  --count-tolerance <n>        check 3 absolute tolerance (default ${COUNT_TOLERANCE_DEFAULT})\n` +
+      '  --output-dir <dir>           write parity-<ts>.md/.json artifacts here\n' +
+      '  -v, --verbose                log per-page fetch progress\n' +
+      '  -h, --help                   show this help and exit 0\n' +
       '\n' +
-      'Required env: BLOB_READ_WRITE_TOKEN (Vercel Blob read token, secret).\n' +
+      'Required env (subgraph URLs embed API keys — all secrets, never logged):\n' +
+      `  ${REQUIRED_ENV.join('\n  ')}\n` +
       '\n' +
-      'Exit codes: 0 pass, 1 unexpected error, 3 divergence, 4 missing field.\n'
+      'Exit codes: 0 pass, 1 error, 2 vacuous, 3 divergence, 4 data gap.\n'
   );
   process.exit(0);
 }
 
 const mechAnalyticsUrl = args['mech-analytics-url'] || process.env.MECH_ANALYTICS_URL;
-if (!mechAnalyticsUrl) {
-  console.error('MECH_ANALYTICS_URL (env or --mech-analytics-url) is required');
+const missingEnv = REQUIRED_ENV.filter(
+  (name) => !(name === 'MECH_ANALYTICS_URL' ? mechAnalyticsUrl : process.env[name])
+);
+if (missingEnv.length > 0) {
+  console.error(`missing required configuration: ${missingEnv.join(', ')}`);
   process.exit(1);
 }
-if (!process.env.BLOB_READ_WRITE_TOKEN) {
-  console.error('BLOB_READ_WRITE_TOKEN is required to read the olas-website snapshot');
-  process.exit(1);
-}
+
+const parsePositiveInt = (raw, label, fallback) => {
+  if (raw == null) return fallback;
+  const value = Number(raw);
+  if (!Number.isInteger(value) || value <= 0) {
+    console.error(`--${label} must be a positive integer, got "${raw}"`);
+    process.exit(1);
+  }
+  return value;
+};
+
+const parseNonNegativeInt = (raw, label, fallback) => {
+  if (raw == null) return fallback;
+  const value = Number(raw);
+  if (!Number.isInteger(value) || value < 0) {
+    console.error(`--${label} must be a non-negative integer, got "${raw}"`);
+    process.exit(1);
+  }
+  return value;
+};
+
 const outputDir = args['output-dir'] ? path.resolve(args['output-dir']) : null;
-const tolerance = args.tolerance ? Number(args.tolerance) : DEFAULT_TOLERANCE_REL;
+const windowDays = parsePositiveInt(args['window-days'], 'window-days', WINDOW_DAYS_DEFAULT);
+const lagBufferMinutes = parseNonNegativeInt(
+  args['lag-buffer-minutes'],
+  'lag-buffer-minutes',
+  LAG_BUFFER_MINUTES_DEFAULT
+);
+const countTolerance = parseNonNegativeInt(
+  args['count-tolerance'],
+  'count-tolerance',
+  COUNT_TOLERANCE_DEFAULT
+);
 const verbose = Boolean(args.verbose);
+
+const mechAnalyticsBase = mechAnalyticsUrl.replace(/\/$/, '');
 
 // ---------------------------------------------------------------------------
 // stdout capture (mirrors mech-predict's Tee for artifact writing)
@@ -140,6 +259,13 @@ const section = (title) => {
   emit('');
   emit(`=== ${title} ===`);
 };
+
+// Subgraph URLs embed API keys; never let one leak through an error
+// message or stack trace into stdout or the artifacts.
+const scrub = (text) =>
+  String(text)
+    .replace(/https?:\/\/\S+/g, '<redacted-url>')
+    .replace(/[0-9a-fA-F]{16,}/g, '<redacted>');
 
 // ---------------------------------------------------------------------------
 // Provenance header
@@ -160,269 +286,648 @@ const metadata = {
   run_at_utc: new Date().toISOString(),
   script_git_sha: scriptGitSha(),
   mech_analytics_url: mechAnalyticsUrl,
-  tolerance_rel: tolerance,
-  snapshot_category: SNAPSHOT_CATEGORY,
-  snapshot_schema_version: SCHEMA_VERSION,
+  window_days: windowDays,
+  lag_buffer_minutes: lagBufferMinutes,
+  count_tolerance_abs: countTolerance,
 };
 
 emit('=== Run metadata ===');
-emit(`  run_at (UTC):        ${metadata.run_at_utc}`);
-emit(`  script git SHA:      ${metadata.script_git_sha}`);
-emit(`  mech-analytics URL:  ${metadata.mech_analytics_url}`);
-emit(`  tolerance (rel):     ${metadata.tolerance_rel}`);
+emit(`  run_at (UTC):         ${metadata.run_at_utc}`);
+emit(`  script git SHA:       ${metadata.script_git_sha}`);
+emit(`  mech-analytics URL:   ${metadata.mech_analytics_url}`);
+emit(`  window (days):        ${metadata.window_days}`);
+emit(`  lag buffer (min):     ${metadata.lag_buffer_minutes}`);
+emit(`  count tolerance (±):  ${metadata.count_tolerance_abs} (check 3 only)`);
+for (const name of REQUIRED_ENV.slice(1)) {
+  // Presence only — the URLs embed API keys.
+  emit(`  ${name}: set`);
+}
 
 // ---------------------------------------------------------------------------
-// Data pulls
+// Shared helpers
 // ---------------------------------------------------------------------------
 
-// Both metrics live in a Vercel Blob keyed by category + schema version.
-// Fetching the blob directly (over its public URL) is much cheaper than
-// re-running fetchAllPredictMetrics and produces the exact values a
-// visitor sees today — which is the parity question.
-const fetchOlasWebsiteSnapshot = async () => {
-  const envPrefix = `metrics-${process.env.NODE_ENV || 'production'}`;
-  const filename = `${envPrefix}-${SCHEMA_VERSION}-${SNAPSHOT_CATEGORY}.json`;
-  const { blobs } = await list({ prefix: filename, limit: 1 });
-  const blob = (blobs || []).find((b) => b.pathname === filename);
-  if (!blob) {
-    throw new Error(
-      `no snapshot blob found for filename=${filename}; check ` +
-        'BLOB_READ_WRITE_TOKEN environment and NODE_ENV'
-    );
+// Copied verbatim from common-util/api/predict/roi-distribution.ts:402
+// (normalizeTitle). Node can't import the site's TypeScript, so the one
+// pure helper the matching depends on is reimplemented here. DRIFT
+// WARNING: if roi-distribution.ts changes normalizeTitle, this copy
+// must change with it or check 1's matching diverges from the site's.
+const normalizeTitle = (title) =>
+  title
+    .toLowerCase()
+    .replace(/[^a-z0-9]/g, '')
+    .slice(0, 100);
+
+const isoFromUnixSec = (sec) => new Date(sec * 1000).toISOString();
+
+// POST { query } like the site's GraphQLClient does under the hood
+// (common-util/graphql/client.ts). Error messages carry the label and
+// status only — never the URL, which embeds the API key.
+const gqlRequest = async (url, query, label) => {
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ query }),
+  });
+  if (!res.ok) {
+    throw new Error(`${label}: subgraph returned HTTP ${res.status}`);
   }
-  if (verbose) emit(`  fetched blob:        ${blob.url}`);
-  const res = await fetch(blob.url, { cache: 'no-store' });
-  if (!res.ok) throw new Error(`snapshot fetch failed: ${res.status} ${res.statusText}`);
-  const snapshot = await res.json();
-  if (!snapshot?.data?.omenstrat || !snapshot?.data?.polystrat) {
-    throw new Error('snapshot is malformed: missing omenstrat/polystrat blocks');
+  const body = await res.json();
+  if (Array.isArray(body.errors) && body.errors.length > 0) {
+    throw new Error(`${label}: GraphQL error: ${body.errors[0]?.message ?? 'unknown'}`);
   }
-  return snapshot.data;
+  return body.data ?? {};
 };
 
-const fetchMechAnalyticsAgent = async (chainId, agentId) => {
-  const url = `${mechAnalyticsUrl.replace(/\/$/, '')}/v1/metrics/ai-agent/${chainId}/${agentId}`;
+// ---------------------------------------------------------------------------
+// Marketplace subgraph pulls
+// ---------------------------------------------------------------------------
+
+// Same query shape and pagination discipline as
+// getMechRequestsIncrementalQuery (common-util/graphql/queries.ts:816)
+// + fetchIncrementalMechRequests (roi-distribution.ts:229). A full page
+// at the graph-node skip ceiling marks the result truncated instead of
+// silently under-counting.
+const fetchMarketplaceRequests = async (url, windowStartSec, windowEndSec, label) => {
+  const rows = [];
+  let skip = 0;
+  let truncated = false;
+  for (;;) {
+    const data = await gqlRequest(
+      url,
+      `query MechRequestsIncremental {
+        requests(
+          first: ${SUBGRAPH_PAGE}
+          skip: ${skip}
+          where: { blockTimestamp_gt: "${windowStartSec}" }
+          orderBy: blockTimestamp
+          orderDirection: asc
+        ) {
+          sender { id }
+          blockTimestamp
+          parsedRequest { questionTitle }
+        }
+      }`,
+      label
+    );
+    const page = data?.requests ?? [];
+    if (verbose) emit(`  [${label}] requests page skip=${skip} rows=${page.length}`);
+    rows.push(...page);
+    if (page.length < SUBGRAPH_PAGE) break;
+    skip += SUBGRAPH_PAGE;
+    if (skip > SUBGRAPH_MAX_SKIP) {
+      truncated = true;
+      break;
+    }
+  }
+
+  // Mirror the site's per-row guards (roi-distribution.ts:251-254):
+  // rows without sender, title, or a positive timestamp never enter QMR.
+  const usable = [];
+  let skippedMissingKey = 0;
+  let skippedAfterWindowEnd = 0;
+  for (const req of rows) {
+    const requester = req.sender?.id?.toLowerCase();
+    const title = req.parsedRequest?.questionTitle;
+    const ts = Number(req.blockTimestamp ?? 0);
+    if (!requester || !title || ts <= 0) {
+      skippedMissingKey += 1;
+      continue;
+    }
+    if (ts > windowEndSec) {
+      skippedAfterWindowEnd += 1;
+      continue;
+    }
+    usable.push({ requester, ts, title });
+  }
+  return { rows: usable, truncated, skippedMissingKey, skippedAfterWindowEnd };
+};
+
+// Subset of getOmenDailyProfitStatsQuery (queries.ts:721) /
+// getPolymarketDailyProfitStatsQuery (queries.ts:790): only the fields
+// the settlement-consumption matching needs.
+const fetchDailyStats = async (url, dateGte, dateLte, participantTitleField, label) => {
+  const participantSelection =
+    participantTitleField === 'question' ? 'question' : 'metadata { title }';
+  const stats = [];
+  let skip = 0;
+  let truncated = false;
+  for (;;) {
+    const data = await gqlRequest(
+      url,
+      `query DailyProfitStats {
+        dailyProfitStatistics(
+          first: ${SUBGRAPH_PAGE}
+          skip: ${skip}
+          where: { date_gte: ${dateGte}, date_lte: ${dateLte} }
+          orderBy: date
+          orderDirection: asc
+        ) {
+          traderAgent { id }
+          date
+          profitParticipants { ${participantSelection} }
+        }
+      }`,
+      label
+    );
+    const page = data?.dailyProfitStatistics ?? [];
+    if (verbose) emit(`  [${label}] daily-stats page skip=${skip} rows=${page.length}`);
+    stats.push(...page);
+    if (page.length < SUBGRAPH_PAGE) break;
+    skip += SUBGRAPH_PAGE;
+    if (skip > SUBGRAPH_MAX_SKIP) {
+      truncated = true;
+      break;
+    }
+  }
+  return { stats, truncated };
+};
+
+// getMarketplaceSendersQuery (queries.ts) narrowed to the Safes under
+// verification via id_in — the site pages every sender, but check 3
+// only needs the registered Safes' counters.
+const fetchSenderTotals = async (url, safeIds, label) => {
+  const totals = new Map();
+  for (let i = 0; i < safeIds.length; i += SENDER_ID_CHUNK) {
+    const chunk = safeIds.slice(i, i + SENDER_ID_CHUNK);
+    const idList = chunk.map((id) => `"${id}"`).join(', ');
+    const data = await gqlRequest(
+      url,
+      `query MarketplaceSendersById {
+        senders(first: ${SENDER_ID_CHUNK}, where: { id_in: [${idList}] }) {
+          id
+          totalLegacyRequests
+          totalMarketplaceRequests
+        }
+      }`,
+      label
+    );
+    for (const sender of data?.senders ?? []) {
+      totals.set(
+        sender.id.toLowerCase(),
+        Number(sender.totalLegacyRequests) + Number(sender.totalMarketplaceRequests)
+      );
+    }
+  }
+  return totals;
+};
+
+// ---------------------------------------------------------------------------
+// mech-analytics pulls
+// ---------------------------------------------------------------------------
+
+const fetchJson = async (url, label) => {
   const res = await fetch(url);
   if (!res.ok) {
-    throw new Error(`mech-analytics ${chainId}/${agentId}: ${res.status} ${res.statusText}`);
+    throw new Error(`${label}: mech-analytics returned HTTP ${res.status}`);
   }
   return res.json();
 };
 
-// ---------------------------------------------------------------------------
-// Cross-agent aggregation (omenstrat = agent 14 + agent 25 on Gnosis)
-//
-// mech-analytics itself aggregates multi-Safe agents in
-// _aggregate_agent (etl/api/routes/agent.py:303). It uses:
-//   * ROI:  sum(payout) / sum(cost)  — never mean of ratios
-//   * Accuracy: bet-count-weighted mean of per-Safe accuracy
-// Because the per-agent endpoint returns already-aggregated ROI (not
-// raw payout/cost), a client-side sum can't perfectly reproduce
-// mech-analytics's payout-weighted ROI for the omenstrat pair. We
-// approximate with an n_bets-weighted mean of ROI, which is the
-// best we can do from the exposed fields, and note the caveat in
-// the report. This is one of the gaps the parity script surfaces
-// — a genuine bug in omenstrat parity would blow past the
-// tolerance regardless of this approximation.
-// ---------------------------------------------------------------------------
+// Pages /v1/data/scored-rows the same way the site's client does
+// (common-util/api/predict/mech-analytics.ts::iterateScoredRows).
+// `since` is >= on requested_at, so windowStart+1s reproduces the
+// subgraph's strict blockTimestamp_gt boundary.
+const fetchScoredRows = async (chainId, windowStartSec, windowEndSec, label) => {
+  const rows = [];
+  let truncated = false;
+  const url = new URL(`${mechAnalyticsBase}/v1/data/scored-rows`);
+  url.searchParams.set('chain_id', String(chainId));
+  url.searchParams.set('since', isoFromUnixSec(windowStartSec + 1));
+  url.searchParams.set('until', isoFromUnixSec(windowEndSec));
+  url.searchParams.set('limit', String(SCORED_ROWS_PAGE));
 
-const weightedMean = (pairs) => {
-  const nonNull = pairs.filter(([value]) => value != null && Number.isFinite(value));
-  if (nonNull.length === 0) return null;
-  const totalWeight = nonNull.reduce((sum, [, weight]) => sum + (weight || 0), 0);
-  if (totalWeight === 0) return null;
-  const weightedSum = nonNull.reduce((sum, [value, weight]) => sum + value * (weight || 0), 0);
-  return weightedSum / totalWeight;
-};
-
-const aggregateOmenstrat = (agentResponses, windowKey) => {
-  // Both agents' window blocks; nulls when the rollup has nothing.
-  const windows = agentResponses.map((r) => r?.windows?.[windowKey] ?? null);
-  const nBetsFor = (w, platform) => (w ? w[`n_bets_${platform}`] || 0 : 0);
-  // Weight ROI and accuracy by the platform-specific bet count. If both
-  // sides are zero-bet, the metric collapses to null (nothing to
-  // compare) which the diff step treats as an unresolved cell.
-  return {
-    roi_omen: weightedMean(windows.map((w) => [w?.roi_omen, nBetsFor(w, 'omen')])),
-    roi_polymarket: weightedMean(
-      windows.map((w) => [w?.roi_polymarket, nBetsFor(w, 'polymarket')])
-    ),
-    tool_accuracy_omen: weightedMean(
-      windows.map((w) => [w?.tool_accuracy_omen, nBetsFor(w, 'omen')])
-    ),
-    tool_accuracy_polymarket: weightedMean(
-      windows.map((w) => [w?.tool_accuracy_polymarket, nBetsFor(w, 'polymarket')])
-    ),
-  };
-};
-
-// ---------------------------------------------------------------------------
-// Field extraction
-//
-// olas-website stores percent values (e.g. 12.5 for 12.5%). mech-analytics
-// stores ratios (e.g. 0.125 for 12.5%). The diff step converts before
-// comparing.
-// ---------------------------------------------------------------------------
-
-const olasPartialRoi = (data, platform, olasWindow) => {
-  const wm = data?.[platform]?.partialRoi?.value?.[olasWindow];
-  return wm == null ? null : Number(wm);
-};
-
-const olasAccuracy = (data, platform, olasWindow) => {
-  const wm = data?.[platform]?.successRate?.value?.[olasWindow];
-  return wm == null ? null : Number(wm);
-};
-
-// mech-analytics returns ROI as a ratio; multiply by 100 for percent.
-// The specific platform (omen vs polymarket) is inferred from the
-// consumer platform key: omenstrat -> omen, polystrat -> polymarket.
-const MECH_PLATFORM_MAP = { omenstrat: 'omen', polystrat: 'polymarket' };
-
-const mechRoiPercent = (windowFields, consumerPlatform) => {
-  const key = `roi_${MECH_PLATFORM_MAP[consumerPlatform]}`;
-  const value = windowFields?.[key];
-  return value == null ? null : value * 100;
-};
-
-const mechAccuracyPercent = (windowFields, consumerPlatform) => {
-  const key = `tool_accuracy_${MECH_PLATFORM_MAP[consumerPlatform]}`;
-  const value = windowFields?.[key];
-  return value == null ? null : value * 100;
-};
-
-// ---------------------------------------------------------------------------
-// Diff logic
-// ---------------------------------------------------------------------------
-
-const compareCell = (oldValue, newValue) => {
-  if (oldValue == null && newValue == null) return { status: 'both-null' };
-  if (oldValue == null || newValue == null) {
-    return { status: 'null-mismatch', oldValue, newValue };
+  let cursor = null;
+  let pages = 0;
+  for (;;) {
+    if (cursor) url.searchParams.set('cursor', cursor);
+    const page = await fetchJson(url, label);
+    if (!Array.isArray(page.rows)) {
+      throw new Error(`${label}: scored-rows response has no rows array`);
+    }
+    if (verbose) emit(`  [${label}] scored-rows page ${pages + 1} rows=${page.rows.length}`);
+    rows.push(...page.rows);
+    pages += 1;
+    if (!page.next_cursor) break;
+    if (typeof page.next_cursor !== 'string') {
+      throw new Error(`${label}: scored-rows next_cursor is not a string`);
+    }
+    if (pages >= SCORED_ROWS_MAX_PAGES) {
+      truncated = true;
+      break;
+    }
+    cursor = page.next_cursor;
   }
-  if (!Number.isFinite(oldValue) || !Number.isFinite(newValue)) {
-    return { status: 'non-finite', oldValue, newValue };
+  return { rows, truncated };
+};
+
+const fetchAgentAggregate = async (chainId, agentId) => {
+  const label = `ai-agent ${chainId}/${agentId}`;
+  const agent = await fetchJson(
+    `${mechAnalyticsBase}/v1/metrics/ai-agent/${chainId}/${agentId}`,
+    label
+  );
+  // days=0 skips the per-Safe daily series — check 3 only needs the
+  // registered Safe addresses.
+  const instances = await fetchJson(
+    `${mechAnalyticsBase}/v1/metrics/ai-agent/${chainId}/${agentId}/instances?days=0`,
+    `${label}/instances`
+  );
+  if (!Array.isArray(instances)) {
+    throw new Error(`${label}: instances response is not an array`);
   }
-  const denom = Math.max(Math.abs(oldValue), 1e-6);
-  const relDiff = Math.abs(oldValue - newValue) / denom;
-  return {
-    status: relDiff <= tolerance ? 'pass' : 'fail',
-    oldValue,
-    newValue,
-    relDiff,
+  return { agent, instances };
+};
+
+// ---------------------------------------------------------------------------
+// Check 1 — open-market count parity
+// ---------------------------------------------------------------------------
+
+// Reproduces roi-distribution.ts's open-market classification over the
+// window: build the QMR-shaped map title→agent→count from the
+// marketplace feed, then consume settled entries via profitParticipants
+// titles (exact key first, then normalizeTitle — mirrors
+// roi-distribution.ts:581-591 including per-agent consumption).
+const computeSubgraphOpenCount = (requests, dailyStats, participantTitleField) => {
+  const qmr = new Map(); // title -> Map(agent -> count)
+  const normalizedIndex = new Map(); // normalizeTitle(title) -> title
+  for (const { requester, title } of requests) {
+    if (!qmr.has(title)) {
+      qmr.set(title, new Map());
+      normalizedIndex.set(normalizeTitle(title), title);
+    }
+    const agents = qmr.get(title);
+    agents.set(requester, (agents.get(requester) ?? 0) + 1);
+  }
+
+  let consumed = 0;
+  for (const stat of dailyStats) {
+    const agentId = stat.traderAgent?.id?.toLowerCase();
+    if (!agentId) continue;
+    for (const participant of stat.profitParticipants ?? []) {
+      const title =
+        participantTitleField === 'question' ? participant.question : participant.metadata?.title;
+      if (!title) continue;
+      const matchedKey = qmr.has(title)
+        ? title
+        : (normalizedIndex.get(normalizeTitle(title)) ?? null);
+      if (!matchedKey) continue;
+      const agents = qmr.get(matchedKey);
+      const count = agents.get(agentId) ?? 0;
+      if (count > 0) {
+        consumed += count;
+        agents.delete(agentId);
+      }
+    }
+  }
+
+  let open = 0;
+  for (const agents of qmr.values()) {
+    for (const count of agents.values()) open += count;
+  }
+  return { open, consumed };
+};
+
+// Breaks the mech-analytics window rows out the way §12 Q4 prescribes.
+// Only (a) pending+market_id is what the consumer's flag-on path counts
+// (mech-analytics.ts skips invalid rows and rows without requester or
+// title before they reach QMR); (b) and (c) are reported so a naive
+// resolved=false count overshooting is visible in the artifact.
+const classifyAnalyticsRows = (rows) => {
+  const counts = {
+    pending_with_market: 0, // (a) — the gated number
+    invalid: 0, // (b)
+    no_market_id: 0, // (c) — non-invalid rows without a market
+    resolved: 0,
+    skipped_missing_key: 0,
   };
+  const usable = [];
+  for (const row of rows) {
+    const requester = row.requester?.toLowerCase();
+    const title = row.question_title;
+    if (!requester || !title) {
+      counts.skipped_missing_key += 1;
+      continue;
+    }
+    usable.push({ requester, row });
+    if (row.resolution_status === 'invalid') {
+      counts.invalid += 1;
+    } else if (row.market_id == null) {
+      counts.no_market_id += 1;
+    } else if (row.resolution_status === 'pending') {
+      counts.pending_with_market += 1;
+    } else {
+      counts.resolved += 1;
+    }
+  }
+  return { counts, usable };
+};
+
+// ---------------------------------------------------------------------------
+// Check 2 — row parity
+// ---------------------------------------------------------------------------
+
+// Multiset diff on (requester, unix timestamp, normalizeTitle(title)).
+// normalizeTitle on both sides matches the consumer's own matching
+// discipline and absorbs title truncation differences between the
+// subgraph's parsedRequest and the lake's question_title.
+const diffRowSets = (subgraphRows, analyticsRows) => {
+  const keyOf = (requester, ts, title) => `${requester}|${ts}|${normalizeTitle(title)}`;
+  const tally = new Map();
+  for (const { requester, ts, title } of subgraphRows) {
+    const key = keyOf(requester, ts, title);
+    const entry = tally.get(key) ?? { subgraph: 0, analytics: 0 };
+    entry.subgraph += 1;
+    tally.set(key, entry);
+  }
+  for (const { requester, row } of analyticsRows) {
+    const ts = Math.floor(Date.parse(row.requested_at) / 1000);
+    if (!Number.isFinite(ts)) continue;
+    const key = keyOf(requester, ts, row.question_title);
+    const entry = tally.get(key) ?? { subgraph: 0, analytics: 0 };
+    entry.analytics += 1;
+    tally.set(key, entry);
+  }
+
+  let missingInAnalytics = 0;
+  let extraInAnalytics = 0;
+  const missingSamples = [];
+  const extraSamples = [];
+  for (const [key, { subgraph, analytics }] of tally) {
+    if (subgraph > analytics) {
+      missingInAnalytics += subgraph - analytics;
+      if (missingSamples.length < SAMPLE_LIMIT) missingSamples.push(key);
+    } else if (analytics > subgraph) {
+      extraInAnalytics += analytics - subgraph;
+      if (extraSamples.length < SAMPLE_LIMIT) extraSamples.push(key);
+    }
+  }
+  return { missingInAnalytics, extraInAnalytics, missingSamples, extraSamples };
 };
 
 // ---------------------------------------------------------------------------
 // Main
 // ---------------------------------------------------------------------------
 
-let exitCode = 1; // sentinel: any unexpected exit stays 1
+let exitCode = 1; // sentinel: only the verdict block overwrites it
 let verdict = 'ERROR';
-const cellResults = [];
+const checkResults = [];
+
+const record = (result) => {
+  checkResults.push(result);
+  return result;
+};
 
 try {
-  section('Data pulls');
-  emit('  pulling olas-website snapshot from Vercel Blob...');
-  const olasData = await fetchOlasWebsiteSnapshot();
-  emit(
-    `  snapshot fetched (timestamp: ${olasData.omenstrat?.partialRoi?.status?.checkedAt || 'unknown'})`
-  );
+  const nowSec = Math.floor(Date.now() / 1000);
+  const windowEndSec = nowSec - lagBufferMinutes * 60;
+  const windowStartSec = nowSec - windowDays * DAY_SECONDS;
+  if (windowEndSec <= windowStartSec) {
+    throw new Error('lag buffer consumes the whole window — lower --lag-buffer-minutes');
+  }
+  metadata.window_start_utc = isoFromUnixSec(windowStartSec);
+  metadata.window_end_utc = isoFromUnixSec(windowEndSec);
+  emit(`  window:               (${metadata.window_start_utc}, ${metadata.window_end_utc}]`);
 
-  emit('  pulling mech-analytics agent responses...');
-  const [omenstratAgent14, omenstratAgent25, polystratAgent] = await Promise.all([
-    fetchMechAnalyticsAgent(OMENSTRAT_AGENTS[0].chainId, OMENSTRAT_AGENTS[0].agentId),
-    fetchMechAnalyticsAgent(OMENSTRAT_AGENTS[1].chainId, OMENSTRAT_AGENTS[1].agentId),
-    fetchMechAnalyticsAgent(POLYSTRAT_AGENT.chainId, POLYSTRAT_AGENT.agentId),
-  ]);
+  for (const platform of PLATFORMS) {
+    const { key, chainId, agentId } = platform;
+    const marketplaceUrl = process.env[platform.marketplaceUrlEnv];
+    const dailyStatsUrl = process.env[platform.dailyStatsUrlEnv];
 
-  section('Per-cell diff');
-  emit(
-    '  platform     window   field         old (olas)   new (mech-analytics)   rel diff   status'
-  );
-  for (const [platform, mechResponse] of [
-    ['omenstrat', null], // aggregated below
-    ['polystrat', polystratAgent],
-  ]) {
-    for (const [olasWindow, mechWindow] of Object.entries(WINDOW_MAP)) {
-      const mechWindowFields =
-        platform === 'omenstrat'
-          ? aggregateOmenstrat([omenstratAgent14, omenstratAgent25], mechWindow)
-          : mechResponse?.windows?.[mechWindow];
+    section(`${key} (chain ${chainId}, agent ${agentId}) — data pulls`);
+    const [marketplace, dailyStats, scoredRows, aggregate] = await Promise.all([
+      fetchMarketplaceRequests(marketplaceUrl, windowStartSec, windowEndSec, `${key}:marketplace`),
+      fetchDailyStats(
+        dailyStatsUrl,
+        Math.floor(windowStartSec / DAY_SECONDS) * DAY_SECONDS,
+        nowSec,
+        platform.participantTitleField,
+        `${key}:daily-stats`
+      ),
+      fetchScoredRows(chainId, windowStartSec, windowEndSec, `${key}:scored-rows`),
+      fetchAgentAggregate(chainId, agentId),
+    ]);
+    emit(`  marketplace requests in window: ${marketplace.rows.length}`);
+    emit(
+      `    (skipped: missing sender/title/ts=${marketplace.skippedMissingKey}, ` +
+        `after window end=${marketplace.skippedAfterWindowEnd}` +
+        `${marketplace.truncated ? ', TRUNCATED at subgraph skip cap' : ''})`
+    );
+    emit(
+      `  daily-stat rows: ${dailyStats.stats.length}` +
+        `${dailyStats.truncated ? ' (TRUNCATED at subgraph skip cap)' : ''}`
+    );
+    emit(
+      `  scored rows in window: ${scoredRows.rows.length}` +
+        `${scoredRows.truncated ? ' (TRUNCATED at page cap)' : ''}`
+    );
 
-      if (!mechWindowFields) {
-        cellResults.push({
-          platform,
-          window: olasWindow,
-          field: 'partialRoi',
-          status: 'missing-field',
-        });
-        cellResults.push({
-          platform,
-          window: olasWindow,
-          field: 'successRate',
-          status: 'missing-field',
-        });
-        emit(`  ${platform.padEnd(12)} ${olasWindow.padEnd(8)} (mech-analytics window missing)`);
-        continue;
+    const { counts, usable: usableAnalyticsRows } = classifyAnalyticsRows(scoredRows.rows);
+
+    // ---- Check 1: open-market count parity --------------------------------
+    section(`${key} — check 1: open-market count parity`);
+    const { open, consumed } = computeSubgraphOpenCount(
+      marketplace.rows,
+      dailyStats.stats,
+      platform.participantTitleField
+    );
+    emit(`  subgraph feed: ${marketplace.rows.length} requests, ${consumed} consumed by`);
+    emit(`    settlement matching (normalizeTitle vs profitParticipants) → open=${open}`);
+    emit('  mech-analytics breakdown (consumer counts only (a)):');
+    emit(`    (a) pending + market_id: ${counts.pending_with_market}`);
+    emit(`    (b) invalid:             ${counts.invalid}`);
+    emit(`    (c) no market_id:        ${counts.no_market_id}`);
+    emit(`        resolved:            ${counts.resolved}`);
+    emit(`        missing key skipped: ${counts.skipped_missing_key}`);
+
+    const check1Truncated = marketplace.truncated || dailyStats.truncated || scoredRows.truncated;
+    let check1Status;
+    if (marketplace.rows.length === 0 && scoredRows.rows.length === 0) {
+      check1Status = 'vacuous';
+      emit('  VACUOUS: no rows on either side in the window.');
+    } else if (open === counts.pending_with_market) {
+      // Exact equality — counts get no tolerance (unlike check 3, both
+      // sides here describe the same window of the same requests).
+      check1Status = check1Truncated ? 'gap' : 'pass';
+      emit(
+        check1Truncated
+          ? `  MATCH on truncated data (${open}) — treating as a data gap, not a pass.`
+          : `  PASS: open-market counts match exactly (${open}).`
+      );
+    } else if (check1Truncated) {
+      // A truncated fetch cannot prove a divergence — the missing rows
+      // could account for the whole delta.
+      check1Status = 'gap';
+      emit(
+        `  GAP: counts differ (subgraph=${open}, analytics=${counts.pending_with_market}) but a fetch was truncated.`
+      );
+    } else {
+      check1Status = 'divergence';
+      emit(
+        `  DIVERGENCE: subgraph open=${open} vs analytics pending+market_id=${counts.pending_with_market}.`
+      );
+    }
+    record({
+      check: 'open_market_count',
+      platform: key,
+      status: check1Status,
+      subgraph_open: open,
+      subgraph_consumed: consumed,
+      analytics: counts,
+      truncated: check1Truncated,
+    });
+
+    // ---- Check 2: scored-rows row parity ----------------------------------
+    section(`${key} — check 2: scored-rows row parity`);
+    const rowDiff = diffRowSets(marketplace.rows, usableAnalyticsRows);
+    emit(
+      `  subgraph rows: ${marketplace.rows.length}, analytics rows: ${usableAnalyticsRows.length}`
+    );
+    emit(`  missing in analytics: ${rowDiff.missingInAnalytics}`);
+    emit(`  extra in analytics:   ${rowDiff.extraInAnalytics}`);
+    for (const sample of rowDiff.missingSamples) emit(`    missing: ${sample}`);
+    for (const sample of rowDiff.extraSamples) emit(`    extra:   ${sample}`);
+
+    const check2Truncated = marketplace.truncated || scoredRows.truncated;
+    let check2Status;
+    if (marketplace.rows.length === 0 && usableAnalyticsRows.length === 0) {
+      check2Status = 'vacuous';
+      emit('  VACUOUS: no rows on either side in the window.');
+    } else if (rowDiff.missingInAnalytics === 0 && rowDiff.extraInAnalytics === 0) {
+      check2Status = check2Truncated ? 'gap' : 'pass';
+      emit(
+        check2Truncated
+          ? '  MATCH on truncated data — treating as a data gap, not a pass.'
+          : '  PASS: row sets match exactly.'
+      );
+    } else if (check2Truncated) {
+      check2Status = 'gap';
+      emit('  GAP: row sets differ but a fetch was truncated — rerun with a smaller window.');
+    } else {
+      check2Status = 'divergence';
+      emit('  DIVERGENCE: row sets differ.');
+    }
+    record({
+      check: 'row_parity',
+      platform: key,
+      status: check2Status,
+      subgraph_rows: marketplace.rows.length,
+      analytics_rows: usableAnalyticsRows.length,
+      missing_in_analytics: rowDiff.missingInAnalytics,
+      extra_in_analytics: rowDiff.extraInAnalytics,
+      missing_samples: rowDiff.missingSamples,
+      extra_samples: rowDiff.extraSamples,
+      truncated: check2Truncated,
+    });
+
+    // ---- Check 3: senderTotal parity --------------------------------------
+    section(`${key} — check 3: senderTotal parity`);
+    const safes = aggregate.instances
+      .map((entry) => entry?.agent_address?.toLowerCase())
+      .filter(Boolean);
+    // Null is preserved, never coerced to 0: windows.all === null means
+    // "no rollup row", which must not read as "zero requests".
+    const allWindow = aggregate.agent?.windows?.all ?? null;
+    const analyticsTotal = allWindow == null ? null : (allWindow.n_mech_requests ?? null);
+
+    let check3Status;
+    if (safes.length === 0 && analyticsTotal == null) {
+      check3Status = 'vacuous';
+      emit('  VACUOUS: no registered Safes and no rollup row — nothing to compare.');
+      record({ check: 'sender_total', platform: key, status: check3Status, safes: 0 });
+    } else if (analyticsTotal == null) {
+      check3Status = 'gap';
+      emit(
+        `  GAP: ${safes.length} Safe(s) registered but agent_aggregates has no 'all' window row.`
+      );
+      record({
+        check: 'sender_total',
+        platform: key,
+        status: check3Status,
+        safes: safes.length,
+        analytics_total: null,
+      });
+    } else {
+      const senderTotals = await fetchSenderTotals(marketplaceUrl, safes, `${key}:senders`);
+      // A Safe absent from the senders result legitimately means "never
+      // made a request" (subgraph entities are created on first
+      // request) — that is an actual 0, not a fetch failure (failures
+      // throw above).
+      let subgraphTotal = 0;
+      let safesWithoutSender = 0;
+      for (const safe of safes) {
+        const total = senderTotals.get(safe);
+        if (total == null) safesWithoutSender += 1;
+        else subgraphTotal += total;
       }
-
-      for (const [fieldName, olasGetter, mechGetter] of [
-        ['partialRoi', olasPartialRoi, mechRoiPercent],
-        ['successRate', olasAccuracy, mechAccuracyPercent],
-      ]) {
-        const oldValue = olasGetter(olasData, platform, olasWindow);
-        const newValue = mechGetter(mechWindowFields, platform);
-        const result = compareCell(oldValue, newValue);
-        cellResults.push({ platform, window: olasWindow, field: fieldName, ...result });
-        const oldStr = oldValue == null ? 'null' : oldValue.toFixed(4);
-        const newStr = newValue == null ? 'null' : newValue.toFixed(4);
-        const relStr = result.relDiff == null ? '-' : result.relDiff.toExponential(2);
-        emit(
-          `  ${platform.padEnd(12)} ${olasWindow.padEnd(8)} ${fieldName.padEnd(13)} ${oldStr.padStart(10)}   ${newStr.padStart(18)}   ${relStr.padStart(9)}   ${result.status}`
-        );
+      const delta = Math.abs(analyticsTotal - subgraphTotal);
+      emit(`  registered Safes: ${safes.length} (${safesWithoutSender} with no sender entity)`);
+      emit(`  analytics n_mech_requests (all): ${analyticsTotal}`);
+      emit(`  subgraph Σ(totalLegacy+totalMarketplace): ${subgraphTotal}`);
+      emit(`  |delta| = ${delta} (tolerance ±${countTolerance}, settlement-lag allowance)`);
+      if (delta <= countTolerance) {
+        check3Status = 'pass';
+        emit('  PASS: totals within the settlement-lag tolerance.');
+      } else {
+        check3Status = 'divergence';
+        emit('  DIVERGENCE: totals differ beyond the settlement-lag tolerance.');
       }
+      record({
+        check: 'sender_total',
+        platform: key,
+        status: check3Status,
+        safes: safes.length,
+        safes_without_sender: safesWithoutSender,
+        analytics_total: analyticsTotal,
+        subgraph_total: subgraphTotal,
+        delta,
+        tolerance_abs: countTolerance,
+      });
     }
   }
 
+  // ---- Verdict -------------------------------------------------------------
   section('Verdict');
-  const failures = cellResults.filter(
-    (r) => r.status === 'fail' || r.status === 'null-mismatch' || r.status === 'non-finite'
-  );
-  const missing = cellResults.filter((r) => r.status === 'missing-field');
-  emit(`  cells checked:       ${cellResults.length}`);
-  emit(`  cells passed:        ${cellResults.filter((r) => r.status === 'pass').length}`);
-  emit(`  cells both-null:     ${cellResults.filter((r) => r.status === 'both-null').length}`);
-  emit(`  cells failed:        ${failures.length}`);
-  emit(`  cells missing field: ${missing.length}`);
+  const byStatus = (status) => checkResults.filter((r) => r.status === status);
+  const divergences = byStatus('divergence');
+  const gaps = byStatus('gap');
+  const vacuous = byStatus('vacuous');
+  emit(`  checks run:       ${checkResults.length}`);
+  emit(`  passed:           ${byStatus('pass').length}`);
+  emit(`  diverged:         ${divergences.length}`);
+  emit(`  data gaps:        ${gaps.length}`);
+  emit(`  vacuous:          ${vacuous.length}`);
 
-  if (missing.length > 0) {
+  // Precedence: divergence (3) outranks gap (4) so an incomplete fetch
+  // on one check can never mask a real regression on another. The
+  // all-vacuous guard (2) stops a run where nothing was comparable from
+  // reading as a PASS.
+  if (divergences.length > 0) {
     emit('');
-    emit(
-      `FAIL (missing field): ${missing.length} cell(s) — mech-analytics response is missing the expected window/field.`
-    );
-    exitCode = 4;
-    verdict = 'FAIL';
-  } else if (failures.length > 0) {
-    emit('');
-    emit(`FAIL (divergence): ${failures.length} cell(s) diverged beyond tolerance ${tolerance}.`);
-    for (const f of failures) {
-      emit(
-        `  - ${f.platform}/${f.window}/${f.field}: old=${f.oldValue}, new=${f.newValue}, status=${f.status}`
-      );
-    }
+    emit(`FAIL (divergence): ${divergences.map((r) => `${r.platform}/${r.check}`).join(', ')}`);
     exitCode = 3;
     verdict = 'FAIL';
+  } else if (gaps.length > 0) {
+    emit('');
+    emit(`FAIL (data gap): ${gaps.map((r) => `${r.platform}/${r.check}`).join(', ')}`);
+    exitCode = 4;
+    verdict = 'FAIL';
+  } else if (vacuous.length === checkResults.length) {
+    emit('');
+    emit('VACUOUS: every check had nothing to compare on either side — not a pass.');
+    exitCode = 2;
+    verdict = 'VACUOUS';
   } else {
     emit('');
-    emit('PASS: every cell within tolerance.');
+    emit('PASS: every non-vacuous check matched.');
     exitCode = 0;
     verdict = 'PASS';
   }
 } catch (err) {
   emit('');
-  emit(`ERROR: ${err.message}`);
-  if (err.stack) emit(err.stack);
+  emit(`ERROR: ${scrub(err.message)}`);
+  if (err.stack) emit(scrub(err.stack));
+  if (err.cause) emit(`cause: ${scrub(err.cause.message ?? err.cause)}`);
   // exitCode remains 1 (sentinel)
 } finally {
   emit('');
@@ -435,11 +940,7 @@ try {
     writeFileSync(mdPath, reportChunks.join(''), 'utf8');
     writeFileSync(
       jsonPath,
-      `${JSON.stringify(
-        { metadata, cells: cellResults, verdict, exit_code: exitCode },
-        null,
-        2
-      )}\n`,
+      `${JSON.stringify({ metadata, checks: checkResults, verdict, exit_code: exitCode }, null, 2)}\n`,
       'utf8'
     );
     emit(`\nwrote ${mdPath}`);


### PR DESCRIPTION
## Summary

Parity gate for the olas-website → mech-analytics migration, scoped to what actually migrates per `mech-analytics/docs/consumer_migration.md` §4 + §12 Q4: **the per-request mech-request feed swap** behind `USE_MECH_ANALYTICS` (PR #548) — `fetchIncrementalMechRequests` → `/v1/data/scored-rows`, `senderTotal` → `agent_aggregates.n_mech_requests`. partialRoi/successRate keep their site-side formulas and are out of scope.

**The gate** (`scripts/verify-mech-analytics-parity.mjs`, `yarn verify-mech-analytics-parity`), per platform (omenstrat = gnosis/100/14, polystrat = polygon/137/86), last-4-days window with a lag buffer for scoring delay:
1. **Open-market count parity (core):** scored-rows `pending` + `market_id` count vs the site's open count (marketplace-subgraph feed minus settlement consumption via normalizeTitle matching, mirroring `roi-distribution.ts`). Reports the (a) pending+market_id / (b) invalid / (c) no-market_id breakout. Exact.
2. **Row parity:** multiset diff on (requester, unix ts, normalized title) between `getMechRequestsIncrementalQuery` rows and scored-rows; missing/extra reported with samples. Exact.
3. **senderTotal parity:** `windows.all.n_mech_requests` vs Σ(totalLegacy + totalMarketplace) over the Safes from `/instances`. ±5 absolute (settlement-lag/rollup-cache allowance, configurable).

The flag-on vs flag-off `openRequestCount` check runs in the ops staging parallel-run (needs the Next/Blob runtime) and is documented in the script header.

**Exit codes:** 0 PASS · 1 unexpected error (sentinel) · 2 all-vacuous (nothing comparable never reads as a pass) · 3 divergence · 4 data gap (e.g. subgraph skip-cap truncation). Divergence outranks gap. Null is never coerced to 0. `finally` always writes `parity-<ts>.md` + `.json` artifacts. Subgraph URLs embed API keys — error output is scrubbed.

**Docker/CI:** `Dockerfile.verify` (node:22-slim, non-root, GIT_SHA baked, node-builtins only so no dependency install layer) + `publish-verify-image.yaml` (publish on release as `valory/olas-website-verify:<version>`; fork-safe build-only + `--help` smoke on PRs touching image inputs).

Read-only and additive — no production code paths touched.

## Test plan

- [x] `yarn lint` clean
- [x] All five exit paths proven against a local mock (pass=0, divergence=3, vacuous=2, gap=4, gap+divergence=3); artifacts written
- [x] Docker build; `--help` exit 0; missing-env run exits 1 with a clean config-error message
- [ ] Production team: real run with the 4 subgraph URLs + `MECH_ANALYTICS_URL`; post the PASS artifact here before cutover

🤖 Generated with [Claude Code](https://claude.com/claude-code)