### PR TITLE
fix(parity): correct check 1 gate, check 3 counter, add --since/--until

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -70,6 +70,31 @@ jobs:
       - name: Validate yarn.lock registry URLs and integrity
         run: yarn lint:lockfile
 
+  parity-script-tests:
+    # Unit tests for the mech-analytics parity verifier
+    # (scripts/verify-mech-analytics-parity*.mjs). The script gates the
+    # olas-website/mech-analytics count-source swap; two prior wiring
+    # regressions (check 1 comparing the wrong bucket, check 3 summing
+    # both counters) shipped because these helpers had no CI coverage.
+    # node --test only runs on the parity test file so an unrelated test
+    # in the repo can't gate this job.
+    name: Verify parity script tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version-file: .nvmrc
+          cache: 'yarn'
+      - name: Activate pinned Yarn via Corepack
+        run: |
+          corepack enable
+          corepack prepare yarn@1.22.22 --activate
+      - name: Install modules
+        run: yarn install --frozen-lockfile
+      - name: Run verify-mech-analytics-parity unit tests
+        run: yarn verify-mech-analytics-parity:test
+
   install-hooks:
     name: Install-hook diff
     runs-on: ubuntu-latest
@@ -122,7 +147,7 @@ jobs:
     # but if one is ever added, this guard prevents a `skipped` result from
     # silently satisfying the required status check.
     name: All checks passed
-    needs: [lint, audit, lockfile-lint, install-hooks]
+    needs: [lint, audit, lockfile-lint, install-hooks, parity-script-tests]
     if: always()
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/publish-verify-image.yaml
+++ b/.github/workflows/publish-verify-image.yaml
@@ -23,6 +23,7 @@ on:
     paths:
       - 'Dockerfile.verify'
       - 'scripts/verify-mech-analytics-parity.mjs'
+      - 'scripts/verify-mech-analytics-parity-lib.mjs'
       - '.github/workflows/publish-verify-image.yaml'
 
 # Least-privilege default for GITHUB_TOKEN (same discipline as main.yml):

--- a/Dockerfile.verify
+++ b/Dockerfile.verify
@@ -46,11 +46,15 @@ RUN mkdir -p /reports \
     && chown node:node /app /reports
 USER node
 
-# The entry point is the only file the image needs from the repo — it
-# imports node built-ins exclusively.
+# The entry point plus its extracted pure-helper module are the only
+# files the image needs from the repo — both import node built-ins
+# exclusively. The -lib.mjs module is imported by the entry point (pure
+# helpers live there so they can be unit-tested); shipping only the
+# entry point would break the import at runtime.
 COPY --chown=node:node \
     scripts/verify-mech-analytics-parity.mjs \
-    ./scripts/verify-mech-analytics-parity.mjs
+    scripts/verify-mech-analytics-parity-lib.mjs \
+    ./scripts/
 
 # ``docker run --rm <image> --help`` exercises the wiring without
 # secrets; a no-env run exits 1 with an ERROR verdict.

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "audit:install-hooks:update": "node scripts/audit-install-hooks.mjs --update",
     "license-check": "node scripts/license-check.mjs",
     "license-check:test": "node --test scripts/license-check.test.mjs",
-    "verify-mech-analytics-parity": "node scripts/verify-mech-analytics-parity.mjs"
+    "verify-mech-analytics-parity": "node scripts/verify-mech-analytics-parity.mjs",
+    "verify-mech-analytics-parity:test": "node --test scripts/verify-mech-analytics-parity.test.mjs"
   },
   "dependencies": {
     "@fontsource/inter": "5.2.6",

--- a/scripts/verify-mech-analytics-parity-lib.mjs
+++ b/scripts/verify-mech-analytics-parity-lib.mjs
@@ -123,32 +123,51 @@ export const computeWindow = ({
     }
     return { windowStartSec, windowEndSec, source: 'explicit' };
   }
+  // Anchor start to end (until = now - lag; since = until - days) so the
+  // span is exactly `days`, matching verify_migration_swap.py:_compute_window
+  // (mech-predict/scripts/verify_migration_swap.py:1286-1287). Anchoring
+  // start to `now` and end to `now - lag` shortens the window by the lag.
   const windowEndSec = nowSec - lagBufferMinutes * 60;
-  const windowStartSec = nowSec - windowDays * DAY_SECONDS;
-  if (windowEndSec <= windowStartSec) {
-    throw new Error('lag buffer consumes the whole window — lower --lag-buffer-minutes');
+  const windowStartSec = windowEndSec - windowDays * DAY_SECONDS;
+  if (windowEndSec <= 0) {
+    // lagBufferMinutes larger than nowSec — nonsensical clock, refuse
+    // to compute a window rather than producing a negative windowEnd.
+    throw new Error('lag buffer pushes window end to or before epoch — check --lag-buffer-minutes');
   }
   return { windowStartSec, windowEndSec, source: 'trailing' };
 };
 
 // ---------------------------------------------------------------------------
-// Check 1 — subgraph-side open-market count via QMR + dailyStats consumption
+// Check 1 — shared QMR pipeline (single-source correctness)
 // ---------------------------------------------------------------------------
 
-// Reproduces roi-distribution.ts's open-market classification over the
-// window: build the QMR-shaped map title→agent→count from the marketplace
-// feed, then consume settled entries via profitParticipants titles (exact
-// key first, then normalizeTitle — mirrors roi-distribution.ts:581-591
-// including per-agent consumption).
-export const computeSubgraphOpenCount = (requests, dailyStats, participantTitleField) => {
-  const qmr = new Map(); // title -> Map(agent -> count)
-  const normalizedIndex = new Map(); // normalizeTitle(title) -> title
-  for (const { requester, title } of requests) {
-    if (!qmr.has(title)) {
-      qmr.set(title, new Map());
-      normalizedIndex.set(normalizeTitle(title), title);
-    }
-    const agents = qmr.get(title);
+// The QMR is keyed on normalizeTitle(title) directly (not on the raw title
+// with a secondary normalized-index lookup). Two rationales:
+//
+//   1. Consumer parity. roi-distribution.ts:513-516 rebuilds `qmr` from
+//      `Object.keys(qmr)` after settlement consumption, then re-derives
+//      normalizedQmrMap from the surviving keys — so production only ever
+//      keeps a single QMR keyed by whichever raw title happened to arrive
+//      first for a given normalized bucket.
+//
+//   2. Order-independence between the two verifier feeds. The subgraph
+//      feed arrives by blockTimestamp; the scored-rows feed by
+//      requested_at + cursor. If we kept a raw-title QMR with a
+//      normalizedIndex fallback (as this file did previously), a collision
+//      past the 100-char slice would resolve to a different raw key on
+//      each side — same logical data, different open count, false
+//      divergence. Keying on normalizeTitle(title) collapses the bucket
+//      before insertion so the tie-break is a no-op.
+//
+// Entries are `{ requester, title }`. Callers pre-filter (invalid,
+// missing key, out-of-window, deduplicated) so the shared body never
+// re-implements per-feed shape logic.
+export const runQmrOpenCount = (entries, dailyStats) => {
+  const qmr = new Map(); // normalizeTitle(title) -> Map(agent -> count)
+  for (const { requester, title } of entries) {
+    const key = normalizeTitle(title);
+    if (!qmr.has(key)) qmr.set(key, new Map());
+    const agents = qmr.get(key);
     agents.set(requester, (agents.get(requester) ?? 0) + 1);
   }
 
@@ -157,14 +176,17 @@ export const computeSubgraphOpenCount = (requests, dailyStats, participantTitleF
     const agentId = stat.traderAgent?.id?.toLowerCase();
     if (!agentId) continue;
     for (const participant of stat.profitParticipants ?? []) {
-      const title =
-        participantTitleField === 'question' ? participant.question : participant.metadata?.title;
+      // Union with fallback matches roi-distribution.ts:573
+      // (`p.question ?? p.metadata?.title`). The two subgraphs surface the
+      // title in different fields (Omen: `question`, Polymarket:
+      // `metadata.title`) and a market whose title lands in the other
+      // field would otherwise fail to consume its QMR entry, overstating
+      // `open` asymmetrically per platform.
+      const title = participant.question ?? participant.metadata?.title;
       if (!title) continue;
-      const matchedKey = qmr.has(title)
-        ? title
-        : (normalizedIndex.get(normalizeTitle(title)) ?? null);
-      if (!matchedKey) continue;
-      const agents = qmr.get(matchedKey);
+      const key = normalizeTitle(title);
+      const agents = qmr.get(key);
+      if (!agents) continue;
       const count = agents.get(agentId) ?? 0;
       if (count > 0) {
         consumed += count;
@@ -180,22 +202,88 @@ export const computeSubgraphOpenCount = (requests, dailyStats, participantTitleF
   return { open, consumed };
 };
 
+// Subgraph-side adapter: build entries from marketplace-subgraph requests
+// (already usable — `requester`/`title`/`ts` guards fire in the fetcher)
+// and delegate to the shared pipeline. `participantTitleField` is
+// retained for signature stability but no longer needed inside the QMR:
+// the shared body reads both title fields via the consumer's `??` union.
+export const computeSubgraphOpenCount = (requests, dailyStats, _participantTitleField) => {
+  const entries = requests.map(({ requester, title }) => ({ requester, title }));
+  return runQmrOpenCount(entries, dailyStats);
+};
+
+// Analytics-side adapter: mirrors the consumer's flag-on filtering in
+// common-util/api/predict/mech-analytics.ts:171-197 exactly:
+//
+//   1. dedup on request_id (the API sends the same row again every time
+//      its resolution updates — without dedup every update re-inflates
+//      the analytics open count vs the subgraph, which counts each
+//      request once)
+//   2. window/ts validity gate (ts <= 0 || ts < windowStartSec) — done
+//      BEFORE the invalid check so out-of-window invalid rows don't get
+//      recorded as "ingested-invalid"
+//   3. invalid rows are recorded (their id enters the ingested set so
+//      later duplicates stay skipped) then skipped
+//   4. missing requester/title are skipped
+//   5. survivors enter QMR; their id is recorded to skip later duplicates
+//
+// Returns the shared `{ open, consumed }` plus analytics-side diagnostics
+// (`ingested`, `skippedInvalid`, `skippedDuplicate`, `skippedOutOfWindow`,
+// `skippedMissingKey`).
+export const computeAnalyticsOpenCount = (rows, dailyStats, windowStartSec) => {
+  const seenIds = new Set();
+  const entries = [];
+  let skippedDuplicate = 0;
+  let skippedOutOfWindow = 0;
+  let skippedInvalid = 0;
+  let skippedMissingKey = 0;
+
+  for (const row of rows) {
+    const requestId = row.request_id ?? null;
+    if (requestId != null && seenIds.has(requestId)) {
+      skippedDuplicate += 1;
+      continue;
+    }
+    const ts = Math.floor(Date.parse(row.requested_at) / 1000);
+    if (!Number.isFinite(ts) || ts <= 0 || ts < windowStartSec) {
+      skippedOutOfWindow += 1;
+      continue;
+    }
+    if (row.resolution_status === 'invalid') {
+      if (requestId != null) seenIds.add(requestId);
+      skippedInvalid += 1;
+      continue;
+    }
+    const requester = row.requester?.toLowerCase();
+    const title = row.question_title;
+    if (!requester || !title) {
+      skippedMissingKey += 1;
+      continue;
+    }
+    entries.push({ requester, title });
+    if (requestId != null) seenIds.add(requestId);
+  }
+
+  const { open, consumed } = runQmrOpenCount(entries, dailyStats);
+  return {
+    open,
+    consumed,
+    ingested: entries.length,
+    skippedInvalid,
+    skippedDuplicate,
+    skippedOutOfWindow,
+    skippedMissingKey,
+  };
+};
+
 // ---------------------------------------------------------------------------
-// Check 1 — analytics-side classification and open-market computation
+// classifyAnalyticsRows — informational bucket breakdown for the artifact
 // ---------------------------------------------------------------------------
 
-// Bucket the mech-analytics rows the way the artifact reports them. The
-// counts are informational (they surface the shape of the raw data); the
-// gated number is `open` from computeAnalyticsOpenCount below, not
-// `pending_with_market` from here.
-//
-// The consumer's flag-on path (mech-analytics.ts::fetchMechRequestsFromAnalytics)
-// does NOT filter on market_id — it filters only on invalid rows and
-// missing requester/title. The old check 1 gated on `pending_with_market`
-// (i.e. rows with market_id IS NOT NULL) which dropped ~99% of legitimate
-// rows for chain-100 where the market_id column is populated for a small
-// recent tail of the data only. That produced a fake divergence in prod
-// (0 vs 1326) even though the consumer would have counted every row.
+// The counts are informational only. The gated number is `open` from
+// computeAnalyticsOpenCount above. Retained so the artifact keeps
+// reporting the (a)/(b)/(c) breakdown that documents which shape of raw
+// data lives in per_request_scores.
 export const classifyAnalyticsRows = (rows) => {
   const counts = {
     pending_with_market: 0, // (a) — historical bucket, informational only
@@ -204,6 +292,10 @@ export const classifyAnalyticsRows = (rows) => {
     resolved: 0,
     skipped_missing_key: 0,
   };
+  // `usable` = rows with both requester and title. Used by check 2's
+  // multiset diff (diffRowSets), which matches on (requester, request_id)
+  // with a (requester, ts, title) fallback. Check 1's stricter filtering
+  // (dedup + window + invalid) lives inside computeAnalyticsOpenCount.
   const usable = [];
   for (const row of rows) {
     const requester = row.requester?.toLowerCase();
@@ -224,66 +316,6 @@ export const classifyAnalyticsRows = (rows) => {
     }
   }
   return { counts, usable };
-};
-
-// Reproduces the consumer's post-swap open-market count for the analytics
-// side. Mirrors mech-analytics.ts::fetchMechRequestsFromAnalytics filtering
-// (invalid rows skipped, rows without requester/title skipped, everything
-// else feeds the QMR by title) followed by roi-distribution.ts's settlement
-// consumption via normalizeTitle-matched profitParticipants. The result is
-// what the site would count as "still open" after processing the same
-// scored-rows page it will use post-cutover.
-//
-// `usableRows` are the {requester, row} entries from classifyAnalyticsRows
-// (already de-noised: no missing keys). Invalid rows are still present and
-// are filtered here so classifyAnalyticsRows can also count them for the
-// (b) bucket without double-work.
-export const computeAnalyticsOpenCount = (usableRows, dailyStats, participantTitleField) => {
-  const qmr = new Map(); // title -> Map(agent -> count)
-  const normalizedIndex = new Map(); // normalizeTitle(title) -> title
-  let ingested = 0;
-  let skippedInvalid = 0;
-  for (const { requester, row } of usableRows) {
-    if (row.resolution_status === 'invalid') {
-      skippedInvalid += 1;
-      continue;
-    }
-    const title = row.question_title;
-    if (!qmr.has(title)) {
-      qmr.set(title, new Map());
-      normalizedIndex.set(normalizeTitle(title), title);
-    }
-    const agents = qmr.get(title);
-    agents.set(requester, (agents.get(requester) ?? 0) + 1);
-    ingested += 1;
-  }
-
-  let consumed = 0;
-  for (const stat of dailyStats) {
-    const agentId = stat.traderAgent?.id?.toLowerCase();
-    if (!agentId) continue;
-    for (const participant of stat.profitParticipants ?? []) {
-      const title =
-        participantTitleField === 'question' ? participant.question : participant.metadata?.title;
-      if (!title) continue;
-      const matchedKey = qmr.has(title)
-        ? title
-        : (normalizedIndex.get(normalizeTitle(title)) ?? null);
-      if (!matchedKey) continue;
-      const agents = qmr.get(matchedKey);
-      const count = agents.get(agentId) ?? 0;
-      if (count > 0) {
-        consumed += count;
-        agents.delete(agentId);
-      }
-    }
-  }
-
-  let open = 0;
-  for (const agents of qmr.values()) {
-    for (const count of agents.values()) open += count;
-  }
-  return { open, consumed, ingested, skippedInvalid };
 };
 
 // ---------------------------------------------------------------------------
@@ -357,32 +389,145 @@ export const diffRowSets = (subgraphRows, analyticsRows) => {
 
 // Which subgraph Sender counter matches agent_aggregates.n_mech_requests.
 //
-// The marketplace subgraph increments the Sender counters like this
-// (verified in autonolas-subgraph/subgraphs/marketplace/src/marketplace/
-// mech-marketplace.ts):
+// The marketplace subgraph increments the Sender counters in three
+// places (autonolas-subgraph @ 30d9043e49059598fc228ad4790ecd20b1bb1c74):
 //
-//   handleMarketplaceRequest (on-chain path):
-//     sender.totalMarketplaceRequests += 1
-//     sender.totalLegacyRequests      += numRequests      ← ALSO bumped
+//   subgraphs/marketplace/src/marketplace/mech-marketplace.ts
+//     handleMarketplaceRequest (on-chain path):
+//       sender.totalMarketplaceRequests += 1
+//       sender.totalLegacyRequests      += numRequests      ← ALSO bumped
 //
-//   handleMarketplaceDeliveryWithSignatures (off-chain path):
-//     sender.totalOffChainRequests    += numDeliveries
-//     sender.totalLegacyRequests      += numDeliveries    ← ALSO bumped
+//     handleMarketplaceDeliveryWithSignatures (off-chain path):
+//       sender.totalOffChainRequests    += numDeliveries
+//       sender.totalLegacyRequests      += numDeliveries    ← ALSO bumped
 //
-// So `totalLegacyRequests` is misnamed — it's the grand total of ALL
-// requests (on-chain + off-chain), not just the legacy tail. The previous
-// check summed `totalLegacyRequests + totalMarketplaceRequests`, which
-// counts the on-chain path twice: once via the grand-total field and once
-// via the marketplace-only field. That produced a chronic 2× divergence
-// in prod (Gnosis 604,930 vs 302,465; Polygon 129,044 vs 64,519).
+//   subgraphs/marketplace/src/agent-mech.ts:265-273
+//     handleRequest (legacy AgentMech Request event, wired via
+//     subgraph.gnosis.yaml:389 and the sister chain manifests):
+//       sender.totalLegacyRequests      += 1
+//       sender.totalMarketplaceRequests += 1                ← ALSO bumped
 //
-// The one field that matches `agent_aggregates.n_mech_requests` semantics
-// (total requests seen for this Safe) is `totalLegacyRequests` alone.
-// An equivalent non-overlapping split is `totalOffChainRequests +
-// totalMarketplaceRequests`, but that's two subtractions from a fragile
-// name and this comment would need to explain both — using the grand-total
-// field directly keeps the mapping one-to-one.
+// So the correct identity is:
+//
+//   totalLegacyRequests      = SUM_agentMech(1) + SUM_mkt(numRequests) + SUM_offchain(n)
+//   totalMarketplaceRequests = SUM_agentMech(1) + SUM_mkt(1)
+//
+// `totalLegacyRequests` is the grand total across all three entry points
+// (misnamed — it's not a "legacy tail", it's the superset). It carries
+// pre-marketplace AgentMech requests as well, so anyone re-verifying this
+// against mech-analytics needs to confirm both sides read the same
+// superset. They do: mech-analytics's `agent_aggregates.n_mech_requests`
+// is populated by reading `totalLegacyRequests` directly
+// (mech-analytics/etl/readers/marketplace_subgraph.py:298 →
+// mech-analytics/etl/aggregates/rollup_agent.py::fetch_sender_request_counts).
+// The AgentMech-era question does not re-open: both sides carry it.
+//
+// The previous check summed `totalLegacyRequests + totalMarketplaceRequests`,
+// which counts every on-chain marketplace path twice (once via the grand
+// total, once via the marketplace-only counter). That produced the
+// chronic 2× divergence in prod. Use `totalLegacyRequests` alone.
+//
+// Coercion contract: null preserved, never coerced to 0 (verify-mech-
+// analytics-parity.mjs script header states this invariant). An empty
+// string or garbage value also returns null — those are data-gap
+// signals, not real zeros. NaN propagating into the sum would flip a
+// divergence verdict via `NaN <= tolerance` being false, so we must
+// stop it here before it reaches the caller.
 export const pickSubgraphSenderTotal = (sender) => {
   if (!sender || sender.totalLegacyRequests == null) return null;
-  return Number(sender.totalLegacyRequests);
+  const raw = sender.totalLegacyRequests;
+  // Empty / whitespace-only strings coerce to 0 via Number(''), which
+  // would silently understate subgraphTotal. Treat them as data-gap
+  // signals (null), matching the null-preserved invariant.
+  if (typeof raw === 'string' && raw.trim() === '') return null;
+  const total = Number(raw);
+  return Number.isFinite(total) ? total : null;
+};
+
+// ---------------------------------------------------------------------------
+// Verdict decision — pure function over the collected checkResults
+// ---------------------------------------------------------------------------
+
+// Extracted so the exit-code precedence and vacuous-dilution guard are
+// unit-testable without spinning the full script. Returns
+// `{ exitCode, verdict, message, counts }` where:
+//
+//   exitCode: 0 pass | 1 error | 2 vacuous | 3 divergence | 4 data gap
+//   verdict:  'PASS' | 'FAIL' | 'VACUOUS'
+//   message:  the one-line summary the run's `Verdict` section prints
+//   counts:   { pass, divergence, gap, vacuous } for the artifact header
+//
+// Precedence: divergence (3) outranks gap (4) — a data gap on one check
+// must not mask a real regression on another. Full-vacuous (all results
+// vacuous) escalates to exit 2 so a run where nothing was comparable
+// doesn't silently read as PASS. Partial-vacuous is also escalated: if
+// any distinct check KIND has no non-vacuous result on any platform,
+// that check verified nothing on this run and the verdict downgrades to
+// vacuous — otherwise a run reporting `passed: 4, vacuous: 2, diverged: 0`
+// would exit 0 despite two checks doing no verification (the reviewer's
+// scenario: check 3 vacuous on both platforms after an API contract
+// change).
+export const decideVerdict = (checkResults) => {
+  const byStatus = (status) => checkResults.filter((r) => r.status === status);
+  const passes = byStatus('pass');
+  const divergences = byStatus('divergence');
+  const gaps = byStatus('gap');
+  const vacuous = byStatus('vacuous');
+  const counts = {
+    pass: passes.length,
+    divergence: divergences.length,
+    gap: gaps.length,
+    vacuous: vacuous.length,
+  };
+
+  if (divergences.length > 0) {
+    return {
+      exitCode: 3,
+      verdict: 'FAIL',
+      message: `FAIL (divergence): ${divergences.map((r) => `${r.platform}/${r.check}`).join(', ')}`,
+      counts,
+    };
+  }
+  if (gaps.length > 0) {
+    return {
+      exitCode: 4,
+      verdict: 'FAIL',
+      message: `FAIL (data gap): ${gaps.map((r) => `${r.platform}/${r.check}`).join(', ')}`,
+      counts,
+    };
+  }
+  if (checkResults.length > 0 && vacuous.length === checkResults.length) {
+    return {
+      exitCode: 2,
+      verdict: 'VACUOUS',
+      message: 'VACUOUS: every check had nothing to compare on either side — not a pass.',
+      counts,
+    };
+  }
+  // Partial-vacuous guard: if any check kind was vacuous on every
+  // platform it ran on, that kind proved nothing this run.
+  const kinds = new Map(); // kind -> { total, vacuous }
+  for (const r of checkResults) {
+    const bucket = kinds.get(r.check) ?? { total: 0, vacuous: 0 };
+    bucket.total += 1;
+    if (r.status === 'vacuous') bucket.vacuous += 1;
+    kinds.set(r.check, bucket);
+  }
+  const unverifiedKinds = [...kinds.entries()]
+    .filter(([, b]) => b.total > 0 && b.total === b.vacuous)
+    .map(([kind]) => kind);
+  if (unverifiedKinds.length > 0) {
+    return {
+      exitCode: 2,
+      verdict: 'VACUOUS',
+      message: `VACUOUS: check kind(s) with no non-vacuous result: ${unverifiedKinds.join(', ')} — not a pass.`,
+      counts,
+    };
+  }
+  return {
+    exitCode: 0,
+    verdict: 'PASS',
+    message: 'PASS: every non-vacuous check matched.',
+    counts,
+  };
 };

--- a/scripts/verify-mech-analytics-parity-lib.mjs
+++ b/scripts/verify-mech-analytics-parity-lib.mjs
@@ -1,0 +1,388 @@
+// Copyright 2026 Valory AG
+// SPDX-License-Identifier: Apache-2.0
+//
+// Pure helpers extracted from verify-mech-analytics-parity.mjs so they can be
+// unit-tested without firing the script's top-level side effects (env-var
+// validation, network I/O, process.exit). Imported by both the script and
+// verify-mech-analytics-parity.test.mjs.
+//
+// No I/O, no exit, no global state — same input → same output.
+
+/* eslint-disable no-undef -- standalone module: uses JS built-in globals */
+
+// ---------------------------------------------------------------------------
+// Title normalisation — copied verbatim from
+// common-util/api/predict/roi-distribution.ts:402. Node can't import the
+// site's TypeScript. If roi-distribution.ts changes normalizeTitle, this copy
+// must change with it or check 1's matching diverges from the site's.
+// ---------------------------------------------------------------------------
+
+export const normalizeTitle = (title) =>
+  String(title)
+    .toLowerCase()
+    .replace(/[^a-z0-9]/g, '')
+    .slice(0, 100);
+
+// ---------------------------------------------------------------------------
+// Simple pure utilities
+// ---------------------------------------------------------------------------
+
+export const isoFromUnixSec = (sec) => new Date(sec * 1000).toISOString();
+
+// Subgraph URLs embed API keys; never let one leak through an error
+// message or stack trace into stdout or the artifacts.
+export const scrub = (text) =>
+  String(text)
+    .replace(/https?:\/\/\S+/g, '<redacted-url>')
+    .replace(/[0-9a-fA-F]{16,}/g, '<redacted>');
+
+// Origin only: the artifact gets posted on the cutover PR, and a signed
+// URL or ?token= query must never travel with it.
+export const safeOrigin = (url) => {
+  try {
+    return new URL(url).origin;
+  } catch {
+    return '<invalid-url>';
+  }
+};
+
+// ---------------------------------------------------------------------------
+// Argument parsing
+// ---------------------------------------------------------------------------
+
+export const parsePositiveInt = (raw, label, fallback) => {
+  if (raw == null) return fallback;
+  const value = Number(raw);
+  if (!Number.isInteger(value) || value <= 0) {
+    throw new Error(`--${label} must be a positive integer, got "${raw}"`);
+  }
+  return value;
+};
+
+export const parseNonNegativeInt = (raw, label, fallback) => {
+  if (raw == null) return fallback;
+  const value = Number(raw);
+  if (!Number.isInteger(value) || value < 0) {
+    throw new Error(`--${label} must be a non-negative integer, got "${raw}"`);
+  }
+  return value;
+};
+
+// Accepts ISO 8601 with a timezone offset ("Z" or "+HH:MM"). Rejects naive
+// datetimes so the script never depends on the local timezone of whichever
+// runner it fires on. Mirrors verify_migration_swap.py's _parse_args
+// (mech-predict/scripts/verify_migration_swap.py:1199) so operators run
+// both scripts the same way.
+export const parseAwareIso = (raw, label) => {
+  if (raw == null) return null;
+  const normalized = String(raw).replace(/Z$/, '+00:00');
+  const date = new Date(normalized);
+  if (Number.isNaN(date.getTime())) {
+    throw new Error(`--${label} is not a valid ISO 8601 datetime: "${raw}"`);
+  }
+  // Naive datetimes ("2026-08-01T00:00:00") lack an offset and are
+  // interpreted in the local zone. Reject them the same way
+  // verify_migration_swap.py does (`--since / --until must include timezone`).
+  if (!/[Zz]$|[+-]\d{2}:?\d{2}$/.test(String(raw).trim())) {
+    throw new Error(`--${label} must include a timezone (Z or ±HH:MM), got "${raw}"`);
+  }
+  return date;
+};
+
+// ---------------------------------------------------------------------------
+// Window computation
+// ---------------------------------------------------------------------------
+
+const DAY_SECONDS = 86400;
+
+// Returns { windowStartSec, windowEndSec, source } where `source` is either
+// 'explicit' (--since/--until provided) or 'trailing' (default trailing
+// window). Rules mirror verify_migration_swap.py's _compute_window:
+//   * --since and --until are all-or-nothing (both or neither)
+//   * both must be timezone-aware (parseAwareIso enforces)
+//   * --until must be strictly greater than --since
+//   * when --since/--until are given, --window-days and --lag-buffer-minutes
+//     no longer apply (the operator chose the window explicitly)
+export const computeWindow = ({
+  since,
+  until,
+  nowSec,
+  windowDays,
+  lagBufferMinutes,
+}) => {
+  const hasSince = since != null;
+  const hasUntil = until != null;
+  if (hasSince !== hasUntil) {
+    throw new Error('--since and --until must be provided together');
+  }
+  if (hasSince && hasUntil) {
+    const windowStartSec = Math.floor(since.getTime() / 1000);
+    const windowEndSec = Math.floor(until.getTime() / 1000);
+    if (windowEndSec <= windowStartSec) {
+      throw new Error('--until must be strictly after --since');
+    }
+    return { windowStartSec, windowEndSec, source: 'explicit' };
+  }
+  const windowEndSec = nowSec - lagBufferMinutes * 60;
+  const windowStartSec = nowSec - windowDays * DAY_SECONDS;
+  if (windowEndSec <= windowStartSec) {
+    throw new Error('lag buffer consumes the whole window — lower --lag-buffer-minutes');
+  }
+  return { windowStartSec, windowEndSec, source: 'trailing' };
+};
+
+// ---------------------------------------------------------------------------
+// Check 1 — subgraph-side open-market count via QMR + dailyStats consumption
+// ---------------------------------------------------------------------------
+
+// Reproduces roi-distribution.ts's open-market classification over the
+// window: build the QMR-shaped map title→agent→count from the marketplace
+// feed, then consume settled entries via profitParticipants titles (exact
+// key first, then normalizeTitle — mirrors roi-distribution.ts:581-591
+// including per-agent consumption).
+export const computeSubgraphOpenCount = (requests, dailyStats, participantTitleField) => {
+  const qmr = new Map(); // title -> Map(agent -> count)
+  const normalizedIndex = new Map(); // normalizeTitle(title) -> title
+  for (const { requester, title } of requests) {
+    if (!qmr.has(title)) {
+      qmr.set(title, new Map());
+      normalizedIndex.set(normalizeTitle(title), title);
+    }
+    const agents = qmr.get(title);
+    agents.set(requester, (agents.get(requester) ?? 0) + 1);
+  }
+
+  let consumed = 0;
+  for (const stat of dailyStats) {
+    const agentId = stat.traderAgent?.id?.toLowerCase();
+    if (!agentId) continue;
+    for (const participant of stat.profitParticipants ?? []) {
+      const title =
+        participantTitleField === 'question' ? participant.question : participant.metadata?.title;
+      if (!title) continue;
+      const matchedKey = qmr.has(title)
+        ? title
+        : (normalizedIndex.get(normalizeTitle(title)) ?? null);
+      if (!matchedKey) continue;
+      const agents = qmr.get(matchedKey);
+      const count = agents.get(agentId) ?? 0;
+      if (count > 0) {
+        consumed += count;
+        agents.delete(agentId);
+      }
+    }
+  }
+
+  let open = 0;
+  for (const agents of qmr.values()) {
+    for (const count of agents.values()) open += count;
+  }
+  return { open, consumed };
+};
+
+// ---------------------------------------------------------------------------
+// Check 1 — analytics-side classification and open-market computation
+// ---------------------------------------------------------------------------
+
+// Bucket the mech-analytics rows the way the artifact reports them. The
+// counts are informational (they surface the shape of the raw data); the
+// gated number is `open` from computeAnalyticsOpenCount below, not
+// `pending_with_market` from here.
+//
+// The consumer's flag-on path (mech-analytics.ts::fetchMechRequestsFromAnalytics)
+// does NOT filter on market_id — it filters only on invalid rows and
+// missing requester/title. The old check 1 gated on `pending_with_market`
+// (i.e. rows with market_id IS NOT NULL) which dropped ~99% of legitimate
+// rows for chain-100 where the market_id column is populated for a small
+// recent tail of the data only. That produced a fake divergence in prod
+// (0 vs 1326) even though the consumer would have counted every row.
+export const classifyAnalyticsRows = (rows) => {
+  const counts = {
+    pending_with_market: 0, // (a) — historical bucket, informational only
+    invalid: 0, // (b)
+    no_market_id: 0, // (c) — non-invalid rows without a market
+    resolved: 0,
+    skipped_missing_key: 0,
+  };
+  const usable = [];
+  for (const row of rows) {
+    const requester = row.requester?.toLowerCase();
+    const title = row.question_title;
+    if (!requester || !title) {
+      counts.skipped_missing_key += 1;
+      continue;
+    }
+    usable.push({ requester, row });
+    if (row.resolution_status === 'invalid') {
+      counts.invalid += 1;
+    } else if (row.market_id == null) {
+      counts.no_market_id += 1;
+    } else if (row.resolution_status === 'pending') {
+      counts.pending_with_market += 1;
+    } else {
+      counts.resolved += 1;
+    }
+  }
+  return { counts, usable };
+};
+
+// Reproduces the consumer's post-swap open-market count for the analytics
+// side. Mirrors mech-analytics.ts::fetchMechRequestsFromAnalytics filtering
+// (invalid rows skipped, rows without requester/title skipped, everything
+// else feeds the QMR by title) followed by roi-distribution.ts's settlement
+// consumption via normalizeTitle-matched profitParticipants. The result is
+// what the site would count as "still open" after processing the same
+// scored-rows page it will use post-cutover.
+//
+// `usableRows` are the {requester, row} entries from classifyAnalyticsRows
+// (already de-noised: no missing keys). Invalid rows are still present and
+// are filtered here so classifyAnalyticsRows can also count them for the
+// (b) bucket without double-work.
+export const computeAnalyticsOpenCount = (usableRows, dailyStats, participantTitleField) => {
+  const qmr = new Map(); // title -> Map(agent -> count)
+  const normalizedIndex = new Map(); // normalizeTitle(title) -> title
+  let ingested = 0;
+  let skippedInvalid = 0;
+  for (const { requester, row } of usableRows) {
+    if (row.resolution_status === 'invalid') {
+      skippedInvalid += 1;
+      continue;
+    }
+    const title = row.question_title;
+    if (!qmr.has(title)) {
+      qmr.set(title, new Map());
+      normalizedIndex.set(normalizeTitle(title), title);
+    }
+    const agents = qmr.get(title);
+    agents.set(requester, (agents.get(requester) ?? 0) + 1);
+    ingested += 1;
+  }
+
+  let consumed = 0;
+  for (const stat of dailyStats) {
+    const agentId = stat.traderAgent?.id?.toLowerCase();
+    if (!agentId) continue;
+    for (const participant of stat.profitParticipants ?? []) {
+      const title =
+        participantTitleField === 'question' ? participant.question : participant.metadata?.title;
+      if (!title) continue;
+      const matchedKey = qmr.has(title)
+        ? title
+        : (normalizedIndex.get(normalizeTitle(title)) ?? null);
+      if (!matchedKey) continue;
+      const agents = qmr.get(matchedKey);
+      const count = agents.get(agentId) ?? 0;
+      if (count > 0) {
+        consumed += count;
+        agents.delete(agentId);
+      }
+    }
+  }
+
+  let open = 0;
+  for (const agents of qmr.values()) {
+    for (const count of agents.values()) open += count;
+  }
+  return { open, consumed, ingested, skippedInvalid };
+};
+
+// ---------------------------------------------------------------------------
+// Check 2 — row parity multiset diff
+// ---------------------------------------------------------------------------
+
+const SAMPLE_LIMIT = 10;
+
+// Multiset diff. Preferred key is (requester, request_id) — the marketplace
+// subgraph's Request.id is the same identifier the lake writes back as
+// `request_id`, and the consumer's fetcher dedupes on it (common-util/api/
+// predict/mech-analytics.ts). Fallback is (requester, unix ts,
+// normalizeTitle(title)) for rows missing an id on either side; this
+// fallback is only sound while ts equality holds — once live-writer rows
+// land, requested_at (authorization time) can drift seconds-to-minutes from
+// blockTimestamp, so any row that falls back and diverges is called out
+// with a mode label so the operator can tell "real regression" from
+// "expected drift".
+export const diffRowSets = (subgraphRows, analyticsRows) => {
+  const idKey = (requester, id) => `id|${requester}|${id}`;
+  const tsKey = (requester, ts, title) => `ts|${requester}|${ts}|${normalizeTitle(title)}`;
+  const tally = new Map();
+  const modeById = new Map();
+
+  const bump = (key, side, mode) => {
+    const entry = tally.get(key) ?? { subgraph: 0, analytics: 0 };
+    entry[side] += 1;
+    tally.set(key, entry);
+    modeById.set(key, mode);
+  };
+
+  for (const { requester, ts, title, requestId } of subgraphRows) {
+    bump(
+      requestId ? idKey(requester, requestId) : tsKey(requester, ts, title),
+      'subgraph',
+      requestId ? 'id' : 'ts'
+    );
+  }
+  for (const { requester, row } of analyticsRows) {
+    const rowId = typeof row.request_id === 'string' ? row.request_id.toLowerCase() : null;
+    if (rowId) {
+      bump(idKey(requester, rowId), 'analytics', 'id');
+      continue;
+    }
+    const ts = Math.floor(Date.parse(row.requested_at) / 1000);
+    if (!Number.isFinite(ts)) continue;
+    bump(tsKey(requester, ts, row.question_title), 'analytics', 'ts');
+  }
+
+  let missingInAnalytics = 0;
+  let extraInAnalytics = 0;
+  let tsFallbackKeys = 0;
+  const missingSamples = [];
+  const extraSamples = [];
+  for (const [key, { subgraph, analytics }] of tally) {
+    if (modeById.get(key) === 'ts') tsFallbackKeys += 1;
+    if (subgraph > analytics) {
+      missingInAnalytics += subgraph - analytics;
+      if (missingSamples.length < SAMPLE_LIMIT) missingSamples.push(key);
+    } else if (analytics > subgraph) {
+      extraInAnalytics += analytics - subgraph;
+      if (extraSamples.length < SAMPLE_LIMIT) extraSamples.push(key);
+    }
+  }
+  return { missingInAnalytics, extraInAnalytics, missingSamples, extraSamples, tsFallbackKeys };
+};
+
+// ---------------------------------------------------------------------------
+// Check 3 — Sender counter selection
+// ---------------------------------------------------------------------------
+
+// Which subgraph Sender counter matches agent_aggregates.n_mech_requests.
+//
+// The marketplace subgraph increments the Sender counters like this
+// (verified in autonolas-subgraph/subgraphs/marketplace/src/marketplace/
+// mech-marketplace.ts):
+//
+//   handleMarketplaceRequest (on-chain path):
+//     sender.totalMarketplaceRequests += 1
+//     sender.totalLegacyRequests      += numRequests      ← ALSO bumped
+//
+//   handleMarketplaceDeliveryWithSignatures (off-chain path):
+//     sender.totalOffChainRequests    += numDeliveries
+//     sender.totalLegacyRequests      += numDeliveries    ← ALSO bumped
+//
+// So `totalLegacyRequests` is misnamed — it's the grand total of ALL
+// requests (on-chain + off-chain), not just the legacy tail. The previous
+// check summed `totalLegacyRequests + totalMarketplaceRequests`, which
+// counts the on-chain path twice: once via the grand-total field and once
+// via the marketplace-only field. That produced a chronic 2× divergence
+// in prod (Gnosis 604,930 vs 302,465; Polygon 129,044 vs 64,519).
+//
+// The one field that matches `agent_aggregates.n_mech_requests` semantics
+// (total requests seen for this Safe) is `totalLegacyRequests` alone.
+// An equivalent non-overlapping split is `totalOffChainRequests +
+// totalMarketplaceRequests`, but that's two subtractions from a fragile
+// name and this comment would need to explain both — using the grand-total
+// field directly keeps the mapping one-to-one.
+export const pickSubgraphSenderTotal = (sender) => {
+  if (!sender || sender.totalLegacyRequests == null) return null;
+  return Number(sender.totalLegacyRequests);
+};

--- a/scripts/verify-mech-analytics-parity-lib.mjs
+++ b/scripts/verify-mech-analytics-parity-lib.mjs
@@ -141,23 +141,25 @@ export const computeWindow = ({
 // Check 1 — shared QMR pipeline (single-source correctness)
 // ---------------------------------------------------------------------------
 
-// The QMR is keyed on normalizeTitle(title) directly (not on the raw title
-// with a secondary normalized-index lookup). Two rationales:
+// The QMR is keyed on normalizeTitle(title) directly rather than on the
+// raw title with a secondary normalized-index lookup. Rationale:
+// order-independence between the two verifier feeds. The subgraph feed
+// arrives by blockTimestamp; the scored-rows feed by requested_at + cursor.
+// If we kept a raw-title QMR with a normalizedIndex fallback (as this
+// file did previously), a collision past the 100-char slice would
+// resolve to a different raw key on each side — same logical data,
+// different open count, false divergence. Keying on normalizeTitle(title)
+// collapses the bucket before insertion so the tie-break is a no-op.
 //
-//   1. Consumer parity. roi-distribution.ts:513-516 rebuilds `qmr` from
-//      `Object.keys(qmr)` after settlement consumption, then re-derives
-//      normalizedQmrMap from the surviving keys — so production only ever
-//      keeps a single QMR keyed by whichever raw title happened to arrive
-//      first for a given normalized bucket.
-//
-//   2. Order-independence between the two verifier feeds. The subgraph
-//      feed arrives by blockTimestamp; the scored-rows feed by
-//      requested_at + cursor. If we kept a raw-title QMR with a
-//      normalizedIndex fallback (as this file did previously), a collision
-//      past the 100-char slice would resolve to a different raw key on
-//      each side — same logical data, different open count, false
-//      divergence. Keying on normalizeTitle(title) collapses the bucket
-//      before insertion so the tie-break is a no-op.
+// Note this is a deliberate deviation from the consumer, not a mirror of
+// it. roi-distribution.ts keeps separate raw-title buckets in `qmr` and
+// only builds `normalizedQmrMap` for settlement lookup, so on a
+// post-100-char collision the consumer keeps two buckets and drains one
+// per matching settlement title. Merging into a single normalized bucket
+// means the verifier consumes more on collision than the consumer would.
+// That is the correct choice for a two-sided verifier (both sides collapse
+// the same way, so the comparison is order-invariant), but it is not a
+// literal reproduction of the consumer's QMR shape.
 //
 // Entries are `{ requester, title }`. Callers pre-filter (invalid,
 // missing key, out-of-window, deduplicated) so the shared body never
@@ -204,12 +206,29 @@ export const runQmrOpenCount = (entries, dailyStats) => {
 
 // Subgraph-side adapter: build entries from marketplace-subgraph requests
 // (already usable — `requester`/`title`/`ts` guards fire in the fetcher)
-// and delegate to the shared pipeline. `participantTitleField` is
-// retained for signature stability but no longer needed inside the QMR:
-// the shared body reads both title fields via the consumer's `??` union.
-export const computeSubgraphOpenCount = (requests, dailyStats, _participantTitleField) => {
+// and delegate to the shared pipeline. The consumer's `??` union
+// (question ?? metadata.title) fires inside runQmrOpenCount, so no
+// per-platform participant-title-field flag is needed here.
+export const computeSubgraphOpenCount = (requests, dailyStats) => {
   const entries = requests.map(({ requester, title }) => ({ requester, title }));
   return runQmrOpenCount(entries, dailyStats);
+};
+
+// Shared usability extraction. Both computeAnalyticsOpenCount and
+// classifyAnalyticsRows care whether a row has a lowercased requester
+// and a non-empty question_title — those are the only fields the
+// consumer requires. Returning `{ requester, title }` (nullable) rather
+// than a boolean lets callers reuse the coerced values without a
+// second normalisation step, and prevents the two functions from
+// drifting on what "usable" means. Before this helper existed, both
+// carried inline copies of the same filter and a schema tweak (a new
+// falsy sentinel, say) would only reach whichever site the reviewer
+// remembered to update.
+export const extractRowUsability = (row) => {
+  const requester = row.requester?.toLowerCase() ?? null;
+  const title = row.question_title ?? null;
+  const usable = Boolean(requester) && Boolean(title);
+  return { requester, title, usable };
 };
 
 // Analytics-side adapter: mirrors the consumer's flag-on filtering in
@@ -254,9 +273,8 @@ export const computeAnalyticsOpenCount = (rows, dailyStats, windowStartSec) => {
       skippedInvalid += 1;
       continue;
     }
-    const requester = row.requester?.toLowerCase();
-    const title = row.question_title;
-    if (!requester || !title) {
+    const { requester, title, usable } = extractRowUsability(row);
+    if (!usable) {
       skippedMissingKey += 1;
       continue;
     }
@@ -284,13 +302,24 @@ export const computeAnalyticsOpenCount = (rows, dailyStats, windowStartSec) => {
 // computeAnalyticsOpenCount above. Retained so the artifact keeps
 // reporting the (a)/(b)/(c) breakdown that documents which shape of raw
 // data lives in per_request_scores.
+//
+// IMPORTANT — these counts are computed over RAW rows (no request_id
+// dedup, no window/ts gate). computeAnalyticsOpenCount's
+// `skippedInvalid`/`skippedDuplicate` counters count POST-dedup, which
+// means the two `invalid` numbers can diverge on any window with
+// resolution-sweep activity (per docs/mech-analytics-migration.md:79-84
+// the API re-serves a row on every sweep touch, so a resolved-then-
+// invalidated row lands in `skippedDuplicate` here and in
+// `bucket_raw_invalid` in the artifact). The bucket keys are prefixed
+// `raw_` in the returned object so the artifact reader sees the two
+// populations aren't the same thing side-by-side.
 export const classifyAnalyticsRows = (rows) => {
   const counts = {
-    pending_with_market: 0, // (a) — historical bucket, informational only
-    invalid: 0, // (b)
-    no_market_id: 0, // (c) — non-invalid rows without a market
-    resolved: 0,
-    skipped_missing_key: 0,
+    raw_pending_with_market: 0, // (a) — historical bucket, informational only
+    raw_invalid: 0, // (b), counted pre-dedup
+    raw_no_market_id: 0, // (c) — non-invalid rows without a market
+    raw_resolved: 0,
+    raw_skipped_missing_key: 0,
   };
   // `usable` = rows with both requester and title. Used by check 2's
   // multiset diff (diffRowSets), which matches on (requester, request_id)
@@ -298,21 +327,20 @@ export const classifyAnalyticsRows = (rows) => {
   // (dedup + window + invalid) lives inside computeAnalyticsOpenCount.
   const usable = [];
   for (const row of rows) {
-    const requester = row.requester?.toLowerCase();
-    const title = row.question_title;
-    if (!requester || !title) {
-      counts.skipped_missing_key += 1;
+    const { requester, usable: rowUsable } = extractRowUsability(row);
+    if (!rowUsable) {
+      counts.raw_skipped_missing_key += 1;
       continue;
     }
     usable.push({ requester, row });
     if (row.resolution_status === 'invalid') {
-      counts.invalid += 1;
+      counts.raw_invalid += 1;
     } else if (row.market_id == null) {
-      counts.no_market_id += 1;
+      counts.raw_no_market_id += 1;
     } else if (row.resolution_status === 'pending') {
-      counts.pending_with_market += 1;
+      counts.raw_pending_with_market += 1;
     } else {
-      counts.resolved += 1;
+      counts.raw_resolved += 1;
     }
   }
   return { counts, usable };
@@ -445,6 +473,123 @@ export const pickSubgraphSenderTotal = (sender) => {
 };
 
 // ---------------------------------------------------------------------------
+// Check 1 status resolution — pure helper over the two open-count numbers
+// ---------------------------------------------------------------------------
+
+// Resolves the check-1 status (`vacuous | pass | gap | divergence`) from
+// the two sides' counts, feed sizes, ingestion outcome, and truncation
+// flag. Extracted so the truncation downgrade (`truncated ? 'gap' :
+// 'pass'`) and the zero-ingest degradation guard are testable in
+// isolation. The main script threads the returned status straight into
+// the record().
+//
+// Precedence (top wins):
+//   1. Both feeds empty                             → vacuous
+//   2. Analytics side ingested zero rows but its
+//      raw feed was non-empty (ts gate / dedup /
+//      invalid drained everything)                  → gap
+//   3. Analytics side dropped >SKIP_RATIO_THRESHOLD
+//      of its raw rows via the ts/window gate       → gap
+//   4. subgraphOpen === analyticsOpen AND
+//      subgraphConsumed === analyticsConsumed       → truncated ? gap : pass
+//   5. Truncated                                    → gap
+//   6. Anything else                                → divergence
+//
+// The zero-ingest branch is new-this-round: without it a total ingestion
+// failure (500 rows all-unparseable requested_at → `ingested: 0`,
+// `open: 0`) would report `PASS: open-market counts match exactly (0)`
+// on a quiet-subgraph window, having verified nothing. The ratio branch
+// (skips > half the raw feed) covers partial degradation short of total
+// failure — a plausible mid-roll-out contract drift where the ETL starts
+// mangling most but not all rows.
+//
+// The consumed compare in branch 4 is a strict tie-breaker on top of
+// open equality: settlement draining an agent's full count on any
+// match makes `open` lossy, so `open=0` on both sides can hide a
+// discrepancy INSIDE a settled market (e.g. subgraph consumed 3 and
+// analytics consumed 4 both round to open=0). check 2's row-level
+// diff catches this specific case, but comparing consumed here costs
+// nothing and closes the hole without relying on check 2 staying as-is.
+export const SKIP_RATIO_THRESHOLD = 0.5;
+
+export const resolveCheck1Status = ({
+  subgraphOpen,
+  subgraphConsumed,
+  analyticsOpen,
+  analyticsConsumed,
+  analyticsIngested,
+  analyticsRawRowCount,
+  subgraphRowCount,
+  analyticsSkippedOutOfWindow,
+  truncated,
+}) => {
+  if (subgraphRowCount === 0 && analyticsRawRowCount === 0) {
+    return { status: 'vacuous', reason: 'no-rows-either-side' };
+  }
+  // Zero-ingest guard: raw feed was non-empty but the ts/dedup/invalid
+  // filters drained every row. Downstream open=0 vs subgraph=0 would
+  // silently PASS otherwise.
+  if (analyticsIngested === 0 && analyticsRawRowCount > 0) {
+    return { status: 'gap', reason: 'analytics-ingested-zero' };
+  }
+  // Partial-degradation guard: raw feed non-empty and majority of rows
+  // fell out via the out-of-window gate. This is the plausible ETL
+  // drift case (`requested_at` starts arriving in a new format on some
+  // rows). Below this ratio we treat it as noise; above it, we can't
+  // trust the open count as representative of the window.
+  if (
+    analyticsRawRowCount > 0 &&
+    analyticsSkippedOutOfWindow / analyticsRawRowCount > SKIP_RATIO_THRESHOLD
+  ) {
+    return { status: 'gap', reason: 'analytics-out-of-window-majority' };
+  }
+  if (subgraphOpen === analyticsOpen && subgraphConsumed === analyticsConsumed) {
+    return {
+      status: truncated ? 'gap' : 'pass',
+      reason: truncated ? 'match-but-truncated' : 'exact-match',
+    };
+  }
+  if (subgraphOpen === analyticsOpen && subgraphConsumed !== analyticsConsumed) {
+    // Open matches but consumed doesn't — the settlement drain hid a
+    // real inside-market discrepancy. Not tolerated even without
+    // truncation.
+    return { status: 'divergence', reason: 'consumed-mismatch' };
+  }
+  if (truncated) {
+    return { status: 'gap', reason: 'mismatch-but-truncated' };
+  }
+  return { status: 'divergence', reason: 'open-mismatch' };
+};
+
+// Resolves the check-2 (row parity) status from the multiset diff
+// outputs, feed sizes, and truncation flag. Same-shape helper as
+// resolveCheck1Status so the truncation-downgrade rule
+// (`truncated ? 'gap' : 'pass'` when diffs are zero;
+//  `truncated ? 'gap' : 'divergence'` when non-zero) is tested in
+// isolation from the script's env-var/network side effects.
+export const resolveCheck2Status = ({
+  subgraphRowCount,
+  analyticsRowCount,
+  missingInAnalytics,
+  extraInAnalytics,
+  truncated,
+}) => {
+  if (subgraphRowCount === 0 && analyticsRowCount === 0) {
+    return { status: 'vacuous', reason: 'no-rows-either-side' };
+  }
+  if (missingInAnalytics === 0 && extraInAnalytics === 0) {
+    return {
+      status: truncated ? 'gap' : 'pass',
+      reason: truncated ? 'match-but-truncated' : 'exact-match',
+    };
+  }
+  if (truncated) {
+    return { status: 'gap', reason: 'mismatch-but-truncated' };
+  }
+  return { status: 'divergence', reason: 'row-set-mismatch' };
+};
+
+// ---------------------------------------------------------------------------
 // Verdict decision — pure function over the collected checkResults
 // ---------------------------------------------------------------------------
 
@@ -467,6 +612,15 @@ export const pickSubgraphSenderTotal = (sender) => {
 // would exit 0 despite two checks doing no verification (the reviewer's
 // scenario: check 3 vacuous on both platforms after an API contract
 // change).
+//
+// Invariant: an empty checkResults MUST return exit 2 VACUOUS, never
+// exit 0 PASS. The script's own flow always records at least one result
+// per platform per check, so this is unreachable through the current
+// entry point — but decideVerdict is exported and independently
+// unit-tested, and any future caller (filtered subset, early return,
+// feature-flagged PLATFORMS) inherits this default. "Nothing checked"
+// must never read as "everything passed". Do not remove the empty
+// branch below without also revisiting every caller.
 export const decideVerdict = (checkResults) => {
   const byStatus = (status) => checkResults.filter((r) => r.status === status);
   const passes = byStatus('pass');
@@ -480,6 +634,14 @@ export const decideVerdict = (checkResults) => {
     vacuous: vacuous.length,
   };
 
+  if (checkResults.length === 0) {
+    return {
+      exitCode: 2,
+      verdict: 'VACUOUS',
+      message: 'VACUOUS: no checks were recorded — nothing to gate, not a pass.',
+      counts,
+    };
+  }
   if (divergences.length > 0) {
     return {
       exitCode: 3,
@@ -496,7 +658,7 @@ export const decideVerdict = (checkResults) => {
       counts,
     };
   }
-  if (checkResults.length > 0 && vacuous.length === checkResults.length) {
+  if (vacuous.length === checkResults.length) {
     return {
       exitCode: 2,
       verdict: 'VACUOUS',

--- a/scripts/verify-mech-analytics-parity-lib.mjs
+++ b/scripts/verify-mech-analytics-parity-lib.mjs
@@ -313,6 +313,18 @@ export const computeAnalyticsOpenCount = (rows, dailyStats, windowStartSec) => {
 // `bucket_raw_invalid` in the artifact). The bucket keys are prefixed
 // `raw_` in the returned object so the artifact reader sees the two
 // populations aren't the same thing side-by-side.
+//
+// Check 1 and check 2 audit different row populations by design.
+// `computeAnalyticsOpenCount` (check 1) dedups on `request_id` and
+// drops invalid + out-of-window rows before building its QMR;
+// `classifyAnalyticsRows.usable` (check 2's feed via `diffRowSets`)
+// applies only the requester/title presence test — no dedup, no window
+// gate, no invalid drop. Consequence: check 2 is a row-set diff, not a
+// backstop for check 1's ingestion guards. A check-1 false pass caused
+// by an attrition-guard miss will NOT be caught by check 2 (e.g. a
+// missing-key storm shrinks `usable` on both sides symmetrically and
+// check 2 still reports exact-match). This is why the attrition guards
+// in `resolveCheck1Status` cover every non-duplicate bucket.
 export const classifyAnalyticsRows = (rows) => {
   const counts = {
     raw_pending_with_market: 0, // (a) — historical bucket, informational only
@@ -489,71 +501,106 @@ export const pickSubgraphSenderTotal = (sender) => {
 //      raw feed was non-empty (ts gate / dedup /
 //      invalid drained everything)                  → gap
 //   3. Analytics side dropped >SKIP_RATIO_THRESHOLD
-//      of its raw rows via the ts/window gate       → gap
-//   4. subgraphOpen === analyticsOpen AND
-//      subgraphConsumed === analyticsConsumed       → truncated ? gap : pass
-//   5. Truncated                                    → gap
-//   6. Anything else                                → divergence
+//      of its raw rows via ts/window + missing-key
+//      + invalid (post-dedup, non-duplicate) skips  → gap
+//   4. Subgraph side ingested zero rows but its
+//      raw feed was non-empty                       → gap
+//   5. Subgraph side dropped >SKIP_RATIO_THRESHOLD
+//      of its raw rows via missing-key + past-end   → gap
+//   6. subgraphOpen === analyticsOpen               → truncated ? gap : pass
+//   7. Truncated                                    → gap
+//   8. Anything else                                → divergence
 //
-// The zero-ingest branch is new-this-round: without it a total ingestion
-// failure (500 rows all-unparseable requested_at → `ingested: 0`,
-// `open: 0`) would report `PASS: open-market counts match exactly (0)`
-// on a quiet-subgraph window, having verified nothing. The ratio branch
-// (skips > half the raw feed) covers partial degradation short of total
-// failure — a plausible mid-roll-out contract drift where the ETL starts
-// mangling most but not all rows.
+// The zero-ingest branches (2, 4) cover total ingestion failure: 500
+// rows all-unparseable requested_at → `ingested: 0`, `open: 0` would
+// otherwise report `PASS: open-market counts match exactly (0)` on a
+// quiet-subgraph window, having verified nothing. The ratio branches
+// (3, 5) cover partial degradation short of total failure — a plausible
+// mid-roll-out contract drift where the ETL / subgraph starts mangling
+// most but not all rows.
 //
-// The consumed compare in branch 4 is a strict tie-breaker on top of
-// open equality: settlement draining an agent's full count on any
-// match makes `open` lossy, so `open=0` on both sides can hide a
-// discrepancy INSIDE a settled market (e.g. subgraph consumed 3 and
-// analytics consumed 4 both round to open=0). check 2's row-level
-// diff catches this specific case, but comparing consumed here costs
-// nothing and closes the hole without relying on check 2 staying as-is.
+// Round 2 added a `consumed !== analyticsConsumed → divergence` tie-
+// breaker after the open-equal branch. Round 3 reverted it: `consumed`
+// is not comparable across the two sides on healthy data because
+// `computeAnalyticsOpenCount` drops `resolution_status === 'invalid'`
+// rows (mirroring the post-swap consumer's filter) while the subgraph
+// feed has no invalid concept, so any window that contains an invalid
+// row will see the two `consumed` counts differ by the invalid count.
+// Reviewer self-corrected in round 3. The correct longer-term fix
+// (drop invalid `request_id`s from the subgraph feed too so both sides
+// model the post-swap consumer) touches how the subgraph feed is built
+// and how check 2 works — deferred to a follow-up PR. `subgraphConsumed`
+// and `analyticsConsumed` remain in the artifact for informational use.
 export const SKIP_RATIO_THRESHOLD = 0.5;
 
 export const resolveCheck1Status = ({
   subgraphOpen,
-  subgraphConsumed,
   analyticsOpen,
-  analyticsConsumed,
   analyticsIngested,
   analyticsRawRowCount,
   subgraphRowCount,
+  subgraphRawRowCount,
+  subgraphSkippedMissingKey,
+  subgraphSkippedAfterWindowEnd,
   analyticsSkippedOutOfWindow,
+  analyticsSkippedMissingKey,
+  analyticsSkippedInvalid,
   truncated,
 }) => {
   if (subgraphRowCount === 0 && analyticsRawRowCount === 0) {
     return { status: 'vacuous', reason: 'no-rows-either-side' };
   }
-  // Zero-ingest guard: raw feed was non-empty but the ts/dedup/invalid
-  // filters drained every row. Downstream open=0 vs subgraph=0 would
-  // silently PASS otherwise.
+  // Zero-ingest guard (analytics): raw feed was non-empty but the
+  // ts/dedup/invalid/missing-key filters drained every row. Downstream
+  // open=0 vs subgraph=0 would silently PASS otherwise.
   if (analyticsIngested === 0 && analyticsRawRowCount > 0) {
     return { status: 'gap', reason: 'analytics-ingested-zero' };
   }
-  // Partial-degradation guard: raw feed non-empty and majority of rows
-  // fell out via the out-of-window gate. This is the plausible ETL
-  // drift case (`requested_at` starts arriving in a new format on some
-  // rows). Below this ratio we treat it as noise; above it, we can't
-  // trust the open count as representative of the window.
+  // Partial-degradation guard (analytics): raw feed non-empty and
+  // majority of rows fell out via the out-of-window / missing-key /
+  // invalid buckets. `skippedDuplicate` is deliberately EXCLUDED from
+  // the numerator — per docs/mech-analytics-migration.md:79-84 the API
+  // re-serves the same row on every sweep touch, so duplicates are
+  // normal healthy traffic and including them would fire the guard
+  // during any resolution sweep. The other three buckets each represent
+  // a plausible upstream regression: `skippedOutOfWindow` covers
+  // requested_at parse / format drift; `skippedMissingKey` covers a
+  // `requester` / `question_title` rename or nulling; `skippedInvalid`
+  // covers predict-api resolution_status classification regressions.
+  const analyticsAttrition =
+    analyticsSkippedOutOfWindow + analyticsSkippedMissingKey + analyticsSkippedInvalid;
   if (
     analyticsRawRowCount > 0 &&
-    analyticsSkippedOutOfWindow / analyticsRawRowCount > SKIP_RATIO_THRESHOLD
+    analyticsAttrition / analyticsRawRowCount > SKIP_RATIO_THRESHOLD
   ) {
-    return { status: 'gap', reason: 'analytics-out-of-window-majority' };
+    return { status: 'gap', reason: 'analytics-attrition-majority' };
   }
-  if (subgraphOpen === analyticsOpen && subgraphConsumed === analyticsConsumed) {
+  // Zero-ingest guard (subgraph): mirror of the analytics-side guard.
+  // `fetchMarketplaceRequests` filters rows without `sender`, `title`,
+  // or a positive `ts`, and rows past `windowEndSec`. A schema change
+  // (`sender.id` going missing on most `Request` entities) presents as
+  // a smaller `subgraphRowCount` — the `vacuous` branch only fires when
+  // BOTH sides are empty, so without this guard a genuine subgraph
+  // regression looks like a quiet window.
+  if (subgraphRawRowCount != null && subgraphRowCount === 0 && subgraphRawRowCount > 0) {
+    return { status: 'gap', reason: 'subgraph-ingested-zero' };
+  }
+  // Partial-degradation guard (subgraph): mirror of the analytics-side
+  // ratio guard. The subgraph fetcher separates rows into two skip
+  // buckets — `skippedMissingKey` and `skippedAfterWindowEnd` — both
+  // represent plausible upstream regressions worth escalating on.
+  if (subgraphRawRowCount != null && subgraphRawRowCount > 0) {
+    const subgraphAttrition =
+      (subgraphSkippedMissingKey ?? 0) + (subgraphSkippedAfterWindowEnd ?? 0);
+    if (subgraphAttrition / subgraphRawRowCount > SKIP_RATIO_THRESHOLD) {
+      return { status: 'gap', reason: 'subgraph-attrition-majority' };
+    }
+  }
+  if (subgraphOpen === analyticsOpen) {
     return {
       status: truncated ? 'gap' : 'pass',
       reason: truncated ? 'match-but-truncated' : 'exact-match',
     };
-  }
-  if (subgraphOpen === analyticsOpen && subgraphConsumed !== analyticsConsumed) {
-    // Open matches but consumed doesn't — the settlement drain hid a
-    // real inside-market discrepancy. Not tolerated even without
-    // truncation.
-    return { status: 'divergence', reason: 'consumed-mismatch' };
   }
   if (truncated) {
     return { status: 'gap', reason: 'mismatch-but-truncated' };

--- a/scripts/verify-mech-analytics-parity.mjs
+++ b/scripts/verify-mech-analytics-parity.mjs
@@ -63,6 +63,22 @@
 //   the on-chain path twice and produced a chronic 2× divergence
 //   in prod. See pickSubgraphSenderTotal in the -lib module.
 //
+//   Important: check 3 gates the POST-SWAP number. Once the migration
+//   ships, the site reads `agent_aggregates.n_mech_requests` from
+//   mech-analytics, which is populated directly by
+//   `sender.totalLegacyRequests` (mech-analytics/etl/readers/
+//   marketplace_subgraph.py:298), and that is what this check compares.
+//   The current live-site formula at common-util/api/predict/
+//   roi-distribution.ts:349 still does
+//   `Number(sender.totalLegacyRequests) + Number(sender.totalMarketplaceRequests)`
+//   — the exact double-counting sum this script diagnoses as the
+//   check-3 bug. That means a green check 3 does NOT gate what users
+//   see on the live site today; it gates the safety of the swap. Fixing
+//   roi-distribution.ts:349 is out of scope for this parity script
+//   (that lives with product sign-off and a separate PR) — but ops
+//   should know that the pre-cutover live number and the post-cutover
+//   verifier number differ by roughly a factor of two until that lands.
+//
 // NOT in this script — flag-on vs flag-off openRequestCount (§12 Q4's
 // framing). Exercising the site's own fetchIncrementalMechRequests /
 // fetchAllTimeAgents path twice (USE_MECH_ANALYTICS on/off) requires
@@ -102,7 +118,6 @@ import path from 'node:path';
 import { parseArgs } from 'node:util';
 
 import {
-  normalizeTitle,
   isoFromUnixSec,
   scrub,
   safeOrigin,
@@ -115,6 +130,7 @@ import {
   computeAnalyticsOpenCount,
   diffRowSets,
   pickSubgraphSenderTotal,
+  decideVerdict,
 } from './verify-mech-analytics-parity-lib.mjs';
 
 // ---------------------------------------------------------------------------
@@ -716,14 +732,14 @@ try {
       platform.participantTitleField
     );
     // Analytics side runs the SAME QMR + dailyStats consumption pipeline
-    // the consumer runs post-swap. This is the number that actually
-    // matters for the swap — not the (a) bucket the previous version
-    // gated on. See computeAnalyticsOpenCount in the -lib module for
-    // why market_id filtering is wrong.
+    // the consumer runs post-swap. Feeds raw scoredRows.rows (not the
+    // usable subset) so computeAnalyticsOpenCount can apply the
+    // consumer's filter order exactly: dedup → window/ts → invalid →
+    // requester/title → ingest. See mech-analytics.ts:171-197.
     const analyticsOpen = computeAnalyticsOpenCount(
-      usableAnalyticsRows,
+      scoredRows.rows,
       dailyStats.stats,
-      platform.participantTitleField
+      windowStartSec
     );
     emit(
       `  subgraph feed: ${marketplace.rows.length} requests, ` +
@@ -731,7 +747,8 @@ try {
     );
     emit(
       `  analytics feed: ${analyticsOpen.ingested} rows ingested ` +
-        `(${analyticsOpen.skippedInvalid} invalid skipped), ` +
+        `(${analyticsOpen.skippedInvalid} invalid, ${analyticsOpen.skippedDuplicate} duplicate, ` +
+        `${analyticsOpen.skippedOutOfWindow} out-of-window, ${analyticsOpen.skippedMissingKey} missing-key skipped), ` +
         `${analyticsOpen.consumed} consumed by settlement matching → open=${analyticsOpen.open}`
     );
     emit('  raw scored-rows breakdown (informational, previously gated (a)):');
@@ -778,6 +795,9 @@ try {
       analytics_consumed: analyticsOpen.consumed,
       analytics_ingested: analyticsOpen.ingested,
       analytics_invalid_skipped: analyticsOpen.skippedInvalid,
+      analytics_duplicate_skipped: analyticsOpen.skippedDuplicate,
+      analytics_out_of_window_skipped: analyticsOpen.skippedOutOfWindow,
+      analytics_missing_key_skipped: analyticsOpen.skippedMissingKey,
       analytics_row_buckets: counts,
       truncated: check1Truncated,
     });
@@ -902,41 +922,16 @@ try {
 
   // ---- Verdict -------------------------------------------------------------
   section('Verdict');
-  const byStatus = (status) => checkResults.filter((r) => r.status === status);
-  const divergences = byStatus('divergence');
-  const gaps = byStatus('gap');
-  const vacuous = byStatus('vacuous');
+  const decision = decideVerdict(checkResults);
   emit(`  checks run:       ${checkResults.length}`);
-  emit(`  passed:           ${byStatus('pass').length}`);
-  emit(`  diverged:         ${divergences.length}`);
-  emit(`  data gaps:        ${gaps.length}`);
-  emit(`  vacuous:          ${vacuous.length}`);
-
-  // Precedence: divergence (3) outranks gap (4) so an incomplete fetch
-  // on one check can never mask a real regression on another. The
-  // all-vacuous guard (2) stops a run where nothing was comparable from
-  // reading as a PASS.
-  if (divergences.length > 0) {
-    emit('');
-    emit(`FAIL (divergence): ${divergences.map((r) => `${r.platform}/${r.check}`).join(', ')}`);
-    exitCode = 3;
-    verdict = 'FAIL';
-  } else if (gaps.length > 0) {
-    emit('');
-    emit(`FAIL (data gap): ${gaps.map((r) => `${r.platform}/${r.check}`).join(', ')}`);
-    exitCode = 4;
-    verdict = 'FAIL';
-  } else if (vacuous.length === checkResults.length) {
-    emit('');
-    emit('VACUOUS: every check had nothing to compare on either side — not a pass.');
-    exitCode = 2;
-    verdict = 'VACUOUS';
-  } else {
-    emit('');
-    emit('PASS: every non-vacuous check matched.');
-    exitCode = 0;
-    verdict = 'PASS';
-  }
+  emit(`  passed:           ${decision.counts.pass}`);
+  emit(`  diverged:         ${decision.counts.divergence}`);
+  emit(`  data gaps:        ${decision.counts.gap}`);
+  emit(`  vacuous:          ${decision.counts.vacuous}`);
+  emit('');
+  emit(decision.message);
+  exitCode = decision.exitCode;
+  verdict = decision.verdict;
 } catch (err) {
   emit('');
   emit(`ERROR: ${scrub(err.message)}`);

--- a/scripts/verify-mech-analytics-parity.mjs
+++ b/scripts/verify-mech-analytics-parity.mjs
@@ -760,15 +760,25 @@ try {
     emit(`        raw missing key skipped: ${counts.raw_skipped_missing_key}`);
 
     const check1Truncated = marketplace.truncated || dailyStats.truncated || scoredRows.truncated;
+    // Subgraph raw row count is the pre-filter count `fetchMarketplaceRequests`
+    // observed BEFORE dropping missing-sender/title/ts rows and post-windowEnd
+    // rows. Mirrors `analyticsRawRowCount = scoredRows.rows.length` (also
+    // pre-filter, in that case pre the analytics-side ts/dedup/invalid gate
+    // that runs inside `computeAnalyticsOpenCount`).
+    const subgraphRawRowCount =
+      marketplace.rows.length + marketplace.skippedMissingKey + marketplace.skippedAfterWindowEnd;
     const { status: check1Status, reason: check1Reason } = resolveCheck1Status({
       subgraphOpen: subgraphOpen.open,
-      subgraphConsumed: subgraphOpen.consumed,
       analyticsOpen: analyticsOpen.open,
-      analyticsConsumed: analyticsOpen.consumed,
       analyticsIngested: analyticsOpen.ingested,
       analyticsRawRowCount: scoredRows.rows.length,
       subgraphRowCount: marketplace.rows.length,
+      subgraphRawRowCount,
+      subgraphSkippedMissingKey: marketplace.skippedMissingKey,
+      subgraphSkippedAfterWindowEnd: marketplace.skippedAfterWindowEnd,
       analyticsSkippedOutOfWindow: analyticsOpen.skippedOutOfWindow,
+      analyticsSkippedMissingKey: analyticsOpen.skippedMissingKey,
+      analyticsSkippedInvalid: analyticsOpen.skippedInvalid,
       truncated: check1Truncated,
     });
     if (check1Reason === 'no-rows-either-side') {
@@ -780,23 +790,42 @@ try {
           `${analyticsOpen.skippedOutOfWindow} out-of-window, ${analyticsOpen.skippedMissingKey} missing-key). ` +
           'Cannot gate an open count computed on zero ingested rows.'
       );
-    } else if (check1Reason === 'analytics-out-of-window-majority') {
+    } else if (check1Reason === 'analytics-attrition-majority') {
+      const analyticsAttrition =
+        analyticsOpen.skippedOutOfWindow +
+        analyticsOpen.skippedMissingKey +
+        analyticsOpen.skippedInvalid;
       emit(
-        `  GAP: analytics dropped ${analyticsOpen.skippedOutOfWindow}/${scoredRows.rows.length} ` +
-          `rows via the out-of-window gate (> ${SKIP_RATIO_THRESHOLD_PCT}% of the raw feed). ` +
-          'This suggests upstream requested_at drift, not a real match.'
+        `  GAP: analytics dropped ${analyticsAttrition}/${scoredRows.rows.length} rows ` +
+          `via out-of-window (${analyticsOpen.skippedOutOfWindow}), missing-key ` +
+          `(${analyticsOpen.skippedMissingKey}), and invalid (${analyticsOpen.skippedInvalid}) ` +
+          `buckets (> ${SKIP_RATIO_THRESHOLD_PCT}% of the raw feed). ` +
+          'Suggests upstream contract drift (requested_at format, requester/title schema, ' +
+          'or predict-api resolution classification), not a real match.'
+      );
+    } else if (check1Reason === 'subgraph-ingested-zero') {
+      emit(
+        `  GAP: subgraph ingested 0 rows from a raw feed of ${subgraphRawRowCount} ` +
+          `(${marketplace.skippedMissingKey} missing sender/title/ts, ` +
+          `${marketplace.skippedAfterWindowEnd} past window end). ` +
+          'Cannot gate an open count when the subgraph side dropped every row.'
+      );
+    } else if (check1Reason === 'subgraph-attrition-majority') {
+      const subgraphAttrition =
+        marketplace.skippedMissingKey + marketplace.skippedAfterWindowEnd;
+      emit(
+        `  GAP: subgraph dropped ${subgraphAttrition}/${subgraphRawRowCount} rows ` +
+          `via missing-key (${marketplace.skippedMissingKey}) and past-window-end ` +
+          `(${marketplace.skippedAfterWindowEnd}) buckets ` +
+          `(> ${SKIP_RATIO_THRESHOLD_PCT}% of the raw feed). ` +
+          'Suggests a subgraph schema regression (e.g. sender.id or parsedRequest.questionTitle ' +
+          'going missing on most entities), not a real match.'
       );
     } else if (check1Reason === 'exact-match') {
       emit(`  PASS: open-market counts match exactly (${subgraphOpen.open}).`);
     } else if (check1Reason === 'match-but-truncated') {
       emit(
         `  MATCH on truncated data (${subgraphOpen.open}) — treating as a data gap, not a pass.`
-      );
-    } else if (check1Reason === 'consumed-mismatch') {
-      emit(
-        `  DIVERGENCE: open counts match (${subgraphOpen.open}) but consumed differs ` +
-          `(subgraph=${subgraphOpen.consumed}, analytics=${analyticsOpen.consumed}) ` +
-          '— settlement drained an agent bucket asymmetrically inside a settled market.'
       );
     } else if (check1Reason === 'mismatch-but-truncated') {
       emit(

--- a/scripts/verify-mech-analytics-parity.mjs
+++ b/scripts/verify-mech-analytics-parity.mjs
@@ -21,16 +21,23 @@
 // parallel-run" and §12 Q4:
 //
 // Check 1 — open-market count parity (the core gate).
-//   mech-analytics's last-4-days count of rows with
-//   resolution_status='pending' AND market_id present (via
-//   /v1/data/scored-rows) must equal the title-normalised open-market
-//   count computed the way roi-distribution.ts computes it today:
-//   requests from the marketplace subgraph's incremental feed, minus
-//   the ones consumed by settlement (normalizeTitle matching against
-//   dailyProfitStatistics.profitParticipants). The mech-analytics side
-//   is broken out into (a) pending+market_id, (b) invalid, (c) no
-//   market_id — the consumer counts only (a); (b) and (c) are reported
-//   so a naive resolved=false count overshooting is visible.
+//   Reproduces the consumer's post-swap QMR pipeline on both sides for
+//   the same window and compares the resulting "still open" counts.
+//   * subgraph side: build QMR from marketplace-subgraph requests,
+//     consume via dailyProfitStatistics profitParticipants (normalizeTitle
+//     matching) — the exact algorithm roi-distribution.ts runs today.
+//   * analytics side: feed scored-rows through the same consumer
+//     filtering (mech-analytics.ts::fetchMechRequestsFromAnalytics
+//     skips invalid rows and rows without requester/title; nothing else
+//     is filtered — crucially, market_id is NOT gated), build the same
+//     QMR shape, then consume via the same dailyStats logic.
+//   The old version of this check gated on analytics rows with
+//   market_id IS NOT NULL, but the consumer doesn't do that — 99% of
+//   chain-100 rows in per_request_scores have market_id NULL (the
+//   column is populated only for a small recent tail), so the previous
+//   gate dropped ~99% of legitimate rows and produced a fake 0-vs-1326
+//   divergence in prod. The (a)/(b)/(c) row-bucket breakdown is still
+//   reported for context but is not the gated number.
 //
 // Check 2 — scored-rows row parity.
 //   For the same window, the row set from
@@ -42,11 +49,19 @@
 // Check 3 — senderTotal parity.
 //   agent_aggregates.n_mech_requests (window 'all', via
 //   /v1/metrics/ai-agent/{chain}/{agent}) vs the marketplace
-//   subgraph's Sender.totalLegacyRequests + totalMarketplaceRequests
-//   summed over the same registered Safes (from the /instances
-//   endpoint). Compared with a small absolute tolerance — see
-//   COUNT_TOLERANCE_DEFAULT below for why exact equality is not the
-//   bar on this one check.
+//   subgraph's Sender.totalLegacyRequests summed over the same
+//   registered Safes (from the /instances endpoint). Compared with a
+//   small absolute tolerance — see COUNT_TOLERANCE_DEFAULT below for
+//   why exact equality is not the bar on this one check.
+//   NOTE the field name is misleading. Verified in the subgraph
+//   handler (autonolas-subgraph/subgraphs/marketplace/src/marketplace/
+//   mech-marketplace.ts), `totalLegacyRequests` is bumped on BOTH the
+//   on-chain (handleMarketplaceRequest) and off-chain
+//   (handleMarketplaceDeliveryWithSignatures) paths, so it is actually
+//   the grand total of every request the Safe made. The previous
+//   version summed it with `totalMarketplaceRequests`, which counts
+//   the on-chain path twice and produced a chronic 2× divergence
+//   in prod. See pickSubgraphSenderTotal in the -lib module.
 //
 // NOT in this script — flag-on vs flag-off openRequestCount (§12 Q4's
 // framing). Exercising the site's own fetchIncrementalMechRequests /
@@ -73,6 +88,10 @@
 //   NEXT_PUBLIC_OLAS_POLYMARKET_AGENTS_SUBGRAPH_URL=... \
 //     node scripts/verify-mech-analytics-parity.mjs [--output-dir ./out]
 //
+// Window override for backfills (mutually exclusive with --window-days):
+//   node scripts/verify-mech-analytics-parity.mjs \
+//     --since 2026-07-01T00:00:00Z --until 2026-07-08T00:00:00Z
+//
 // Subgraph URLs embed API keys — they are secrets. This script never
 // prints them (presence is logged as yes/no; HTTP errors carry status
 // codes only, never the URL).
@@ -81,6 +100,22 @@ import { execSync } from 'node:child_process';
 import { mkdirSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
 import { parseArgs } from 'node:util';
+
+import {
+  normalizeTitle,
+  isoFromUnixSec,
+  scrub,
+  safeOrigin,
+  parsePositiveInt,
+  parseNonNegativeInt,
+  parseAwareIso,
+  computeWindow,
+  computeSubgraphOpenCount,
+  classifyAnalyticsRows,
+  computeAnalyticsOpenCount,
+  diffRowSets,
+  pickSubgraphSenderTotal,
+} from './verify-mech-analytics-parity-lib.mjs';
 
 // ---------------------------------------------------------------------------
 // Configuration
@@ -124,7 +159,6 @@ const SUBGRAPH_MAX_SKIP = 5000;
 const SCORED_ROWS_PAGE = 1000;
 const SCORED_ROWS_MAX_PAGES = 500;
 const SENDER_ID_CHUNK = 100;
-const SAMPLE_LIMIT = 10;
 
 // One platform = one (marketplace-subgraph chain, daily-stats subgraph,
 // mech-analytics chain_id/agent_id) triple. Agent ids per
@@ -166,6 +200,8 @@ const { values: args } = parseArgs({
     'mech-analytics-url': { type: 'string' },
     'output-dir': { type: 'string' },
     'window-days': { type: 'string' },
+    since: { type: 'string' },
+    until: { type: 'string' },
     'lag-buffer-minutes': { type: 'string' },
     'finality-lag-hours': { type: 'string' },
     'count-tolerance': { type: 'string' },
@@ -184,18 +220,26 @@ if (args.help) {
       'Gates the mech-request count-source swap of the olas-website predict-page\n' +
       'migration (consumer_migration.md §4 / §12 Q4). Three checks per platform\n' +
       '(omenstrat=gnosis/100/14, polystrat=polygon/137/86):\n' +
-      '  1. open-market count parity: scored-rows pending+market_id count vs the\n' +
-      '     normalizeTitle-based open count over the marketplace-subgraph feed\n' +
+      '  1. open-market count parity: same QMR + dailyStats consumption pipeline\n' +
+      '     the consumer runs, executed against both sides for the same window\n' +
       '  2. scored-rows row parity: (requester, timestamp, title) row sets match\n' +
       '  3. senderTotal parity: agent_aggregates.n_mech_requests vs subgraph\n' +
-      '     Sender.totalLegacyRequests + totalMarketplaceRequests per Safe\n' +
+      '     Sender.totalLegacyRequests (misnamed — it is the grand total,\n' +
+      '     bumped on both on-chain and off-chain paths) per Safe\n' +
       'Flag-on/off openRequestCount comparison is the staging parallel-run\n' +
       'check done by ops on the deployed site — it is NOT run here.\n' +
       '\n' +
       'Options:\n' +
       '  --mech-analytics-url <url>   mech-analytics base URL (or MECH_ANALYTICS_URL env)\n' +
-      `  --window-days <n>            checks 1+2 window (default ${WINDOW_DAYS_DEFAULT})\n` +
-      `  --lag-buffer-minutes <n>     near-edge trim for scoring lag (default ${LAG_BUFFER_MINUTES_DEFAULT})\n` +
+      `  --window-days <n>            checks 1+2 trailing window (default ${WINDOW_DAYS_DEFAULT});\n` +
+      '                               ignored when --since/--until are given\n' +
+      '  --since <iso>                explicit window lower bound (ISO 8601, must include\n' +
+      '                               timezone offset). Requires --until.\n' +
+      '  --until <iso>                explicit window upper bound (ISO 8601, must include\n' +
+      '                               timezone offset). Requires --since. Mutually\n' +
+      '                               exclusive with --window-days / --lag-buffer-minutes.\n' +
+      `  --lag-buffer-minutes <n>     trailing-window near-edge trim (default ${LAG_BUFFER_MINUTES_DEFAULT});\n` +
+      '                               ignored when --since/--until are given\n' +
       `  --finality-lag-hours <n>     check 1 consumption cutoff for the analytics 24h\n` +
       `                               finality gate (default ${FINALITY_LAG_HOURS_DEFAULT})\n` +
       `  --count-tolerance <n>        check 3 absolute tolerance (default ${COUNT_TOLERANCE_DEFAULT})\n` +
@@ -220,43 +264,61 @@ if (missingEnv.length > 0) {
   process.exit(1);
 }
 
-const parsePositiveInt = (raw, label, fallback) => {
-  if (raw == null) return fallback;
-  const value = Number(raw);
-  if (!Number.isInteger(value) || value <= 0) {
-    console.error(`--${label} must be a positive integer, got "${raw}"`);
+// parsePositiveInt / parseNonNegativeInt live in the -lib module and throw
+// on bad input. Wrap here so the CLI still emits a clean error to stderr
+// and exits 1 instead of spraying a stack trace.
+const cliInt = (fn, raw, label, fallback) => {
+  try {
+    return fn(raw, label, fallback);
+  } catch (err) {
+    console.error(err.message);
     process.exit(1);
   }
-  return value;
 };
 
-const parseNonNegativeInt = (raw, label, fallback) => {
-  if (raw == null) return fallback;
-  const value = Number(raw);
-  if (!Number.isInteger(value) || value < 0) {
-    console.error(`--${label} must be a non-negative integer, got "${raw}"`);
-    process.exit(1);
-  }
-  return value;
-};
+// --since / --until are mutually exclusive with --window-days /
+// --lag-buffer-minutes (an explicit window means the operator chose the
+// exact bounds, so the trailing-window knobs don't apply). Reject the
+// combination up front so the operator sees a clear message instead of
+// silent priority behavior.
+if ((args.since || args.until) && (args['window-days'] || args['lag-buffer-minutes'])) {
+  console.error(
+    '--since / --until are mutually exclusive with --window-days and --lag-buffer-minutes'
+  );
+  process.exit(1);
+}
 
 const outputDir = args['output-dir'] ? path.resolve(args['output-dir']) : null;
-const windowDays = parsePositiveInt(args['window-days'], 'window-days', WINDOW_DAYS_DEFAULT);
-const lagBufferMinutes = parseNonNegativeInt(
+const windowDays = cliInt(parsePositiveInt, args['window-days'], 'window-days', WINDOW_DAYS_DEFAULT);
+const lagBufferMinutes = cliInt(
+  parseNonNegativeInt,
   args['lag-buffer-minutes'],
   'lag-buffer-minutes',
   LAG_BUFFER_MINUTES_DEFAULT
 );
-const finalityLagHours = parseNonNegativeInt(
+const finalityLagHours = cliInt(
+  parseNonNegativeInt,
   args['finality-lag-hours'],
   'finality-lag-hours',
   FINALITY_LAG_HOURS_DEFAULT
 );
-const countTolerance = parseNonNegativeInt(
+const countTolerance = cliInt(
+  parseNonNegativeInt,
   args['count-tolerance'],
   'count-tolerance',
   COUNT_TOLERANCE_DEFAULT
 );
+
+let sinceDate = null;
+let untilDate = null;
+try {
+  sinceDate = parseAwareIso(args.since, 'since');
+  untilDate = parseAwareIso(args.until, 'until');
+} catch (err) {
+  console.error(err.message);
+  process.exit(1);
+}
+
 const verbose = Boolean(args.verbose);
 
 const mechAnalyticsBase = mechAnalyticsUrl.replace(/\/$/, '');
@@ -277,13 +339,6 @@ const section = (title) => {
   emit(`=== ${title} ===`);
 };
 
-// Subgraph URLs embed API keys; never let one leak through an error
-// message or stack trace into stdout or the artifacts.
-const scrub = (text) =>
-  String(text)
-    .replace(/https?:\/\/\S+/g, '<redacted-url>')
-    .replace(/[0-9a-fA-F]{16,}/g, '<redacted>');
-
 // ---------------------------------------------------------------------------
 // Provenance header
 // ---------------------------------------------------------------------------
@@ -299,32 +354,53 @@ const scriptGitSha = () => {
   }
 };
 
-// Origin only: the artifact gets posted on the cutover PR, and a
-// signed URL or ?token= query must never travel with it.
-const safeOrigin = (url) => {
-  try {
-    return new URL(url).origin;
-  } catch {
-    return '<invalid-url>';
-  }
-};
+// Window resolution: parseAwareIso rejects naive datetimes, computeWindow
+// enforces the all-or-nothing --since/--until pairing and until > since,
+// and falls back to the trailing (now - windowDays, now - lag) window
+// otherwise. Same shape as verify_migration_swap.py's _compute_window.
+let windowStartSec;
+let windowEndSec;
+let windowSource;
+try {
+  ({
+    windowStartSec,
+    windowEndSec,
+    source: windowSource,
+  } = computeWindow({
+    since: sinceDate,
+    until: untilDate,
+    nowSec: Math.floor(Date.now() / 1000),
+    windowDays,
+    lagBufferMinutes,
+  }));
+} catch (err) {
+  console.error(err.message);
+  process.exit(1);
+}
 
 const metadata = {
   run_at_utc: new Date().toISOString(),
   script_git_sha: scriptGitSha(),
   mech_analytics_url: safeOrigin(mechAnalyticsUrl),
-  window_days: windowDays,
-  lag_buffer_minutes: lagBufferMinutes,
+  window_source: windowSource,
+  window_days: windowSource === 'trailing' ? windowDays : null,
+  lag_buffer_minutes: windowSource === 'trailing' ? lagBufferMinutes : null,
   finality_lag_hours: finalityLagHours,
   count_tolerance_abs: countTolerance,
+  window_start_utc: isoFromUnixSec(windowStartSec),
+  window_end_utc: isoFromUnixSec(windowEndSec),
 };
 
 emit('=== Run metadata ===');
 emit(`  run_at (UTC):         ${metadata.run_at_utc}`);
 emit(`  script git SHA:       ${metadata.script_git_sha}`);
 emit(`  mech-analytics URL:   ${metadata.mech_analytics_url}`);
-emit(`  window (days):        ${metadata.window_days}`);
-emit(`  lag buffer (min):     ${metadata.lag_buffer_minutes}`);
+emit(`  window source:        ${metadata.window_source}`);
+if (windowSource === 'trailing') {
+  emit(`  window (days):        ${metadata.window_days}`);
+  emit(`  lag buffer (min):     ${metadata.lag_buffer_minutes}`);
+}
+emit(`  window:               (${metadata.window_start_utc}, ${metadata.window_end_utc}]`);
 emit(`  finality lag (h):     ${metadata.finality_lag_hours} (check 1 only)`);
 emit(`  count tolerance (±):  ${metadata.count_tolerance_abs} (check 3 only)`);
 for (const name of REQUIRED_ENV.slice(1)) {
@@ -333,21 +409,8 @@ for (const name of REQUIRED_ENV.slice(1)) {
 }
 
 // ---------------------------------------------------------------------------
-// Shared helpers
+// HTTP helpers
 // ---------------------------------------------------------------------------
-
-// Copied verbatim from common-util/api/predict/roi-distribution.ts:402
-// (normalizeTitle). Node can't import the site's TypeScript, so the one
-// pure helper the matching depends on is reimplemented here. DRIFT
-// WARNING: if roi-distribution.ts changes normalizeTitle, this copy
-// must change with it or check 1's matching diverges from the site's.
-const normalizeTitle = (title) =>
-  title
-    .toLowerCase()
-    .replace(/[^a-z0-9]/g, '')
-    .slice(0, 100);
-
-const isoFromUnixSec = (sec) => new Date(sec * 1000).toISOString();
 
 // POST { query } like the site's GraphQLClient does under the hood
 // (common-util/graphql/client.ts). Error messages carry the label and
@@ -483,7 +546,8 @@ const fetchDailyStats = async (url, dateGte, dateLte, participantTitleField, lab
 
 // getMarketplaceSendersQuery (queries.ts) narrowed to the Safes under
 // verification via id_in — the site pages every sender, but check 3
-// only needs the registered Safes' counters.
+// only needs the registered Safes' counters. See pickSubgraphSenderTotal
+// in the -lib module for the counter choice.
 const fetchSenderTotals = async (url, safeIds, label) => {
   const totals = new Map();
   for (let i = 0; i < safeIds.length; i += SENDER_ID_CHUNK) {
@@ -495,16 +559,13 @@ const fetchSenderTotals = async (url, safeIds, label) => {
         senders(first: ${SENDER_ID_CHUNK}, where: { id_in: [${idList}] }) {
           id
           totalLegacyRequests
-          totalMarketplaceRequests
         }
       }`,
       label
     );
     for (const sender of data?.senders ?? []) {
-      totals.set(
-        sender.id.toLowerCase(),
-        Number(sender.totalLegacyRequests) + Number(sender.totalMarketplaceRequests)
-      );
+      const total = pickSubgraphSenderTotal(sender);
+      if (total != null) totals.set(sender.id.toLowerCase(), total);
     }
   }
   return totals;
@@ -581,153 +642,6 @@ const fetchAgentAggregate = async (chainId, agentId) => {
 };
 
 // ---------------------------------------------------------------------------
-// Check 1 — open-market count parity
-// ---------------------------------------------------------------------------
-
-// Reproduces roi-distribution.ts's open-market classification over the
-// window: build the QMR-shaped map title→agent→count from the
-// marketplace feed, then consume settled entries via profitParticipants
-// titles (exact key first, then normalizeTitle — mirrors
-// roi-distribution.ts:581-591 including per-agent consumption).
-const computeSubgraphOpenCount = (requests, dailyStats, participantTitleField) => {
-  const qmr = new Map(); // title -> Map(agent -> count)
-  const normalizedIndex = new Map(); // normalizeTitle(title) -> title
-  for (const { requester, title } of requests) {
-    if (!qmr.has(title)) {
-      qmr.set(title, new Map());
-      normalizedIndex.set(normalizeTitle(title), title);
-    }
-    const agents = qmr.get(title);
-    agents.set(requester, (agents.get(requester) ?? 0) + 1);
-  }
-
-  let consumed = 0;
-  for (const stat of dailyStats) {
-    const agentId = stat.traderAgent?.id?.toLowerCase();
-    if (!agentId) continue;
-    for (const participant of stat.profitParticipants ?? []) {
-      const title =
-        participantTitleField === 'question' ? participant.question : participant.metadata?.title;
-      if (!title) continue;
-      const matchedKey = qmr.has(title)
-        ? title
-        : (normalizedIndex.get(normalizeTitle(title)) ?? null);
-      if (!matchedKey) continue;
-      const agents = qmr.get(matchedKey);
-      const count = agents.get(agentId) ?? 0;
-      if (count > 0) {
-        consumed += count;
-        agents.delete(agentId);
-      }
-    }
-  }
-
-  let open = 0;
-  for (const agents of qmr.values()) {
-    for (const count of agents.values()) open += count;
-  }
-  return { open, consumed };
-};
-
-// Breaks the mech-analytics window rows out the way §12 Q4 prescribes.
-// Only (a) pending+market_id is what the consumer's flag-on path counts
-// (mech-analytics.ts skips invalid rows and rows without requester or
-// title before they reach QMR); (b) and (c) are reported so a naive
-// resolved=false count overshooting is visible in the artifact.
-const classifyAnalyticsRows = (rows) => {
-  const counts = {
-    pending_with_market: 0, // (a) — the gated number
-    invalid: 0, // (b)
-    no_market_id: 0, // (c) — non-invalid rows without a market
-    resolved: 0,
-    skipped_missing_key: 0,
-  };
-  const usable = [];
-  for (const row of rows) {
-    const requester = row.requester?.toLowerCase();
-    const title = row.question_title;
-    if (!requester || !title) {
-      counts.skipped_missing_key += 1;
-      continue;
-    }
-    usable.push({ requester, row });
-    if (row.resolution_status === 'invalid') {
-      counts.invalid += 1;
-    } else if (row.market_id == null) {
-      counts.no_market_id += 1;
-    } else if (row.resolution_status === 'pending') {
-      counts.pending_with_market += 1;
-    } else {
-      counts.resolved += 1;
-    }
-  }
-  return { counts, usable };
-};
-
-// ---------------------------------------------------------------------------
-// Check 2 — row parity
-// ---------------------------------------------------------------------------
-
-// Multiset diff. Preferred key is (requester, request_id) — the
-// marketplace subgraph's Request.id is the same identifier the lake
-// writes back as `request_id`, and the consumer's fetcher dedupes on
-// it (common-util/api/predict/mech-analytics.ts). Fallback is
-// (requester, unix ts, normalizeTitle(title)) for rows missing an id
-// on either side; this fallback is only sound while ts equality
-// holds — once live-writer rows land, requested_at (authorization
-// time) can drift seconds-to-minutes from blockTimestamp, so any
-// row that falls back and diverges is called out with a mode label
-// so the operator can tell "real regression" from "expected drift".
-const diffRowSets = (subgraphRows, analyticsRows) => {
-  const idKey = (requester, id) => `id|${requester}|${id}`;
-  const tsKey = (requester, ts, title) => `ts|${requester}|${ts}|${normalizeTitle(title)}`;
-  const tally = new Map();
-  const modeById = new Map();
-
-  const bump = (key, side, mode) => {
-    const entry = tally.get(key) ?? { subgraph: 0, analytics: 0 };
-    entry[side] += 1;
-    tally.set(key, entry);
-    modeById.set(key, mode);
-  };
-
-  for (const { requester, ts, title, requestId } of subgraphRows) {
-    bump(
-      requestId ? idKey(requester, requestId) : tsKey(requester, ts, title),
-      'subgraph',
-      requestId ? 'id' : 'ts'
-    );
-  }
-  for (const { requester, row } of analyticsRows) {
-    const rowId = typeof row.request_id === 'string' ? row.request_id.toLowerCase() : null;
-    if (rowId) {
-      bump(idKey(requester, rowId), 'analytics', 'id');
-      continue;
-    }
-    const ts = Math.floor(Date.parse(row.requested_at) / 1000);
-    if (!Number.isFinite(ts)) continue;
-    bump(tsKey(requester, ts, row.question_title), 'analytics', 'ts');
-  }
-
-  let missingInAnalytics = 0;
-  let extraInAnalytics = 0;
-  let tsFallbackKeys = 0;
-  const missingSamples = [];
-  const extraSamples = [];
-  for (const [key, { subgraph, analytics }] of tally) {
-    if (modeById.get(key) === 'ts') tsFallbackKeys += 1;
-    if (subgraph > analytics) {
-      missingInAnalytics += subgraph - analytics;
-      if (missingSamples.length < SAMPLE_LIMIT) missingSamples.push(key);
-    } else if (analytics > subgraph) {
-      extraInAnalytics += analytics - subgraph;
-      if (extraSamples.length < SAMPLE_LIMIT) extraSamples.push(key);
-    }
-  }
-  return { missingInAnalytics, extraInAnalytics, missingSamples, extraSamples, tsFallbackKeys };
-};
-
-// ---------------------------------------------------------------------------
 // Main
 // ---------------------------------------------------------------------------
 
@@ -741,16 +655,6 @@ const record = (result) => {
 };
 
 try {
-  const nowSec = Math.floor(Date.now() / 1000);
-  const windowEndSec = nowSec - lagBufferMinutes * 60;
-  const windowStartSec = nowSec - windowDays * DAY_SECONDS;
-  if (windowEndSec <= windowStartSec) {
-    throw new Error('lag buffer consumes the whole window — lower --lag-buffer-minutes');
-  }
-  metadata.window_start_utc = isoFromUnixSec(windowStartSec);
-  metadata.window_end_utc = isoFromUnixSec(windowEndSec);
-  emit(`  window:               (${metadata.window_start_utc}, ${metadata.window_end_utc}]`);
-
   for (const platform of PLATFORMS) {
     const { key, chainId, agentId } = platform;
     const marketplaceUrl = process.env[platform.marketplaceUrlEnv];
@@ -763,11 +667,24 @@ try {
       // side doesn't consume settlements still inside the analytics
       // 24h finality gate — otherwise recent settlements would show as
       // consumed on the subgraph but pending in analytics and produce
-      // a chronic delta on honest runs.
+      // a chronic delta on honest runs. `nowSec` for the lag is
+      // computed against the actual clock, not the window end, so an
+      // explicit --since/--until run still trims the DailyStats side
+      // by the same gate.
       fetchDailyStats(
         dailyStatsUrl,
         Math.floor(windowStartSec / DAY_SECONDS) * DAY_SECONDS,
-        nowSec - finalityLagHours * 60 * 60,
+        // For a trailing window the cap is (now - finality lag) — the
+        // usual guard. For an explicit --since/--until historical window
+        // the cap becomes (windowEnd + finality lag), so we don't
+        // uselessly sweep months of daily-stats to consume settlements
+        // that already happened well after the window closed. Both
+        // stay in effect (`min`), so operators can't accidentally
+        // widen the consumption horizon by picking a huge window.
+        Math.min(
+          Math.floor(Date.now() / 1000) - finalityLagHours * 60 * 60,
+          windowEndSec + finalityLagHours * 60 * 60
+        ),
         platform.participantTitleField,
         `${key}:daily-stats`
       ),
@@ -793,14 +710,31 @@ try {
 
     // ---- Check 1: open-market count parity --------------------------------
     section(`${key} — check 1: open-market count parity`);
-    const { open, consumed } = computeSubgraphOpenCount(
+    const subgraphOpen = computeSubgraphOpenCount(
       marketplace.rows,
       dailyStats.stats,
       platform.participantTitleField
     );
-    emit(`  subgraph feed: ${marketplace.rows.length} requests, ${consumed} consumed by`);
-    emit(`    settlement matching (normalizeTitle vs profitParticipants) → open=${open}`);
-    emit('  mech-analytics breakdown (consumer counts only (a)):');
+    // Analytics side runs the SAME QMR + dailyStats consumption pipeline
+    // the consumer runs post-swap. This is the number that actually
+    // matters for the swap — not the (a) bucket the previous version
+    // gated on. See computeAnalyticsOpenCount in the -lib module for
+    // why market_id filtering is wrong.
+    const analyticsOpen = computeAnalyticsOpenCount(
+      usableAnalyticsRows,
+      dailyStats.stats,
+      platform.participantTitleField
+    );
+    emit(
+      `  subgraph feed: ${marketplace.rows.length} requests, ` +
+        `${subgraphOpen.consumed} consumed by settlement matching → open=${subgraphOpen.open}`
+    );
+    emit(
+      `  analytics feed: ${analyticsOpen.ingested} rows ingested ` +
+        `(${analyticsOpen.skippedInvalid} invalid skipped), ` +
+        `${analyticsOpen.consumed} consumed by settlement matching → open=${analyticsOpen.open}`
+    );
+    emit('  raw scored-rows breakdown (informational, previously gated (a)):');
     emit(`    (a) pending + market_id: ${counts.pending_with_market}`);
     emit(`    (b) invalid:             ${counts.invalid}`);
     emit(`    (c) no market_id:        ${counts.no_market_id}`);
@@ -812,35 +746,39 @@ try {
     if (marketplace.rows.length === 0 && scoredRows.rows.length === 0) {
       check1Status = 'vacuous';
       emit('  VACUOUS: no rows on either side in the window.');
-    } else if (open === counts.pending_with_market) {
+    } else if (subgraphOpen.open === analyticsOpen.open) {
       // Exact equality — counts get no tolerance (unlike check 3, both
       // sides here describe the same window of the same requests).
       check1Status = check1Truncated ? 'gap' : 'pass';
       emit(
         check1Truncated
-          ? `  MATCH on truncated data (${open}) — treating as a data gap, not a pass.`
-          : `  PASS: open-market counts match exactly (${open}).`
+          ? `  MATCH on truncated data (${subgraphOpen.open}) — treating as a data gap, not a pass.`
+          : `  PASS: open-market counts match exactly (${subgraphOpen.open}).`
       );
     } else if (check1Truncated) {
       // A truncated fetch cannot prove a divergence — the missing rows
       // could account for the whole delta.
       check1Status = 'gap';
       emit(
-        `  GAP: counts differ (subgraph=${open}, analytics=${counts.pending_with_market}) but a fetch was truncated.`
+        `  GAP: counts differ (subgraph=${subgraphOpen.open}, analytics=${analyticsOpen.open}) but a fetch was truncated.`
       );
     } else {
       check1Status = 'divergence';
       emit(
-        `  DIVERGENCE: subgraph open=${open} vs analytics pending+market_id=${counts.pending_with_market}.`
+        `  DIVERGENCE: subgraph open=${subgraphOpen.open} vs analytics open=${analyticsOpen.open}.`
       );
     }
     record({
       check: 'open_market_count',
       platform: key,
       status: check1Status,
-      subgraph_open: open,
-      subgraph_consumed: consumed,
-      analytics: counts,
+      subgraph_open: subgraphOpen.open,
+      subgraph_consumed: subgraphOpen.consumed,
+      analytics_open: analyticsOpen.open,
+      analytics_consumed: analyticsOpen.consumed,
+      analytics_ingested: analyticsOpen.ingested,
+      analytics_invalid_skipped: analyticsOpen.skippedInvalid,
+      analytics_row_buckets: counts,
       truncated: check1Truncated,
     });
 
@@ -939,7 +877,7 @@ try {
       const delta = Math.abs(analyticsTotal - subgraphTotal);
       emit(`  registered Safes: ${safes.length} (${safesWithoutSender} with no sender entity)`);
       emit(`  analytics n_mech_requests (all): ${analyticsTotal}`);
-      emit(`  subgraph Σ(totalLegacy+totalMarketplace): ${subgraphTotal}`);
+      emit(`  subgraph Σ(totalLegacyRequests): ${subgraphTotal}`);
       emit(`  |delta| = ${delta} (tolerance ±${countTolerance}, settlement-lag allowance)`);
       if (delta <= countTolerance) {
         check3Status = 'pass';

--- a/scripts/verify-mech-analytics-parity.mjs
+++ b/scripts/verify-mech-analytics-parity.mjs
@@ -131,7 +131,12 @@ import {
   diffRowSets,
   pickSubgraphSenderTotal,
   decideVerdict,
+  resolveCheck1Status,
+  resolveCheck2Status,
+  SKIP_RATIO_THRESHOLD,
 } from './verify-mech-analytics-parity-lib.mjs';
+
+const SKIP_RATIO_THRESHOLD_PCT = Math.round(SKIP_RATIO_THRESHOLD * 100);
 
 // ---------------------------------------------------------------------------
 // Configuration
@@ -726,11 +731,7 @@ try {
 
     // ---- Check 1: open-market count parity --------------------------------
     section(`${key} — check 1: open-market count parity`);
-    const subgraphOpen = computeSubgraphOpenCount(
-      marketplace.rows,
-      dailyStats.stats,
-      platform.participantTitleField
-    );
+    const subgraphOpen = computeSubgraphOpenCount(marketplace.rows, dailyStats.stats);
     // Analytics side runs the SAME QMR + dailyStats consumption pipeline
     // the consumer runs post-swap. Feeds raw scoredRows.rows (not the
     // usable subset) so computeAnalyticsOpenCount can apply the
@@ -751,36 +752,57 @@ try {
         `${analyticsOpen.skippedOutOfWindow} out-of-window, ${analyticsOpen.skippedMissingKey} missing-key skipped), ` +
         `${analyticsOpen.consumed} consumed by settlement matching → open=${analyticsOpen.open}`
     );
-    emit('  raw scored-rows breakdown (informational, previously gated (a)):');
-    emit(`    (a) pending + market_id: ${counts.pending_with_market}`);
-    emit(`    (b) invalid:             ${counts.invalid}`);
-    emit(`    (c) no market_id:        ${counts.no_market_id}`);
-    emit(`        resolved:            ${counts.resolved}`);
-    emit(`        missing key skipped: ${counts.skipped_missing_key}`);
+    emit('  raw scored-rows breakdown (informational, pre-dedup, previously gated (a)):');
+    emit(`    (a) raw pending + market_id: ${counts.raw_pending_with_market}`);
+    emit(`    (b) raw invalid:             ${counts.raw_invalid}`);
+    emit(`    (c) raw no market_id:        ${counts.raw_no_market_id}`);
+    emit(`        raw resolved:            ${counts.raw_resolved}`);
+    emit(`        raw missing key skipped: ${counts.raw_skipped_missing_key}`);
 
     const check1Truncated = marketplace.truncated || dailyStats.truncated || scoredRows.truncated;
-    let check1Status;
-    if (marketplace.rows.length === 0 && scoredRows.rows.length === 0) {
-      check1Status = 'vacuous';
+    const { status: check1Status, reason: check1Reason } = resolveCheck1Status({
+      subgraphOpen: subgraphOpen.open,
+      subgraphConsumed: subgraphOpen.consumed,
+      analyticsOpen: analyticsOpen.open,
+      analyticsConsumed: analyticsOpen.consumed,
+      analyticsIngested: analyticsOpen.ingested,
+      analyticsRawRowCount: scoredRows.rows.length,
+      subgraphRowCount: marketplace.rows.length,
+      analyticsSkippedOutOfWindow: analyticsOpen.skippedOutOfWindow,
+      truncated: check1Truncated,
+    });
+    if (check1Reason === 'no-rows-either-side') {
       emit('  VACUOUS: no rows on either side in the window.');
-    } else if (subgraphOpen.open === analyticsOpen.open) {
-      // Exact equality — counts get no tolerance (unlike check 3, both
-      // sides here describe the same window of the same requests).
-      check1Status = check1Truncated ? 'gap' : 'pass';
+    } else if (check1Reason === 'analytics-ingested-zero') {
       emit(
-        check1Truncated
-          ? `  MATCH on truncated data (${subgraphOpen.open}) — treating as a data gap, not a pass.`
-          : `  PASS: open-market counts match exactly (${subgraphOpen.open}).`
+        `  GAP: analytics ingested 0 rows from a raw feed of ${scoredRows.rows.length} ` +
+          `(${analyticsOpen.skippedInvalid} invalid, ${analyticsOpen.skippedDuplicate} duplicate, ` +
+          `${analyticsOpen.skippedOutOfWindow} out-of-window, ${analyticsOpen.skippedMissingKey} missing-key). ` +
+          'Cannot gate an open count computed on zero ingested rows.'
       );
-    } else if (check1Truncated) {
-      // A truncated fetch cannot prove a divergence — the missing rows
-      // could account for the whole delta.
-      check1Status = 'gap';
+    } else if (check1Reason === 'analytics-out-of-window-majority') {
+      emit(
+        `  GAP: analytics dropped ${analyticsOpen.skippedOutOfWindow}/${scoredRows.rows.length} ` +
+          `rows via the out-of-window gate (> ${SKIP_RATIO_THRESHOLD_PCT}% of the raw feed). ` +
+          'This suggests upstream requested_at drift, not a real match.'
+      );
+    } else if (check1Reason === 'exact-match') {
+      emit(`  PASS: open-market counts match exactly (${subgraphOpen.open}).`);
+    } else if (check1Reason === 'match-but-truncated') {
+      emit(
+        `  MATCH on truncated data (${subgraphOpen.open}) — treating as a data gap, not a pass.`
+      );
+    } else if (check1Reason === 'consumed-mismatch') {
+      emit(
+        `  DIVERGENCE: open counts match (${subgraphOpen.open}) but consumed differs ` +
+          `(subgraph=${subgraphOpen.consumed}, analytics=${analyticsOpen.consumed}) ` +
+          '— settlement drained an agent bucket asymmetrically inside a settled market.'
+      );
+    } else if (check1Reason === 'mismatch-but-truncated') {
       emit(
         `  GAP: counts differ (subgraph=${subgraphOpen.open}, analytics=${analyticsOpen.open}) but a fetch was truncated.`
       );
     } else {
-      check1Status = 'divergence';
       emit(
         `  DIVERGENCE: subgraph open=${subgraphOpen.open} vs analytics open=${analyticsOpen.open}.`
       );
@@ -789,6 +811,7 @@ try {
       check: 'open_market_count',
       platform: key,
       status: check1Status,
+      status_reason: check1Reason,
       subgraph_open: subgraphOpen.open,
       subgraph_consumed: subgraphOpen.consumed,
       analytics_open: analyticsOpen.open,
@@ -822,28 +845,29 @@ try {
     for (const sample of rowDiff.extraSamples) emit(`    extra:   ${sample}`);
 
     const check2Truncated = marketplace.truncated || scoredRows.truncated;
-    let check2Status;
-    if (marketplace.rows.length === 0 && usableAnalyticsRows.length === 0) {
-      check2Status = 'vacuous';
+    const { status: check2Status, reason: check2Reason } = resolveCheck2Status({
+      subgraphRowCount: marketplace.rows.length,
+      analyticsRowCount: usableAnalyticsRows.length,
+      missingInAnalytics: rowDiff.missingInAnalytics,
+      extraInAnalytics: rowDiff.extraInAnalytics,
+      truncated: check2Truncated,
+    });
+    if (check2Reason === 'no-rows-either-side') {
       emit('  VACUOUS: no rows on either side in the window.');
-    } else if (rowDiff.missingInAnalytics === 0 && rowDiff.extraInAnalytics === 0) {
-      check2Status = check2Truncated ? 'gap' : 'pass';
-      emit(
-        check2Truncated
-          ? '  MATCH on truncated data — treating as a data gap, not a pass.'
-          : '  PASS: row sets match exactly.'
-      );
-    } else if (check2Truncated) {
-      check2Status = 'gap';
+    } else if (check2Reason === 'exact-match') {
+      emit('  PASS: row sets match exactly.');
+    } else if (check2Reason === 'match-but-truncated') {
+      emit('  MATCH on truncated data — treating as a data gap, not a pass.');
+    } else if (check2Reason === 'mismatch-but-truncated') {
       emit('  GAP: row sets differ but a fetch was truncated — rerun with a smaller window.');
     } else {
-      check2Status = 'divergence';
       emit('  DIVERGENCE: row sets differ.');
     }
     record({
       check: 'row_parity',
       platform: key,
       status: check2Status,
+      status_reason: check2Reason,
       subgraph_rows: marketplace.rows.length,
       analytics_rows: usableAnalyticsRows.length,
       missing_in_analytics: rowDiff.missingInAnalytics,

--- a/scripts/verify-mech-analytics-parity.test.mjs
+++ b/scripts/verify-mech-analytics-parity.test.mjs
@@ -1,0 +1,588 @@
+#!/usr/bin/env node
+/**
+ * Unit tests for the pure helpers exported by
+ * verify-mech-analytics-parity-lib.mjs, plus a handful of subprocess
+ * checks over the entry script itself to nail down the sentinel exit-code
+ * discipline (0 for --help, 1 for bad CLI, no accidental 0 on error).
+ *
+ * Uses Node's built-in test runner (node:test, ≥18) — no new
+ * devDependencies. Run with
+ *   node --test scripts/verify-mech-analytics-parity.test.mjs
+ *
+ * Live subgraph / mech-analytics pulls, docker/K8s wiring, and artifact
+ * writing are out of scope here — they are exercised by the Docker
+ * smoke-build (publish-verify-image.yaml build-only job) and by the
+ * infra-run K8s Job. These tests target the three behaviours a change
+ * to the script is most likely to break:
+ *   * check 1 gate: title-based QMR consumption (not the market_id
+ *     bucket) is the analytics-side open count
+ *   * check 3 counter: totalLegacyRequests alone, never summed with
+ *     totalMarketplaceRequests
+ *   * --since/--until parsing: aware-only, mutually-required, exclusive
+ *     with --window-days / --lag-buffer-minutes
+ */
+
+/* eslint-disable no-undef -- standalone test module: uses JS built-in globals */
+
+import { execFileSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  normalizeTitle,
+  isoFromUnixSec,
+  scrub,
+  safeOrigin,
+  parsePositiveInt,
+  parseNonNegativeInt,
+  parseAwareIso,
+  computeWindow,
+  computeSubgraphOpenCount,
+  computeAnalyticsOpenCount,
+  classifyAnalyticsRows,
+  diffRowSets,
+  pickSubgraphSenderTotal,
+} from './verify-mech-analytics-parity-lib.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const SCRIPT_PATH = path.join(__dirname, 'verify-mech-analytics-parity.mjs');
+
+// ---------------------------------------------------------------------------
+// normalizeTitle — must match roi-distribution.ts:402 character-for-character
+// ---------------------------------------------------------------------------
+
+test('normalizeTitle: lower-cases, strips non-alphanumerics, keeps first 100 chars', () => {
+  assert.equal(normalizeTitle('Will BTC hit $100k by 2026?'), 'willbtchit100kby2026');
+  assert.equal(normalizeTitle('  Padded  Whitespace  '), 'paddedwhitespace');
+  assert.equal(normalizeTitle(''), '');
+});
+
+test('normalizeTitle: 100-char slice creates predictable collisions on long prefixes', () => {
+  const base = 'a'.repeat(100);
+  assert.equal(normalizeTitle(`${base} tail-one`), base);
+  assert.equal(normalizeTitle(`${base} tail-two`), base);
+  // Two titles that differ only in a suffix past char 100 hash to the
+  // same key — check 1's matching depends on this happening consistently
+  // on both sides, so a regression that changes the slice would surface
+  // as a divergence on the parity run.
+  assert.equal(normalizeTitle(`${base} X`), normalizeTitle(`${base} Y`));
+});
+
+test('normalizeTitle: emoji and unicode punctuation are stripped', () => {
+  assert.equal(normalizeTitle('will "AI" win 🚀?'), 'willaiwin');
+  assert.equal(normalizeTitle('U.S. election — 2026'), 'uselection2026');
+});
+
+test('normalizeTitle: does not throw on non-string values', () => {
+  // Defensive: the site does not pass non-strings, but the -lib should
+  // never crash if a subgraph response drifts to a null/number.
+  assert.equal(normalizeTitle(123), '123');
+  assert.equal(normalizeTitle(null), 'null');
+  assert.equal(normalizeTitle(undefined), 'undefined');
+});
+
+// ---------------------------------------------------------------------------
+// scrub / safeOrigin / isoFromUnixSec
+// ---------------------------------------------------------------------------
+
+test('scrub: redacts urls and hex-looking blobs (API keys leak protection)', () => {
+  const msg = 'GET https://api.thegraph.com/subgraphs/id/abcdef1234567890abcdef1234567890 failed';
+  const scrubbed = scrub(msg);
+  assert.equal(scrubbed.includes('api.thegraph.com'), false);
+  assert.equal(scrubbed.includes('abcdef1234567890'), false);
+  assert.match(scrubbed, /<redacted-url>/);
+});
+
+test('safeOrigin: returns origin without query/path', () => {
+  assert.equal(safeOrigin('https://analytics.example.com/v1/data/scored-rows?x=1'), 'https://analytics.example.com');
+  assert.equal(safeOrigin('http://localhost:8000/x'), 'http://localhost:8000');
+});
+
+test('safeOrigin: returns sentinel on unparseable input (never throws)', () => {
+  assert.equal(safeOrigin('not-a-url'), '<invalid-url>');
+  assert.equal(safeOrigin(''), '<invalid-url>');
+});
+
+test('isoFromUnixSec: emits UTC ISO 8601', () => {
+  assert.equal(isoFromUnixSec(0), '1970-01-01T00:00:00.000Z');
+  assert.equal(isoFromUnixSec(1_700_000_000), new Date(1_700_000_000_000).toISOString());
+});
+
+// ---------------------------------------------------------------------------
+// parsePositiveInt / parseNonNegativeInt
+// ---------------------------------------------------------------------------
+
+test('parsePositiveInt: uses fallback when raw is null', () => {
+  assert.equal(parsePositiveInt(null, 'days', 7), 7);
+  assert.equal(parsePositiveInt(undefined, 'days', 7), 7);
+});
+
+test('parsePositiveInt: accepts positive int strings', () => {
+  assert.equal(parsePositiveInt('4', 'days', 7), 4);
+  assert.equal(parsePositiveInt('100', 'days', 7), 100);
+});
+
+test('parsePositiveInt: rejects zero, negatives, fractions, non-numeric', () => {
+  for (const bad of ['0', '-1', '1.5', 'abc', '4x', '']) {
+    assert.throws(() => parsePositiveInt(bad, 'days'), /must be a positive integer/);
+  }
+});
+
+test('parseNonNegativeInt: accepts zero (unlike parsePositiveInt)', () => {
+  assert.equal(parseNonNegativeInt('0', 'lag', 30), 0);
+  assert.equal(parseNonNegativeInt('30', 'lag', 30), 30);
+});
+
+test('parseNonNegativeInt: rejects negatives and fractions', () => {
+  for (const bad of ['-1', '1.5', 'abc']) {
+    assert.throws(() => parseNonNegativeInt(bad, 'lag'), /must be a non-negative integer/);
+  }
+});
+
+// ---------------------------------------------------------------------------
+// parseAwareIso — reject naive datetimes, accept Z / offset forms
+// ---------------------------------------------------------------------------
+
+test('parseAwareIso: returns null when raw is null (optional arg)', () => {
+  assert.equal(parseAwareIso(null, 'since'), null);
+  assert.equal(parseAwareIso(undefined, 'since'), null);
+});
+
+test('parseAwareIso: accepts "Z" suffix (UTC)', () => {
+  const d = parseAwareIso('2026-07-01T00:00:00Z', 'since');
+  assert.equal(d instanceof Date, true);
+  assert.equal(d.toISOString(), '2026-07-01T00:00:00.000Z');
+});
+
+test('parseAwareIso: accepts explicit +HH:MM offset', () => {
+  const d = parseAwareIso('2026-07-01T02:00:00+02:00', 'since');
+  assert.equal(d.toISOString(), '2026-07-01T00:00:00.000Z');
+});
+
+test('parseAwareIso: accepts explicit -HH:MM offset', () => {
+  const d = parseAwareIso('2026-06-30T20:00:00-04:00', 'since');
+  assert.equal(d.toISOString(), '2026-07-01T00:00:00.000Z');
+});
+
+test('parseAwareIso: rejects naive datetime (no offset — local zone risk)', () => {
+  assert.throws(
+    () => parseAwareIso('2026-07-01T00:00:00', 'since'),
+    /must include a timezone/
+  );
+  assert.throws(
+    () => parseAwareIso('2026-07-01', 'since'),
+    /must include a timezone/
+  );
+});
+
+test('parseAwareIso: rejects garbage input', () => {
+  assert.throws(() => parseAwareIso('not-a-date', 'since'), /valid ISO 8601 datetime/);
+  assert.throws(() => parseAwareIso('2026-13-01T00:00:00Z', 'since'), /valid ISO 8601 datetime/);
+});
+
+// ---------------------------------------------------------------------------
+// computeWindow — trailing default, explicit override, mutual requirement
+// ---------------------------------------------------------------------------
+
+test('computeWindow: trailing default when neither since nor until is given', () => {
+  const nowSec = 1_800_000_000;
+  const w = computeWindow({
+    since: null,
+    until: null,
+    nowSec,
+    windowDays: 4,
+    lagBufferMinutes: 30,
+  });
+  assert.equal(w.source, 'trailing');
+  assert.equal(w.windowEndSec, nowSec - 30 * 60);
+  assert.equal(w.windowStartSec, nowSec - 4 * 86400);
+});
+
+test('computeWindow: --since without --until throws (and vice versa)', () => {
+  const nowSec = 1_800_000_000;
+  const args = { nowSec, windowDays: 4, lagBufferMinutes: 30 };
+  assert.throws(
+    () => computeWindow({ ...args, since: new Date('2026-07-01T00:00:00Z'), until: null }),
+    /--since and --until must be provided together/
+  );
+  assert.throws(
+    () => computeWindow({ ...args, since: null, until: new Date('2026-07-08T00:00:00Z') }),
+    /--since and --until must be provided together/
+  );
+});
+
+test('computeWindow: explicit window overrides trailing knobs', () => {
+  const w = computeWindow({
+    since: new Date('2026-07-01T00:00:00Z'),
+    until: new Date('2026-07-08T00:00:00Z'),
+    nowSec: 1_800_000_000,
+    windowDays: 4,
+    lagBufferMinutes: 30,
+  });
+  assert.equal(w.source, 'explicit');
+  assert.equal(w.windowStartSec, Math.floor(Date.parse('2026-07-01T00:00:00Z') / 1000));
+  assert.equal(w.windowEndSec, Math.floor(Date.parse('2026-07-08T00:00:00Z') / 1000));
+});
+
+test('computeWindow: rejects --until <= --since', () => {
+  const args = { nowSec: 1_800_000_000, windowDays: 4, lagBufferMinutes: 30 };
+  assert.throws(
+    () =>
+      computeWindow({
+        ...args,
+        since: new Date('2026-07-08T00:00:00Z'),
+        until: new Date('2026-07-01T00:00:00Z'),
+      }),
+    /--until must be strictly after --since/
+  );
+  assert.throws(
+    () =>
+      computeWindow({
+        ...args,
+        since: new Date('2026-07-01T00:00:00Z'),
+        until: new Date('2026-07-01T00:00:00Z'),
+      }),
+    /--until must be strictly after --since/
+  );
+});
+
+test('computeWindow: trailing window rejects lag buffer that consumes the whole window', () => {
+  const nowSec = 1_800_000_000;
+  assert.throws(
+    () =>
+      computeWindow({
+        since: null,
+        until: null,
+        nowSec,
+        windowDays: 1,
+        lagBufferMinutes: 60 * 24 + 1, // > 1 day
+      }),
+    /lag buffer consumes the whole window/
+  );
+});
+
+// ---------------------------------------------------------------------------
+// pickSubgraphSenderTotal — check 3 counter bug regression guard
+// ---------------------------------------------------------------------------
+
+test('pickSubgraphSenderTotal: returns totalLegacyRequests when present', () => {
+  const sender = {
+    id: '0xabc',
+    totalLegacyRequests: '100',
+    totalMarketplaceRequests: '40',
+    totalOffChainRequests: '60',
+  };
+  // The regression this guards: the previous version returned
+  // totalLegacy + totalMarketplace = 140, double-counting the on-chain path.
+  // Correct answer is 100 — totalLegacy alone (which is really the grand
+  // total, misnamed in the subgraph schema).
+  assert.equal(pickSubgraphSenderTotal(sender), 100);
+});
+
+test('pickSubgraphSenderTotal: does NOT sum with totalMarketplaceRequests (regression guard)', () => {
+  const sender = { id: '0xabc', totalLegacyRequests: '100', totalMarketplaceRequests: '40' };
+  const total = pickSubgraphSenderTotal(sender);
+  // Explicit anti-assertions — if a future refactor re-introduces the
+  // sum, this test fails loudly.
+  assert.notEqual(total, 140);
+  assert.notEqual(total, Number('100') + Number('40'));
+});
+
+test('pickSubgraphSenderTotal: returns null when the counter is missing', () => {
+  assert.equal(pickSubgraphSenderTotal({ id: '0xabc' }), null);
+  assert.equal(pickSubgraphSenderTotal({ id: '0xabc', totalLegacyRequests: null }), null);
+  assert.equal(pickSubgraphSenderTotal(null), null);
+  assert.equal(pickSubgraphSenderTotal(undefined), null);
+});
+
+test('pickSubgraphSenderTotal: coerces string counter to number (subgraph BigInt shape)', () => {
+  // Graph-node returns BigInt fields as JSON strings — the aggregation
+  // downstream sums with `+`, so a passed-through string would produce
+  // "100" + "50" = "10050". Force numeric conversion here.
+  const total = pickSubgraphSenderTotal({ id: '0xabc', totalLegacyRequests: '100' });
+  assert.equal(typeof total, 'number');
+  assert.equal(total, 100);
+});
+
+// ---------------------------------------------------------------------------
+// classifyAnalyticsRows — bucket accounting stays intact
+// ---------------------------------------------------------------------------
+
+test('classifyAnalyticsRows: buckets rows by resolution_status and market_id presence', () => {
+  const rows = [
+    { requester: '0xa', question_title: 'q1', resolution_status: 'pending', market_id: '0xM1' },
+    { requester: '0xa', question_title: 'q2', resolution_status: 'pending', market_id: null },
+    { requester: '0xb', question_title: 'q3', resolution_status: 'invalid', market_id: null },
+    { requester: '0xb', question_title: 'q4', resolution_status: 'resolved', market_id: '0xM2' },
+    { requester: null, question_title: 'q5', resolution_status: 'pending', market_id: '0xM3' },
+    { requester: '0xc', question_title: null, resolution_status: 'pending', market_id: '0xM4' },
+  ];
+  const { counts, usable } = classifyAnalyticsRows(rows);
+  assert.equal(counts.pending_with_market, 1);
+  assert.equal(counts.no_market_id, 1);
+  assert.equal(counts.invalid, 1);
+  assert.equal(counts.resolved, 1);
+  assert.equal(counts.skipped_missing_key, 2);
+  assert.equal(usable.length, 4); // rows with requester+title survive the key check
+});
+
+// ---------------------------------------------------------------------------
+// computeAnalyticsOpenCount / computeSubgraphOpenCount — the check 1 fix
+// ---------------------------------------------------------------------------
+
+test('computeAnalyticsOpenCount: does NOT filter on market_id (check 1 gate bug regression)', () => {
+  // The pre-fix version gated on rows with market_id IS NOT NULL, which
+  // dropped ~99% of legitimate chain-100 rows because market_id is a
+  // recently-added column. The consumer (mech-analytics.ts) doesn't
+  // filter on market_id at all — it filters only on invalid and
+  // missing requester/title. Force the shape of that bug into the input
+  // and confirm the rows without market_id still enter QMR.
+  const usable = [
+    { requester: '0xa', row: { requester: '0xa', question_title: 'q1', resolution_status: 'pending', market_id: null } },
+    { requester: '0xa', row: { requester: '0xa', question_title: 'q2', resolution_status: 'pending', market_id: null } },
+    { requester: '0xb', row: { requester: '0xb', question_title: 'q3', resolution_status: 'invalid', market_id: null } },
+  ];
+  const result = computeAnalyticsOpenCount(usable, [], 'question');
+  // Two pending rows without market_id: both count as open. One invalid: skipped.
+  assert.equal(result.ingested, 2);
+  assert.equal(result.skippedInvalid, 1);
+  assert.equal(result.consumed, 0);
+  assert.equal(result.open, 2);
+});
+
+test('computeAnalyticsOpenCount: settlement consumes matching (title, agent) via normalizeTitle', () => {
+  const usable = [
+    { requester: '0xagent1', row: { requester: '0xagent1', question_title: 'Will BTC hit $100k by 2026?', resolution_status: 'pending', market_id: null } },
+    { requester: '0xagent1', row: { requester: '0xagent1', question_title: 'Will BTC hit $100k by 2026?', resolution_status: 'pending', market_id: null } },
+    { requester: '0xagent2', row: { requester: '0xagent2', question_title: 'Will ETH hit 10k?', resolution_status: 'pending', market_id: null } },
+  ];
+  const dailyStats = [
+    {
+      // agent1 settled a market whose title differs by punctuation only —
+      // normalizeTitle collapses to the same key, so both agent1's rows
+      // are consumed.
+      traderAgent: { id: '0xAGENT1' },
+      profitParticipants: [{ question: 'will btc hit 100k by 2026' }],
+    },
+  ];
+  const result = computeAnalyticsOpenCount(usable, dailyStats, 'question');
+  assert.equal(result.ingested, 3);
+  assert.equal(result.consumed, 2); // agent1's two rows drained
+  assert.equal(result.open, 1); // agent2's row survives (no settlement)
+});
+
+test('computeAnalyticsOpenCount and computeSubgraphOpenCount converge on equivalent inputs', () => {
+  // If the analytics and subgraph feeds carry the same (requester, title)
+  // shape for the window, the two open counts must match — this is the
+  // property check 1 gates on. Sanity: a hand-built matching pair.
+  const requests = [
+    { requester: '0xagent1', title: 'Market A' },
+    { requester: '0xagent1', title: 'Market A' },
+    { requester: '0xagent2', title: 'Market B' },
+  ];
+  const usable = requests.map(({ requester, title }) => ({
+    requester,
+    row: { requester, question_title: title, resolution_status: 'pending', market_id: null },
+  }));
+  const dailyStats = [
+    { traderAgent: { id: '0xagent2' }, profitParticipants: [{ question: 'market b' }] },
+  ];
+  const sub = computeSubgraphOpenCount(requests, dailyStats, 'question');
+  const ana = computeAnalyticsOpenCount(usable, dailyStats, 'question');
+  assert.equal(sub.open, ana.open);
+  assert.equal(sub.consumed, ana.consumed);
+});
+
+test('computeAnalyticsOpenCount: handles polymarket metadata.title participant field', () => {
+  const usable = [
+    { requester: '0xagent1', row: { requester: '0xagent1', question_title: 'Market X', resolution_status: 'pending', market_id: null } },
+  ];
+  const dailyStats = [
+    { traderAgent: { id: '0xagent1' }, profitParticipants: [{ metadata: { title: 'market x' } }] },
+  ];
+  const result = computeAnalyticsOpenCount(usable, dailyStats, 'metadata.title');
+  assert.equal(result.consumed, 1);
+  assert.equal(result.open, 0);
+});
+
+test('computeAnalyticsOpenCount: does not consume across agents (per-agent QMR)', () => {
+  // A dailyStat from agent2 must not consume agent1's open rows even
+  // if the titles match — this mirrors roi-distribution.ts's per-agent
+  // consumption (each agent's stats consume only their own entries).
+  const usable = [
+    { requester: '0xagent1', row: { requester: '0xagent1', question_title: 'Market Z', resolution_status: 'pending', market_id: null } },
+  ];
+  const dailyStats = [
+    { traderAgent: { id: '0xagent2' }, profitParticipants: [{ question: 'market z' }] },
+  ];
+  const result = computeAnalyticsOpenCount(usable, dailyStats, 'question');
+  assert.equal(result.consumed, 0);
+  assert.equal(result.open, 1);
+});
+
+// ---------------------------------------------------------------------------
+// diffRowSets — smoke tests for the row-parity multiset diff
+// ---------------------------------------------------------------------------
+
+test('diffRowSets: matching (requester, request_id) pairs balance out', () => {
+  const subgraph = [
+    { requester: '0xa', ts: 1000, title: 'x', requestId: '0xr1' },
+    { requester: '0xa', ts: 2000, title: 'y', requestId: '0xr2' },
+  ];
+  const analytics = [
+    { requester: '0xa', row: { request_id: '0xr1', requested_at: '1970-01-01T00:16:40Z', question_title: 'x' } },
+    { requester: '0xa', row: { request_id: '0xr2', requested_at: '1970-01-01T00:33:20Z', question_title: 'y' } },
+  ];
+  const result = diffRowSets(subgraph, analytics);
+  assert.equal(result.missingInAnalytics, 0);
+  assert.equal(result.extraInAnalytics, 0);
+});
+
+test('diffRowSets: rows missing on analytics side are counted, samples captured', () => {
+  const subgraph = [
+    { requester: '0xa', ts: 1000, title: 'x', requestId: '0xr1' },
+    { requester: '0xa', ts: 2000, title: 'y', requestId: '0xr2' },
+  ];
+  const analytics = [
+    { requester: '0xa', row: { request_id: '0xr1', requested_at: '1970-01-01T00:16:40Z', question_title: 'x' } },
+  ];
+  const result = diffRowSets(subgraph, analytics);
+  assert.equal(result.missingInAnalytics, 1);
+  assert.equal(result.extraInAnalytics, 0);
+  assert.equal(result.missingSamples.length, 1);
+});
+
+test('diffRowSets: rows extra on analytics side are counted, samples captured', () => {
+  const subgraph = [
+    { requester: '0xa', ts: 1000, title: 'x', requestId: '0xr1' },
+  ];
+  const analytics = [
+    { requester: '0xa', row: { request_id: '0xr1', requested_at: '1970-01-01T00:16:40Z', question_title: 'x' } },
+    { requester: '0xa', row: { request_id: '0xr9', requested_at: '1970-01-01T00:33:20Z', question_title: 'z' } },
+  ];
+  const result = diffRowSets(subgraph, analytics);
+  assert.equal(result.missingInAnalytics, 0);
+  assert.equal(result.extraInAnalytics, 1);
+  assert.equal(result.extraSamples.length, 1);
+});
+
+test('diffRowSets: ts fallback engages when one side has no request_id, flagged in tsFallbackKeys', () => {
+  const subgraph = [{ requester: '0xa', ts: 1000, title: 'x', requestId: null }];
+  const analytics = [
+    { requester: '0xa', row: { request_id: null, requested_at: '1970-01-01T00:16:40Z', question_title: 'x' } },
+  ];
+  const result = diffRowSets(subgraph, analytics);
+  assert.equal(result.missingInAnalytics, 0);
+  assert.equal(result.extraInAnalytics, 0);
+  assert.equal(result.tsFallbackKeys, 1);
+});
+
+// ---------------------------------------------------------------------------
+// CLI subprocess tests — sentinel exit-code discipline
+// ---------------------------------------------------------------------------
+//
+// These exercise the script itself, not the -lib module: the sentinel
+// contract (exit 0 only when --help, exit 1 on config errors, exit 3/4
+// preserved for divergence/gap) is a script-level property. Runs are
+// hermetic (no network, no env vars set beyond what we pass) — every
+// invocation with real config would need subgraph URLs, which we do NOT
+// provide, so any test that would reach the network path fails at env
+// validation instead.
+
+const runScript = (argv, env = {}) => {
+  try {
+    const stdout = execFileSync('node', [SCRIPT_PATH, ...argv], {
+      encoding: 'utf8',
+      // Wipe inherited env so a developer running the tests with real
+      // MECH_ANALYTICS_URL set doesn't turn "missing env" tests into
+      // accidental live runs. Only PATH + explicit overrides survive.
+      env: { PATH: process.env.PATH ?? '', ...env },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    return { code: 0, stdout, stderr: '' };
+  } catch (err) {
+    return {
+      code: err.status ?? 1,
+      stdout: err.stdout?.toString?.() ?? '',
+      stderr: err.stderr?.toString?.() ?? '',
+    };
+  }
+};
+
+test('--help exits 0 with no env required (docker smoke-test path)', () => {
+  const { code, stdout } = runScript(['--help']);
+  assert.equal(code, 0);
+  assert.match(stdout, /Usage:/);
+  assert.match(stdout, /--since <iso>/);
+  assert.match(stdout, /--until <iso>/);
+  assert.match(stdout, /Exit codes: 0 pass, 1 error, 2 vacuous, 3 divergence, 4 data gap\./);
+});
+
+test('missing MECH_ANALYTICS_URL exits 1 (never 0)', () => {
+  const { code, stderr } = runScript([]);
+  assert.equal(code, 1);
+  assert.match(stderr, /missing required configuration/);
+});
+
+test('--since without --until exits 1 (mutual-requirement)', () => {
+  // Supply all env so validation reaches the window-parse step.
+  const { code, stderr } = runScript(
+    ['--since', '2026-07-01T00:00:00Z'],
+    {
+      MECH_ANALYTICS_URL: 'https://ma.example',
+      NEXT_PUBLIC_GNOSIS_MARKETPLACE_SUBGRAPH_URL: 'https://sg1.example',
+      NEXT_PUBLIC_POLYGON_MARKETPLACE_SUBGRAPH_URL: 'https://sg2.example',
+      NEXT_PUBLIC_OLAS_PREDICT_AGENTS_SUBGRAPH_URL: 'https://sg3.example',
+      NEXT_PUBLIC_OLAS_POLYMARKET_AGENTS_SUBGRAPH_URL: 'https://sg4.example',
+    }
+  );
+  assert.equal(code, 1);
+  assert.match(stderr, /--since and --until must be provided together/);
+});
+
+test('--since with naive datetime (no tz) exits 1', () => {
+  const { code, stderr } = runScript(
+    ['--since', '2026-07-01T00:00:00', '--until', '2026-07-08T00:00:00'],
+    {
+      MECH_ANALYTICS_URL: 'https://ma.example',
+      NEXT_PUBLIC_GNOSIS_MARKETPLACE_SUBGRAPH_URL: 'https://sg1.example',
+      NEXT_PUBLIC_POLYGON_MARKETPLACE_SUBGRAPH_URL: 'https://sg2.example',
+      NEXT_PUBLIC_OLAS_PREDICT_AGENTS_SUBGRAPH_URL: 'https://sg3.example',
+      NEXT_PUBLIC_OLAS_POLYMARKET_AGENTS_SUBGRAPH_URL: 'https://sg4.example',
+    }
+  );
+  assert.equal(code, 1);
+  assert.match(stderr, /must include a timezone/);
+});
+
+test('--since with --window-days is mutually exclusive (exits 1)', () => {
+  const { code, stderr } = runScript(
+    ['--since', '2026-07-01T00:00:00Z', '--until', '2026-07-08T00:00:00Z', '--window-days', '4'],
+    {
+      MECH_ANALYTICS_URL: 'https://ma.example',
+      NEXT_PUBLIC_GNOSIS_MARKETPLACE_SUBGRAPH_URL: 'https://sg1.example',
+      NEXT_PUBLIC_POLYGON_MARKETPLACE_SUBGRAPH_URL: 'https://sg2.example',
+      NEXT_PUBLIC_OLAS_PREDICT_AGENTS_SUBGRAPH_URL: 'https://sg3.example',
+      NEXT_PUBLIC_OLAS_POLYMARKET_AGENTS_SUBGRAPH_URL: 'https://sg4.example',
+    }
+  );
+  assert.equal(code, 1);
+  assert.match(stderr, /mutually exclusive/);
+});
+
+test('bad --window-days exits 1 (not 0, not a stack trace)', () => {
+  // env-var validation runs before flag parsing (correct order — the
+  // script cannot do anything without those URLs), so supply the env
+  // to force the failure onto the --window-days branch.
+  const { code, stderr } = runScript(['--window-days', 'seven'], {
+    MECH_ANALYTICS_URL: 'https://ma.example',
+    NEXT_PUBLIC_GNOSIS_MARKETPLACE_SUBGRAPH_URL: 'https://sg1.example',
+    NEXT_PUBLIC_POLYGON_MARKETPLACE_SUBGRAPH_URL: 'https://sg2.example',
+    NEXT_PUBLIC_OLAS_PREDICT_AGENTS_SUBGRAPH_URL: 'https://sg3.example',
+    NEXT_PUBLIC_OLAS_POLYMARKET_AGENTS_SUBGRAPH_URL: 'https://sg4.example',
+  });
+  assert.equal(code, 1);
+  assert.match(stderr, /--window-days must be a positive integer/);
+});

--- a/scripts/verify-mech-analytics-parity.test.mjs
+++ b/scripts/verify-mech-analytics-parity.test.mjs
@@ -39,11 +39,13 @@ import {
   parseNonNegativeInt,
   parseAwareIso,
   computeWindow,
+  runQmrOpenCount,
   computeSubgraphOpenCount,
   computeAnalyticsOpenCount,
   classifyAnalyticsRows,
   diffRowSets,
   pickSubgraphSenderTotal,
+  decideVerdict,
 } from './verify-mech-analytics-parity-lib.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -186,7 +188,13 @@ test('parseAwareIso: rejects garbage input', () => {
 // computeWindow — trailing default, explicit override, mutual requirement
 // ---------------------------------------------------------------------------
 
-test('computeWindow: trailing default when neither since nor until is given', () => {
+test('computeWindow: trailing default anchors start to end so the span is exactly windowDays', () => {
+  // Regression guard for the anchoring bug: previously windowStart was
+  // anchored to `nowSec` and windowEnd to `nowSec - lag`, so the span
+  // was `windowDays - lag` (3d 23h 30m instead of 4d on defaults).
+  // verify_migration_swap.py:_compute_window anchors start to end
+  // (`until = now - lag; since = until - days`) so the span is exactly
+  // `days`. Mirror that here.
   const nowSec = 1_800_000_000;
   const w = computeWindow({
     since: null,
@@ -197,7 +205,9 @@ test('computeWindow: trailing default when neither since nor until is given', ()
   });
   assert.equal(w.source, 'trailing');
   assert.equal(w.windowEndSec, nowSec - 30 * 60);
-  assert.equal(w.windowStartSec, nowSec - 4 * 86400);
+  // span = end - start = windowDays * 86400, exactly (not windowDays*86400 - lag).
+  assert.equal(w.windowEndSec - w.windowStartSec, 4 * 86400);
+  assert.equal(w.windowStartSec, nowSec - 30 * 60 - 4 * 86400);
 });
 
 test('computeWindow: --since without --until throws (and vice versa)', () => {
@@ -248,18 +258,22 @@ test('computeWindow: rejects --until <= --since', () => {
   );
 });
 
-test('computeWindow: trailing window rejects lag buffer that consumes the whole window', () => {
-  const nowSec = 1_800_000_000;
+test('computeWindow: trailing window rejects a lag that pushes end past the epoch', () => {
+  // With the new anchoring (windowStart = windowEnd - windowDays * 86400),
+  // the span is always exactly `windowDays`, so "lag consumes the whole
+  // window" is no longer reachable — only a nonsensical clock (lag
+  // larger than nowSec) can produce a non-positive windowEnd, and we
+  // refuse rather than compute negative timestamps.
   assert.throws(
     () =>
       computeWindow({
         since: null,
         until: null,
-        nowSec,
+        nowSec: 100, // absurdly small "now"
         windowDays: 1,
-        lagBufferMinutes: 60 * 24 + 1, // > 1 day
+        lagBufferMinutes: 60, // 3600s > nowSec
       }),
-    /lag buffer consumes the whole window/
+    /lag buffer pushes window end/
   );
 });
 
@@ -331,6 +345,15 @@ test('classifyAnalyticsRows: buckets rows by resolution_status and market_id pre
 // ---------------------------------------------------------------------------
 // computeAnalyticsOpenCount / computeSubgraphOpenCount — the check 1 fix
 // ---------------------------------------------------------------------------
+// Signature reminder: computeAnalyticsOpenCount now takes RAW scored rows
+// plus windowStartSec (not a pre-filtered usable list). It reproduces the
+// consumer's filter order from mech-analytics.ts:171-197 exactly:
+// dedup(request_id) → window/ts → invalid+remember-id → requester/title
+// → ingest+remember-id.
+
+// Any windowStartSec that predates the test timestamps disables the
+// window gate — helper so tests can focus on the property they care about.
+const NO_WINDOW = 0;
 
 test('computeAnalyticsOpenCount: does NOT filter on market_id (check 1 gate bug regression)', () => {
   // The pre-fix version gated on rows with market_id IS NOT NULL, which
@@ -339,12 +362,12 @@ test('computeAnalyticsOpenCount: does NOT filter on market_id (check 1 gate bug 
   // filter on market_id at all — it filters only on invalid and
   // missing requester/title. Force the shape of that bug into the input
   // and confirm the rows without market_id still enter QMR.
-  const usable = [
-    { requester: '0xa', row: { requester: '0xa', question_title: 'q1', resolution_status: 'pending', market_id: null } },
-    { requester: '0xa', row: { requester: '0xa', question_title: 'q2', resolution_status: 'pending', market_id: null } },
-    { requester: '0xb', row: { requester: '0xb', question_title: 'q3', resolution_status: 'invalid', market_id: null } },
+  const rows = [
+    { request_id: 'r1', requester: '0xa', question_title: 'q1', resolution_status: 'pending', requested_at: '2026-07-01T00:00:00Z', market_id: null },
+    { request_id: 'r2', requester: '0xa', question_title: 'q2', resolution_status: 'pending', requested_at: '2026-07-01T00:00:00Z', market_id: null },
+    { request_id: 'r3', requester: '0xb', question_title: 'q3', resolution_status: 'invalid', requested_at: '2026-07-01T00:00:00Z', market_id: null },
   ];
-  const result = computeAnalyticsOpenCount(usable, [], 'question');
+  const result = computeAnalyticsOpenCount(rows, [], NO_WINDOW);
   // Two pending rows without market_id: both count as open. One invalid: skipped.
   assert.equal(result.ingested, 2);
   assert.equal(result.skippedInvalid, 1);
@@ -353,10 +376,10 @@ test('computeAnalyticsOpenCount: does NOT filter on market_id (check 1 gate bug 
 });
 
 test('computeAnalyticsOpenCount: settlement consumes matching (title, agent) via normalizeTitle', () => {
-  const usable = [
-    { requester: '0xagent1', row: { requester: '0xagent1', question_title: 'Will BTC hit $100k by 2026?', resolution_status: 'pending', market_id: null } },
-    { requester: '0xagent1', row: { requester: '0xagent1', question_title: 'Will BTC hit $100k by 2026?', resolution_status: 'pending', market_id: null } },
-    { requester: '0xagent2', row: { requester: '0xagent2', question_title: 'Will ETH hit 10k?', resolution_status: 'pending', market_id: null } },
+  const rows = [
+    { request_id: 'r1', requester: '0xagent1', question_title: 'Will BTC hit $100k by 2026?', resolution_status: 'pending', requested_at: '2026-07-01T00:00:00Z', market_id: null },
+    { request_id: 'r2', requester: '0xagent1', question_title: 'Will BTC hit $100k by 2026?', resolution_status: 'pending', requested_at: '2026-07-01T00:00:00Z', market_id: null },
+    { request_id: 'r3', requester: '0xagent2', question_title: 'Will ETH hit 10k?', resolution_status: 'pending', requested_at: '2026-07-01T00:00:00Z', market_id: null },
   ];
   const dailyStats = [
     {
@@ -367,7 +390,7 @@ test('computeAnalyticsOpenCount: settlement consumes matching (title, agent) via
       profitParticipants: [{ question: 'will btc hit 100k by 2026' }],
     },
   ];
-  const result = computeAnalyticsOpenCount(usable, dailyStats, 'question');
+  const result = computeAnalyticsOpenCount(rows, dailyStats, NO_WINDOW);
   assert.equal(result.ingested, 3);
   assert.equal(result.consumed, 2); // agent1's two rows drained
   assert.equal(result.open, 1); // agent2's row survives (no settlement)
@@ -382,27 +405,34 @@ test('computeAnalyticsOpenCount and computeSubgraphOpenCount converge on equival
     { requester: '0xagent1', title: 'Market A' },
     { requester: '0xagent2', title: 'Market B' },
   ];
-  const usable = requests.map(({ requester, title }) => ({
+  const rows = requests.map(({ requester, title }, i) => ({
+    request_id: `r${i}`,
     requester,
-    row: { requester, question_title: title, resolution_status: 'pending', market_id: null },
+    question_title: title,
+    resolution_status: 'pending',
+    requested_at: '2026-07-01T00:00:00Z',
+    market_id: null,
   }));
   const dailyStats = [
     { traderAgent: { id: '0xagent2' }, profitParticipants: [{ question: 'market b' }] },
   ];
   const sub = computeSubgraphOpenCount(requests, dailyStats, 'question');
-  const ana = computeAnalyticsOpenCount(usable, dailyStats, 'question');
+  const ana = computeAnalyticsOpenCount(rows, dailyStats, NO_WINDOW);
   assert.equal(sub.open, ana.open);
   assert.equal(sub.consumed, ana.consumed);
 });
 
-test('computeAnalyticsOpenCount: handles polymarket metadata.title participant field', () => {
-  const usable = [
-    { requester: '0xagent1', row: { requester: '0xagent1', question_title: 'Market X', resolution_status: 'pending', market_id: null } },
+test('computeAnalyticsOpenCount: handles polymarket metadata.title participant field via union', () => {
+  // Consumer uses `p.question ?? p.metadata?.title` unconditionally
+  // (roi-distribution.ts:573). No per-platform flag: both fields are
+  // tried for every stat, so a title landing in either field consumes.
+  const rows = [
+    { request_id: 'r1', requester: '0xagent1', question_title: 'Market X', resolution_status: 'pending', requested_at: '2026-07-01T00:00:00Z', market_id: null },
   ];
   const dailyStats = [
     { traderAgent: { id: '0xagent1' }, profitParticipants: [{ metadata: { title: 'market x' } }] },
   ];
-  const result = computeAnalyticsOpenCount(usable, dailyStats, 'metadata.title');
+  const result = computeAnalyticsOpenCount(rows, dailyStats, NO_WINDOW);
   assert.equal(result.consumed, 1);
   assert.equal(result.open, 0);
 });
@@ -411,15 +441,167 @@ test('computeAnalyticsOpenCount: does not consume across agents (per-agent QMR)'
   // A dailyStat from agent2 must not consume agent1's open rows even
   // if the titles match — this mirrors roi-distribution.ts's per-agent
   // consumption (each agent's stats consume only their own entries).
-  const usable = [
-    { requester: '0xagent1', row: { requester: '0xagent1', question_title: 'Market Z', resolution_status: 'pending', market_id: null } },
+  const rows = [
+    { request_id: 'r1', requester: '0xagent1', question_title: 'Market Z', resolution_status: 'pending', requested_at: '2026-07-01T00:00:00Z', market_id: null },
   ];
   const dailyStats = [
     { traderAgent: { id: '0xagent2' }, profitParticipants: [{ question: 'market z' }] },
   ];
-  const result = computeAnalyticsOpenCount(usable, dailyStats, 'question');
+  const result = computeAnalyticsOpenCount(rows, dailyStats, NO_WINDOW);
   assert.equal(result.consumed, 0);
   assert.equal(result.open, 1);
+});
+
+// ---------------------------------------------------------------------------
+// Consumer-parity tests: dedup, window/ts gate, order-independent collisions
+// ---------------------------------------------------------------------------
+
+test('computeAnalyticsOpenCount: deduplicates repeat request_id (resolution updates)', () => {
+  // The consumer skips already-ingested request_ids because the API
+  // sends the same row again every time its resolution updates
+  // (mech-analytics.ts:171-174). Without this, every update re-inflates
+  // the analytics open count vs the subgraph, which counts each request
+  // exactly once — a chronic false divergence.
+  const rows = [
+    { request_id: 'r1', requester: '0xa', question_title: 'q1', resolution_status: 'pending', requested_at: '2026-07-01T00:00:00Z', market_id: null },
+    { request_id: 'r1', requester: '0xa', question_title: 'q1', resolution_status: 'pending', requested_at: '2026-07-01T00:00:00Z', market_id: null },
+    { request_id: 'r1', requester: '0xa', question_title: 'q1', resolution_status: 'pending', requested_at: '2026-07-01T00:00:00Z', market_id: null },
+  ];
+  const result = computeAnalyticsOpenCount(rows, [], NO_WINDOW);
+  assert.equal(result.ingested, 1);
+  assert.equal(result.skippedDuplicate, 2);
+  assert.equal(result.open, 1);
+});
+
+test('computeAnalyticsOpenCount: invalid row records id, later duplicates stay skipped', () => {
+  // mech-analytics.ts:181-185 remembers invalid row ids so subsequent
+  // updates carrying the same id (an invalid row that later resolves,
+  // or vice versa) don't re-enter as ingested.
+  const rows = [
+    { request_id: 'r1', requester: '0xa', question_title: 'q1', resolution_status: 'invalid', requested_at: '2026-07-01T00:00:00Z', market_id: null },
+    { request_id: 'r1', requester: '0xa', question_title: 'q1', resolution_status: 'pending', requested_at: '2026-07-01T00:00:00Z', market_id: null },
+  ];
+  const result = computeAnalyticsOpenCount(rows, [], NO_WINDOW);
+  assert.equal(result.skippedInvalid, 1);
+  assert.equal(result.skippedDuplicate, 1);
+  assert.equal(result.ingested, 0);
+  assert.equal(result.open, 0);
+});
+
+test('computeAnalyticsOpenCount: window/ts gate runs BEFORE the invalid check', () => {
+  // Consumer ordering (mech-analytics.ts:175-185): out-of-window rows
+  // are skipped without recording their id, so an invalid row that
+  // falls outside the window does NOT enter seenIds. If the ordering
+  // were flipped, an in-window duplicate would then be wrongly skipped.
+  const windowStartSec = Math.floor(Date.parse('2026-07-01T00:00:00Z') / 1000);
+  const rows = [
+    // Out of window, invalid — must be skipped as out-of-window, id NOT recorded
+    { request_id: 'r1', requester: '0xa', question_title: 'q1', resolution_status: 'invalid', requested_at: '2026-06-01T00:00:00Z', market_id: null },
+    // In-window duplicate id, pending — id was not recorded above, so this must ingest
+    { request_id: 'r1', requester: '0xa', question_title: 'q1', resolution_status: 'pending', requested_at: '2026-07-02T00:00:00Z', market_id: null },
+  ];
+  const result = computeAnalyticsOpenCount(rows, [], windowStartSec);
+  assert.equal(result.skippedOutOfWindow, 1);
+  assert.equal(result.skippedInvalid, 0);
+  assert.equal(result.skippedDuplicate, 0);
+  assert.equal(result.ingested, 1);
+  assert.equal(result.open, 1);
+});
+
+test('computeAnalyticsOpenCount: rejects ts <= 0 (Date.parse failure or epoch zero)', () => {
+  const windowStartSec = Math.floor(Date.parse('2026-07-01T00:00:00Z') / 1000);
+  const rows = [
+    { request_id: 'r1', requester: '0xa', question_title: 'q1', resolution_status: 'pending', requested_at: 'not-a-date', market_id: null },
+    { request_id: 'r2', requester: '0xa', question_title: 'q2', resolution_status: 'pending', requested_at: '1970-01-01T00:00:00Z', market_id: null },
+  ];
+  const result = computeAnalyticsOpenCount(rows, [], windowStartSec);
+  assert.equal(result.skippedOutOfWindow, 2);
+  assert.equal(result.ingested, 0);
+});
+
+// This is the invariant check 1 actually depends on: two feeds with the
+// same logical rows in DIFFERENT ORDERS where two titles collide past
+// char 100 with different per-agent counts must produce the same `open`
+// on both sides. The pre-fix version kept a raw-title QMR with a
+// normalized-index fallback, so the two feeds picked different collision
+// winners and drained different buckets — same data, different answer.
+test('subgraph vs analytics open counts are order-invariant on normalizeTitle collisions', () => {
+  // Two long titles that differ only in the last char — collide under
+  // the 100-char normalizeTitle slice. Different per-agent counts:
+  // agent1 has 3 on titleA + 1 on titleB (bucket total 4).
+  // One settlement whose title also normalizes into the same bucket
+  // consumes all of agent1's entries (per-agent bucket drain).
+  const base = 'a'.repeat(100);
+  const titleA = `${base} X`;
+  const titleB = `${base} Y`;
+
+  // SUBGRAPH FEED: interleaved order (blockTimestamp interleaves rows)
+  const subgraphRequests = [
+    { requester: '0xagent1', title: titleA },
+    { requester: '0xagent1', title: titleB },
+    { requester: '0xagent1', title: titleA },
+    { requester: '0xagent1', title: titleA },
+  ];
+  // ANALYTICS FEED: same logical set, DIFFERENT order (grouped)
+  const analyticsRows = [
+    { request_id: 'r-b1', requester: '0xagent1', question_title: titleB, resolution_status: 'pending', requested_at: '2026-07-01T00:00:00Z', market_id: null },
+    { request_id: 'r-a1', requester: '0xagent1', question_title: titleA, resolution_status: 'pending', requested_at: '2026-07-01T00:00:01Z', market_id: null },
+    { request_id: 'r-a2', requester: '0xagent1', question_title: titleA, resolution_status: 'pending', requested_at: '2026-07-01T00:00:02Z', market_id: null },
+    { request_id: 'r-a3', requester: '0xagent1', question_title: titleA, resolution_status: 'pending', requested_at: '2026-07-01T00:00:03Z', market_id: null },
+  ];
+  const dailyStats = [
+    { traderAgent: { id: '0xagent1' }, profitParticipants: [{ question: base }] },
+  ];
+
+  const sub = computeSubgraphOpenCount(subgraphRequests, dailyStats, 'question');
+  const ana = computeAnalyticsOpenCount(analyticsRows, dailyStats, NO_WINDOW);
+
+  // The property that must hold: same logical data → same open count.
+  assert.equal(sub.open, ana.open);
+  assert.equal(sub.consumed, ana.consumed);
+  // And structurally: settlement consumed all 4 (whole bucket drained).
+  assert.equal(sub.open, 0);
+  assert.equal(sub.consumed, 4);
+});
+
+// ---------------------------------------------------------------------------
+// runQmrOpenCount — direct tests of the shared helper
+// ---------------------------------------------------------------------------
+
+test('runQmrOpenCount: consumes via metadata.title AND question via the ?? union', () => {
+  // Consumer fallback (roi-distribution.ts:573) is `p.question ??
+  // p.metadata?.title` unconditionally. Prove both fields are tried by
+  // driving one consumption via each.
+  const entries = [
+    { requester: '0xagent1', title: 'Market A' },
+    { requester: '0xagent1', title: 'Market B' },
+  ];
+  const dailyStats = [
+    { traderAgent: { id: '0xagent1' }, profitParticipants: [{ question: 'market a' }] },
+    { traderAgent: { id: '0xagent1' }, profitParticipants: [{ metadata: { title: 'market b' } }] },
+  ];
+  const result = runQmrOpenCount(entries, dailyStats);
+  assert.equal(result.consumed, 2);
+  assert.equal(result.open, 0);
+});
+
+// ---------------------------------------------------------------------------
+// pickSubgraphSenderTotal — data-gap coercion contract (item 5 fix)
+// ---------------------------------------------------------------------------
+
+test('pickSubgraphSenderTotal: empty string returns null (not 0), malformed returns null (not NaN)', () => {
+  // Regression guard: the header docstring states "null preserved,
+  // never coerced to 0". Before the fix, `''` coerced to `0`
+  // (contributing a real zero to subgraphTotal, understating it) and
+  // `'oops'` propagated NaN into `delta`, tripping the `else` branch
+  // and reporting DIVERGENCE (exit 3) when it should have been GAP
+  // (exit 4). Both must now round-trip to null.
+  assert.equal(pickSubgraphSenderTotal({ totalLegacyRequests: '' }), null);
+  assert.equal(pickSubgraphSenderTotal({ totalLegacyRequests: 'oops' }), null);
+  assert.equal(pickSubgraphSenderTotal({ totalLegacyRequests: 'NaN' }), null);
+  // Genuine 0 (a Safe with zero recorded requests) still returns 0.
+  assert.equal(pickSubgraphSenderTotal({ totalLegacyRequests: '0' }), 0);
+  assert.equal(pickSubgraphSenderTotal({ totalLegacyRequests: 0 }), 0);
 });
 
 // ---------------------------------------------------------------------------
@@ -585,4 +767,133 @@ test('bad --window-days exits 1 (not 0, not a stack trace)', () => {
   });
   assert.equal(code, 1);
   assert.match(stderr, /--window-days must be a positive integer/);
+});
+
+// ---------------------------------------------------------------------------
+// decideVerdict — exit-code precedence, truncation downgrade, vacuous dilution
+// ---------------------------------------------------------------------------
+//
+// Exit-code contract: 0 pass / 1 error (sentinel — set only when the try
+// block never reaches decideVerdict) / 2 vacuous / 3 divergence / 4 gap.
+// Precedence: divergence > gap > full-vacuous > partial-vacuous > pass.
+
+test('decideVerdict: all pass → exit 0', () => {
+  const r = [
+    { check: 'open_market_count', platform: 'omenstrat', status: 'pass' },
+    { check: 'open_market_count', platform: 'polystrat', status: 'pass' },
+    { check: 'row_parity', platform: 'omenstrat', status: 'pass' },
+    { check: 'row_parity', platform: 'polystrat', status: 'pass' },
+    { check: 'sender_total', platform: 'omenstrat', status: 'pass' },
+    { check: 'sender_total', platform: 'polystrat', status: 'pass' },
+  ];
+  const d = decideVerdict(r);
+  assert.equal(d.exitCode, 0);
+  assert.equal(d.verdict, 'PASS');
+  assert.equal(d.counts.pass, 6);
+});
+
+test('decideVerdict: any divergence → exit 3 (outranks gap)', () => {
+  const r = [
+    { check: 'open_market_count', platform: 'omenstrat', status: 'divergence' },
+    { check: 'row_parity', platform: 'omenstrat', status: 'gap' },
+    { check: 'sender_total', platform: 'omenstrat', status: 'pass' },
+  ];
+  const d = decideVerdict(r);
+  assert.equal(d.exitCode, 3);
+  assert.equal(d.verdict, 'FAIL');
+  assert.match(d.message, /divergence.*omenstrat\/open_market_count/);
+});
+
+test('decideVerdict: gap without divergence → exit 4', () => {
+  const r = [
+    { check: 'open_market_count', platform: 'omenstrat', status: 'gap' },
+    { check: 'row_parity', platform: 'omenstrat', status: 'pass' },
+  ];
+  const d = decideVerdict(r);
+  assert.equal(d.exitCode, 4);
+  assert.equal(d.verdict, 'FAIL');
+  assert.match(d.message, /data gap.*omenstrat\/open_market_count/);
+});
+
+test('decideVerdict: every result vacuous → exit 2 (full-vacuous)', () => {
+  const r = [
+    { check: 'open_market_count', platform: 'omenstrat', status: 'vacuous' },
+    { check: 'open_market_count', platform: 'polystrat', status: 'vacuous' },
+  ];
+  const d = decideVerdict(r);
+  assert.equal(d.exitCode, 2);
+  assert.equal(d.verdict, 'VACUOUS');
+});
+
+test('decideVerdict: partial-vacuous — one check kind 100% vacuous → exit 2 (not 0)', () => {
+  // Reviewer's scenario: 2 platforms × 3 checks = 6 results. Check 3
+  // goes vacuous on both platforms (empty instances + null windows.all
+  // after an API contract change). Old logic reported passed=4,
+  // vacuous=2, diverged=0 and exited 0 despite two checks doing no
+  // verification. New logic must exit 2.
+  const r = [
+    { check: 'open_market_count', platform: 'omenstrat', status: 'pass' },
+    { check: 'open_market_count', platform: 'polystrat', status: 'pass' },
+    { check: 'row_parity', platform: 'omenstrat', status: 'pass' },
+    { check: 'row_parity', platform: 'polystrat', status: 'pass' },
+    { check: 'sender_total', platform: 'omenstrat', status: 'vacuous' },
+    { check: 'sender_total', platform: 'polystrat', status: 'vacuous' },
+  ];
+  const d = decideVerdict(r);
+  assert.equal(d.exitCode, 2);
+  assert.equal(d.verdict, 'VACUOUS');
+  assert.match(d.message, /sender_total/);
+  assert.equal(d.counts.pass, 4);
+  assert.equal(d.counts.vacuous, 2);
+});
+
+test('decideVerdict: mixed vacuous — kind is verified on at least one platform → exit 0', () => {
+  // Contrast with the previous test: sender_total is vacuous on
+  // polystrat but PASS on omenstrat. The check kind IS verified on at
+  // least one platform, so the run stands.
+  const r = [
+    { check: 'open_market_count', platform: 'omenstrat', status: 'pass' },
+    { check: 'open_market_count', platform: 'polystrat', status: 'pass' },
+    { check: 'sender_total', platform: 'omenstrat', status: 'pass' },
+    { check: 'sender_total', platform: 'polystrat', status: 'vacuous' },
+  ];
+  const d = decideVerdict(r);
+  assert.equal(d.exitCode, 0);
+  assert.equal(d.verdict, 'PASS');
+});
+
+test('decideVerdict: empty checkResults → exit 0 (nothing to gate, mirrors no-op run)', () => {
+  // Defensive: decideVerdict must never crash on an empty list. In
+  // practice the script always records at least one result per platform
+  // per check, but the guard makes the contract obvious.
+  const d = decideVerdict([]);
+  assert.equal(d.exitCode, 0);
+  assert.equal(d.verdict, 'PASS');
+});
+
+test('decideVerdict: truncation downgrade — check status is "gap" not "pass" when truncated+match', () => {
+  // Truncation-to-gap downgrade lives at the per-check site (check1Status
+  // = check1Truncated ? 'gap' : 'pass' when counts match). decideVerdict
+  // sees the downgraded status, so a truncated+match check contributes
+  // to the gap tally and escalates to exit 4.
+  const r = [
+    { check: 'open_market_count', platform: 'omenstrat', status: 'gap' /* truncated+match */ },
+    { check: 'row_parity', platform: 'omenstrat', status: 'pass' },
+  ];
+  const d = decideVerdict(r);
+  assert.equal(d.exitCode, 4);
+});
+
+test('decideVerdict: truncation downgrade — truncated+mismatch is gap, not divergence', () => {
+  // Same downgrade in the opposite direction: truncated+mismatch must
+  // NOT be reported as divergence because the missing rows could account
+  // for the whole delta. Per-check code sets status='gap' in this case;
+  // decideVerdict must treat it as gap (exit 4), not divergence (exit 3).
+  const r = [
+    { check: 'open_market_count', platform: 'omenstrat', status: 'gap' /* truncated+mismatch */ },
+  ];
+  const d = decideVerdict(r);
+  assert.equal(d.exitCode, 4);
+  assert.equal(d.counts.divergence, 0);
+  assert.equal(d.counts.gap, 1);
 });

--- a/scripts/verify-mech-analytics-parity.test.mjs
+++ b/scripts/verify-mech-analytics-parity.test.mjs
@@ -43,9 +43,13 @@ import {
   computeSubgraphOpenCount,
   computeAnalyticsOpenCount,
   classifyAnalyticsRows,
+  extractRowUsability,
   diffRowSets,
   pickSubgraphSenderTotal,
   decideVerdict,
+  resolveCheck1Status,
+  resolveCheck2Status,
+  SKIP_RATIO_THRESHOLD,
 } from './verify-mech-analytics-parity-lib.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -334,12 +338,33 @@ test('classifyAnalyticsRows: buckets rows by resolution_status and market_id pre
     { requester: '0xc', question_title: null, resolution_status: 'pending', market_id: '0xM4' },
   ];
   const { counts, usable } = classifyAnalyticsRows(rows);
-  assert.equal(counts.pending_with_market, 1);
-  assert.equal(counts.no_market_id, 1);
-  assert.equal(counts.invalid, 1);
-  assert.equal(counts.resolved, 1);
-  assert.equal(counts.skipped_missing_key, 2);
+  // Bucket keys are `raw_*` prefixed so the artifact reader can tell
+  // these are pre-dedup / pre-window counts, not the same population as
+  // computeAnalyticsOpenCount's post-dedup skippedInvalid/etc.
+  assert.equal(counts.raw_pending_with_market, 1);
+  assert.equal(counts.raw_no_market_id, 1);
+  assert.equal(counts.raw_invalid, 1);
+  assert.equal(counts.raw_resolved, 1);
+  assert.equal(counts.raw_skipped_missing_key, 2);
   assert.equal(usable.length, 4); // rows with requester+title survive the key check
+});
+
+test('classifyAnalyticsRows: duplicate request_ids all counted (pre-dedup semantics)', () => {
+  // Deliberate divergence from computeAnalyticsOpenCount. The API re-serves
+  // a row every time the resolution sweep touches it
+  // (docs/mech-analytics-migration.md:79-84); this bucket count reports
+  // that raw shape so the artifact reader can see the physical row
+  // volume, and computeAnalyticsOpenCount dedups so the check-1 gate
+  // uses each request once. Regression guard so a future edit that
+  // deduplicates here doesn't silently change the artifact's meaning.
+  const rows = [
+    { request_id: 'r1', requester: '0xa', question_title: 'q1', resolution_status: 'invalid', market_id: '0xM' },
+    { request_id: 'r1', requester: '0xa', question_title: 'q1', resolution_status: 'invalid', market_id: '0xM' },
+    { request_id: 'r1', requester: '0xa', question_title: 'q1', resolution_status: 'invalid', market_id: '0xM' },
+  ];
+  const { counts, usable } = classifyAnalyticsRows(rows);
+  assert.equal(counts.raw_invalid, 3);
+  assert.equal(usable.length, 3);
 });
 
 // ---------------------------------------------------------------------------
@@ -862,38 +887,432 @@ test('decideVerdict: mixed vacuous — kind is verified on at least one platform
   assert.equal(d.verdict, 'PASS');
 });
 
-test('decideVerdict: empty checkResults → exit 0 (nothing to gate, mirrors no-op run)', () => {
-  // Defensive: decideVerdict must never crash on an empty list. In
-  // practice the script always records at least one result per platform
-  // per check, but the guard makes the contract obvious.
+test('decideVerdict: empty checkResults → exit 2 VACUOUS (nothing checked is never a pass)', () => {
+  // Reviewer regression: round 2 added `checkResults.length > 0 &&` to
+  // the all-vacuous branch and, as a side effect, made an empty list
+  // fall through to the final `PASS`. Any future caller that hands an
+  // empty list to decideVerdict (filtered subset, early return,
+  // feature-flagged PLATFORMS) would inherit "nothing checked means
+  // PASS". Empty MUST be exit 2, not exit 0.
   const d = decideVerdict([]);
-  assert.equal(d.exitCode, 0);
-  assert.equal(d.verdict, 'PASS');
+  assert.equal(d.exitCode, 2);
+  assert.equal(d.verdict, 'VACUOUS');
+  assert.match(d.message, /no checks were recorded/);
 });
 
-test('decideVerdict: truncation downgrade — check status is "gap" not "pass" when truncated+match', () => {
-  // Truncation-to-gap downgrade lives at the per-check site (check1Status
-  // = check1Truncated ? 'gap' : 'pass' when counts match). decideVerdict
-  // sees the downgraded status, so a truncated+match check contributes
-  // to the gap tally and escalates to exit 4.
+test('decideVerdict: propagates pre-labelled "gap" status to exit 4', () => {
+  // decideVerdict operates on already-classified statuses. This test
+  // pins the contract that a `gap` from any check-site downgrade
+  // escalates to exit 4 (not exit 0). The actual downgrade computation
+  // is tested against resolveCheck1Status / resolveCheck2Status below.
   const r = [
-    { check: 'open_market_count', platform: 'omenstrat', status: 'gap' /* truncated+match */ },
+    { check: 'open_market_count', platform: 'omenstrat', status: 'gap' },
     { check: 'row_parity', platform: 'omenstrat', status: 'pass' },
   ];
   const d = decideVerdict(r);
   assert.equal(d.exitCode, 4);
 });
 
-test('decideVerdict: truncation downgrade — truncated+mismatch is gap, not divergence', () => {
-  // Same downgrade in the opposite direction: truncated+mismatch must
-  // NOT be reported as divergence because the missing rows could account
-  // for the whole delta. Per-check code sets status='gap' in this case;
-  // decideVerdict must treat it as gap (exit 4), not divergence (exit 3).
+test('decideVerdict: pre-labelled "gap" from truncated+mismatch does not escalate to divergence', () => {
+  // Same as above in the opposite direction: even when there IS a diff,
+  // a check-site that labels itself `gap` (because it was truncated)
+  // must not be treated as `divergence` by decideVerdict — otherwise a
+  // truncated fetch could report a fake regression.
   const r = [
-    { check: 'open_market_count', platform: 'omenstrat', status: 'gap' /* truncated+mismatch */ },
+    { check: 'open_market_count', platform: 'omenstrat', status: 'gap' },
   ];
   const d = decideVerdict(r);
   assert.equal(d.exitCode, 4);
   assert.equal(d.counts.divergence, 0);
   assert.equal(d.counts.gap, 1);
+});
+
+// ---------------------------------------------------------------------------
+// extractRowUsability — the shared filter classifyAnalyticsRows /
+// computeAnalyticsOpenCount both go through
+// ---------------------------------------------------------------------------
+
+test('extractRowUsability: lowercases requester and requires non-empty title', () => {
+  // Both fields required; requester lowercased; either missing → not usable.
+  assert.deepEqual(extractRowUsability({ requester: '0xABC', question_title: 'q' }), {
+    requester: '0xabc',
+    title: 'q',
+    usable: true,
+  });
+  assert.deepEqual(extractRowUsability({ requester: null, question_title: 'q' }), {
+    requester: null,
+    title: 'q',
+    usable: false,
+  });
+  assert.deepEqual(extractRowUsability({ requester: '0xABC', question_title: null }), {
+    requester: '0xabc',
+    title: null,
+    usable: false,
+  });
+  assert.deepEqual(extractRowUsability({ requester: '', question_title: 'q' }), {
+    requester: '',
+    title: 'q',
+    usable: false,
+  });
+  assert.deepEqual(extractRowUsability({ requester: '0xabc', question_title: '' }), {
+    requester: '0xabc',
+    title: '',
+    usable: false,
+  });
+});
+
+test('classifyAnalyticsRows and computeAnalyticsOpenCount agree on usability filter', () => {
+  // Both call sites must classify "usable" identically for the artifact
+  // to make sense. This is the anti-drift test the reviewer asked for:
+  // if the shared helper's contract changes, both callers move together
+  // or this fails.
+  const rows = [
+    { request_id: 'r1', requester: '0xA', question_title: 'q1', resolution_status: 'pending', requested_at: '2026-07-01T00:00:00Z', market_id: null },
+    { request_id: 'r2', requester: null, question_title: 'q2', resolution_status: 'pending', requested_at: '2026-07-01T00:00:00Z', market_id: null },
+    { request_id: 'r3', requester: '0xB', question_title: '', resolution_status: 'pending', requested_at: '2026-07-01T00:00:00Z', market_id: null },
+    { request_id: 'r4', requester: '', question_title: 'q4', resolution_status: 'pending', requested_at: '2026-07-01T00:00:00Z', market_id: null },
+  ];
+  const { counts, usable } = classifyAnalyticsRows(rows);
+  const result = computeAnalyticsOpenCount(rows, [], NO_WINDOW);
+  // classifyAnalyticsRows skipped 3, computeAnalyticsOpenCount skipped 3;
+  // exactly one row survived on each side.
+  assert.equal(counts.raw_skipped_missing_key, 3);
+  assert.equal(usable.length, 1);
+  assert.equal(result.skippedMissingKey, 3);
+  assert.equal(result.ingested, 1);
+});
+
+// ---------------------------------------------------------------------------
+// computeAnalyticsOpenCount — skippedMissingKey counter (previously untested)
+// ---------------------------------------------------------------------------
+
+test('computeAnalyticsOpenCount: skippedMissingKey counts survivors of ts+invalid but no requester/title', () => {
+  // Ordering matters: dedup → ts → invalid → missing-key. A row that
+  // survives dedup, ts, and invalid but has no requester or title lands
+  // in skippedMissingKey (not skippedInvalid or skippedOutOfWindow).
+  const rows = [
+    { request_id: 'r1', requester: '0xA', question_title: 'q1', resolution_status: 'pending', requested_at: '2026-07-01T00:00:00Z', market_id: null },
+    { request_id: 'r2', requester: null, question_title: 'q2', resolution_status: 'pending', requested_at: '2026-07-01T00:00:00Z', market_id: null },
+    { request_id: 'r3', requester: '0xB', question_title: null, resolution_status: 'pending', requested_at: '2026-07-01T00:00:00Z', market_id: null },
+    { request_id: 'r4', requester: null, question_title: null, resolution_status: 'pending', requested_at: '2026-07-01T00:00:00Z', market_id: null },
+  ];
+  const result = computeAnalyticsOpenCount(rows, [], NO_WINDOW);
+  assert.equal(result.skippedMissingKey, 3);
+  assert.equal(result.skippedInvalid, 0);
+  assert.equal(result.skippedOutOfWindow, 0);
+  assert.equal(result.skippedDuplicate, 0);
+  assert.equal(result.ingested, 1);
+});
+
+// ---------------------------------------------------------------------------
+// resolveCheck1Status — extracted downgrade / vacuous / gap logic
+// ---------------------------------------------------------------------------
+
+test('resolveCheck1Status: exact match with no truncation → pass', () => {
+  const r = resolveCheck1Status({
+    subgraphOpen: 5,
+    subgraphConsumed: 2,
+    analyticsOpen: 5,
+    analyticsConsumed: 2,
+    analyticsIngested: 7,
+    analyticsRawRowCount: 7,
+    subgraphRowCount: 7,
+    analyticsSkippedOutOfWindow: 0,
+    truncated: false,
+  });
+  assert.equal(r.status, 'pass');
+  assert.equal(r.reason, 'exact-match');
+});
+
+test('resolveCheck1Status: truncated match downgrades pass → gap', () => {
+  const r = resolveCheck1Status({
+    subgraphOpen: 5,
+    subgraphConsumed: 2,
+    analyticsOpen: 5,
+    analyticsConsumed: 2,
+    analyticsIngested: 7,
+    analyticsRawRowCount: 7,
+    subgraphRowCount: 7,
+    analyticsSkippedOutOfWindow: 0,
+    truncated: true,
+  });
+  assert.equal(r.status, 'gap');
+  assert.equal(r.reason, 'match-but-truncated');
+});
+
+test('resolveCheck1Status: truncated mismatch downgrades divergence → gap', () => {
+  const r = resolveCheck1Status({
+    subgraphOpen: 5,
+    subgraphConsumed: 2,
+    analyticsOpen: 3,
+    analyticsConsumed: 4,
+    analyticsIngested: 7,
+    analyticsRawRowCount: 7,
+    subgraphRowCount: 7,
+    analyticsSkippedOutOfWindow: 0,
+    truncated: true,
+  });
+  assert.equal(r.status, 'gap');
+  assert.equal(r.reason, 'mismatch-but-truncated');
+});
+
+test('resolveCheck1Status: untruncated mismatch → divergence', () => {
+  const r = resolveCheck1Status({
+    subgraphOpen: 5,
+    subgraphConsumed: 2,
+    analyticsOpen: 4,
+    analyticsConsumed: 3,
+    analyticsIngested: 7,
+    analyticsRawRowCount: 7,
+    subgraphRowCount: 7,
+    analyticsSkippedOutOfWindow: 0,
+    truncated: false,
+  });
+  assert.equal(r.status, 'divergence');
+  assert.equal(r.reason, 'open-mismatch');
+});
+
+test('resolveCheck1Status: open matches but consumed differs → divergence (advisory 4 fix)', () => {
+  // Reviewer's example: subgraph 3 requests with 1 genuinely missing
+  // vs analytics 4 correct. Both settle in the same market, so open=0
+  // on both sides — but consumed diverges 3 vs 4. Comparing open alone
+  // would PASS. resolveCheck1Status must flag this as divergence.
+  const r = resolveCheck1Status({
+    subgraphOpen: 0,
+    subgraphConsumed: 3,
+    analyticsOpen: 0,
+    analyticsConsumed: 4,
+    analyticsIngested: 4,
+    analyticsRawRowCount: 4,
+    subgraphRowCount: 3,
+    analyticsSkippedOutOfWindow: 0,
+    truncated: false,
+  });
+  assert.equal(r.status, 'divergence');
+  assert.equal(r.reason, 'consumed-mismatch');
+});
+
+test('resolveCheck1Status: both feeds empty → vacuous', () => {
+  const r = resolveCheck1Status({
+    subgraphOpen: 0,
+    subgraphConsumed: 0,
+    analyticsOpen: 0,
+    analyticsConsumed: 0,
+    analyticsIngested: 0,
+    analyticsRawRowCount: 0,
+    subgraphRowCount: 0,
+    analyticsSkippedOutOfWindow: 0,
+    truncated: false,
+  });
+  assert.equal(r.status, 'vacuous');
+  assert.equal(r.reason, 'no-rows-either-side');
+});
+
+test('resolveCheck1Status: analytics raw non-empty but ingested=0 → gap (round-2 regression)', () => {
+  // Reviewer's reproduction: 500 rows with unparseable requested_at, the
+  // window/ts gate drops all 500, ingested=0, open=0. Subgraph quiet in
+  // the same window (open=0). Old branch would PASS. Must now GAP.
+  const r = resolveCheck1Status({
+    subgraphOpen: 0,
+    subgraphConsumed: 0,
+    analyticsOpen: 0,
+    analyticsConsumed: 0,
+    analyticsIngested: 0,
+    analyticsRawRowCount: 500,
+    subgraphRowCount: 0,
+    analyticsSkippedOutOfWindow: 500,
+    truncated: false,
+  });
+  assert.equal(r.status, 'gap');
+  assert.equal(r.reason, 'analytics-ingested-zero');
+});
+
+test('resolveCheck1Status: analytics dropped >50% of raw via out-of-window → gap (partial degradation)', () => {
+  // Between total failure and healthy: half the raw feed gets dropped
+  // by the ts gate. We can't trust the open count as representative.
+  // Ratio threshold guard should escalate to gap.
+  const r = resolveCheck1Status({
+    subgraphOpen: 5,
+    subgraphConsumed: 2,
+    analyticsOpen: 5,
+    analyticsConsumed: 2,
+    analyticsIngested: 4,
+    analyticsRawRowCount: 10,
+    subgraphRowCount: 7,
+    analyticsSkippedOutOfWindow: 6, // 6/10 = 60% > 50%
+    truncated: false,
+  });
+  assert.equal(r.status, 'gap');
+  assert.equal(r.reason, 'analytics-out-of-window-majority');
+});
+
+test('resolveCheck1Status: skip ratio at threshold is not enough to trigger gap', () => {
+  // Boundary check: SKIP_RATIO_THRESHOLD is strict-greater-than (`>`).
+  // Exactly at the threshold is not a gap — otherwise flapping around
+  // the boundary would produce inconsistent verdicts.
+  assert.equal(SKIP_RATIO_THRESHOLD, 0.5);
+  const r = resolveCheck1Status({
+    subgraphOpen: 5,
+    subgraphConsumed: 2,
+    analyticsOpen: 5,
+    analyticsConsumed: 2,
+    analyticsIngested: 5,
+    analyticsRawRowCount: 10,
+    subgraphRowCount: 7,
+    analyticsSkippedOutOfWindow: 5, // 5/10 = exactly 0.5
+    truncated: false,
+  });
+  assert.equal(r.status, 'pass');
+});
+
+// ---------------------------------------------------------------------------
+// resolveCheck2Status — extracted row-parity downgrade
+// ---------------------------------------------------------------------------
+
+test('resolveCheck2Status: zero diffs, not truncated → pass', () => {
+  const r = resolveCheck2Status({
+    subgraphRowCount: 10,
+    analyticsRowCount: 10,
+    missingInAnalytics: 0,
+    extraInAnalytics: 0,
+    truncated: false,
+  });
+  assert.equal(r.status, 'pass');
+  assert.equal(r.reason, 'exact-match');
+});
+
+test('resolveCheck2Status: zero diffs BUT truncated → gap (match-but-truncated)', () => {
+  const r = resolveCheck2Status({
+    subgraphRowCount: 10,
+    analyticsRowCount: 10,
+    missingInAnalytics: 0,
+    extraInAnalytics: 0,
+    truncated: true,
+  });
+  assert.equal(r.status, 'gap');
+  assert.equal(r.reason, 'match-but-truncated');
+});
+
+test('resolveCheck2Status: non-zero diffs BUT truncated → gap not divergence', () => {
+  const r = resolveCheck2Status({
+    subgraphRowCount: 10,
+    analyticsRowCount: 8,
+    missingInAnalytics: 2,
+    extraInAnalytics: 0,
+    truncated: true,
+  });
+  assert.equal(r.status, 'gap');
+  assert.equal(r.reason, 'mismatch-but-truncated');
+});
+
+test('resolveCheck2Status: non-zero diffs, not truncated → divergence', () => {
+  const r = resolveCheck2Status({
+    subgraphRowCount: 10,
+    analyticsRowCount: 8,
+    missingInAnalytics: 2,
+    extraInAnalytics: 0,
+    truncated: false,
+  });
+  assert.equal(r.status, 'divergence');
+  assert.equal(r.reason, 'row-set-mismatch');
+});
+
+test('resolveCheck2Status: both empty → vacuous', () => {
+  const r = resolveCheck2Status({
+    subgraphRowCount: 0,
+    analyticsRowCount: 0,
+    missingInAnalytics: 0,
+    extraInAnalytics: 0,
+    truncated: false,
+  });
+  assert.equal(r.status, 'vacuous');
+});
+
+// ---------------------------------------------------------------------------
+// End-to-end reproduction of the round-2 zero-ingest regression
+// ---------------------------------------------------------------------------
+
+test('E2E round-2 regression: 500 unparseable rows + quiet subgraph must be GAP not PASS', () => {
+  // Ojus's exact scenario: mech-analytics ETL contract drift produces
+  // 500 scored rows with unparseable requested_at. The ts gate drops
+  // all 500 → ingested=0 → open=0. Subgraph is quiet in the same
+  // window (no marketplace rows). Old check-1 branch would emit
+  // "PASS: open-market counts match exactly (0)" and exit 0. This test
+  // wires computeAnalyticsOpenCount to resolveCheck1Status the same
+  // way parity.mjs does and asserts the pipeline lands on `gap`.
+  const rows = Array.from({ length: 500 }, (_, i) => ({
+    request_id: `r${i}`,
+    requester: '0xa',
+    question_title: 'q',
+    resolution_status: 'pending',
+    requested_at: 'not a valid date at all', // Date.parse → NaN → ts NaN → skipped
+    market_id: null,
+  }));
+  const windowStartSec = Math.floor(Date.parse('2026-07-01T00:00:00Z') / 1000);
+  const analyticsOpen = computeAnalyticsOpenCount(rows, [], windowStartSec);
+  // Precondition: exactly the ETL-drift shape the reviewer described.
+  assert.equal(analyticsOpen.ingested, 0);
+  assert.equal(analyticsOpen.open, 0);
+  assert.equal(analyticsOpen.skippedOutOfWindow, 500);
+  const subgraphOpen = { open: 0, consumed: 0 };
+  const decision = resolveCheck1Status({
+    subgraphOpen: subgraphOpen.open,
+    subgraphConsumed: subgraphOpen.consumed,
+    analyticsOpen: analyticsOpen.open,
+    analyticsConsumed: analyticsOpen.consumed,
+    analyticsIngested: analyticsOpen.ingested,
+    analyticsRawRowCount: rows.length, // 500 raw rows in
+    subgraphRowCount: 0,
+    analyticsSkippedOutOfWindow: analyticsOpen.skippedOutOfWindow,
+    truncated: false,
+  });
+  assert.equal(decision.status, 'gap');
+  assert.equal(decision.reason, 'analytics-ingested-zero');
+});
+
+test('E2E round-2 regression: consumed-drain hides discrepancy (advisory 4)', () => {
+  // Ojus's example for advisory 4: subgraph has 3 requests on title T
+  // for agent A but ONE is genuinely missing (2 usable). analytics has
+  // 4 correctly. Settlement drains agent A on match → open=0 on both
+  // sides. Comparing open alone: PASS. Comparing consumed too: divergence.
+  //
+  // Build subgraph feed: 2 requests (post the "missing" one) on title T.
+  const subgraphRequests = [
+    { requester: '0xa', title: 'Some market title' },
+    { requester: '0xa', title: 'Some market title' },
+  ];
+  // Build analytics feed: 4 requests on the same title.
+  const analyticsRows = Array.from({ length: 4 }, (_, i) => ({
+    request_id: `r${i}`,
+    requester: '0xa',
+    question_title: 'Some market title',
+    resolution_status: 'pending',
+    requested_at: '2026-07-02T00:00:00Z',
+    market_id: '0xM',
+  }));
+  // Settlement: agent A settles the market.
+  const dailyStats = [
+    { traderAgent: { id: '0xa' }, profitParticipants: [{ question: 'Some market title' }] },
+  ];
+  const subgraphOpen = computeSubgraphOpenCount(subgraphRequests, dailyStats);
+  const analyticsOpen = computeAnalyticsOpenCount(analyticsRows, dailyStats, NO_WINDOW);
+  // Confirm both open=0 (settlement drained both agent buckets fully).
+  assert.equal(subgraphOpen.open, 0);
+  assert.equal(analyticsOpen.open, 0);
+  // But consumed differs — that's the hidden discrepancy.
+  assert.equal(subgraphOpen.consumed, 2);
+  assert.equal(analyticsOpen.consumed, 4);
+  const decision = resolveCheck1Status({
+    subgraphOpen: subgraphOpen.open,
+    subgraphConsumed: subgraphOpen.consumed,
+    analyticsOpen: analyticsOpen.open,
+    analyticsConsumed: analyticsOpen.consumed,
+    analyticsIngested: analyticsOpen.ingested,
+    analyticsRawRowCount: analyticsRows.length,
+    subgraphRowCount: subgraphRequests.length,
+    analyticsSkippedOutOfWindow: 0,
+    truncated: false,
+  });
+  assert.equal(decision.status, 'divergence');
+  assert.equal(decision.reason, 'consumed-mismatch');
 });

--- a/scripts/verify-mech-analytics-parity.test.mjs
+++ b/scripts/verify-mech-analytics-parity.test.mjs
@@ -1072,26 +1072,6 @@ test('resolveCheck1Status: untruncated mismatch → divergence', () => {
   assert.equal(r.reason, 'open-mismatch');
 });
 
-test('resolveCheck1Status: open matches but consumed differs → divergence (advisory 4 fix)', () => {
-  // Reviewer's example: subgraph 3 requests with 1 genuinely missing
-  // vs analytics 4 correct. Both settle in the same market, so open=0
-  // on both sides — but consumed diverges 3 vs 4. Comparing open alone
-  // would PASS. resolveCheck1Status must flag this as divergence.
-  const r = resolveCheck1Status({
-    subgraphOpen: 0,
-    subgraphConsumed: 3,
-    analyticsOpen: 0,
-    analyticsConsumed: 4,
-    analyticsIngested: 4,
-    analyticsRawRowCount: 4,
-    subgraphRowCount: 3,
-    analyticsSkippedOutOfWindow: 0,
-    truncated: false,
-  });
-  assert.equal(r.status, 'divergence');
-  assert.equal(r.reason, 'consumed-mismatch');
-});
-
 test('resolveCheck1Status: both feeds empty → vacuous', () => {
   const r = resolveCheck1Status({
     subgraphOpen: 0,
@@ -1133,17 +1113,17 @@ test('resolveCheck1Status: analytics dropped >50% of raw via out-of-window → g
   // Ratio threshold guard should escalate to gap.
   const r = resolveCheck1Status({
     subgraphOpen: 5,
-    subgraphConsumed: 2,
     analyticsOpen: 5,
-    analyticsConsumed: 2,
     analyticsIngested: 4,
     analyticsRawRowCount: 10,
     subgraphRowCount: 7,
     analyticsSkippedOutOfWindow: 6, // 6/10 = 60% > 50%
+    analyticsSkippedMissingKey: 0,
+    analyticsSkippedInvalid: 0,
     truncated: false,
   });
   assert.equal(r.status, 'gap');
-  assert.equal(r.reason, 'analytics-out-of-window-majority');
+  assert.equal(r.reason, 'analytics-attrition-majority');
 });
 
 test('resolveCheck1Status: skip ratio at threshold is not enough to trigger gap', () => {
@@ -1153,16 +1133,131 @@ test('resolveCheck1Status: skip ratio at threshold is not enough to trigger gap'
   assert.equal(SKIP_RATIO_THRESHOLD, 0.5);
   const r = resolveCheck1Status({
     subgraphOpen: 5,
-    subgraphConsumed: 2,
     analyticsOpen: 5,
-    analyticsConsumed: 2,
     analyticsIngested: 5,
     analyticsRawRowCount: 10,
     subgraphRowCount: 7,
     analyticsSkippedOutOfWindow: 5, // 5/10 = exactly 0.5
+    analyticsSkippedMissingKey: 0,
+    analyticsSkippedInvalid: 0,
     truncated: false,
   });
   assert.equal(r.status, 'pass');
+});
+
+test('resolveCheck1Status: majority of analytics feed lost via missing-key → gap (round-3 widened numerator)', () => {
+  // Ojus's round-3 repro (comment 3736451382): 5000 raw rows, 4999 lose
+  // `requester` to a schema drift and land in `skippedMissingKey`, one
+  // survivor matches the subgraph's single row. Old numerator counted
+  // only `skippedOutOfWindow` → 0/5000 → ratio guard didn't fire → open
+  // matched → PASS on a feed that lost 99.98% of its rows. Widened
+  // numerator must escalate to gap.
+  const r = resolveCheck1Status({
+    subgraphOpen: 1,
+    analyticsOpen: 1,
+    analyticsIngested: 1,
+    analyticsRawRowCount: 5000,
+    subgraphRowCount: 1,
+    analyticsSkippedOutOfWindow: 0,
+    analyticsSkippedMissingKey: 4999,
+    analyticsSkippedInvalid: 0,
+    truncated: false,
+  });
+  assert.equal(r.status, 'gap');
+  assert.equal(r.reason, 'analytics-attrition-majority');
+});
+
+test('resolveCheck1Status: majority of analytics feed lost via invalid → gap (widened numerator, predict-api regression)', () => {
+  // Sibling of the missing-key case: predict-api starts mis-classifying
+  // rows as `resolution_status = 'invalid'` on most of the feed. Landing
+  // entirely in `skippedInvalid` was invisible to the round-2 numerator.
+  const r = resolveCheck1Status({
+    subgraphOpen: 1,
+    analyticsOpen: 1,
+    analyticsIngested: 1,
+    analyticsRawRowCount: 100,
+    subgraphRowCount: 1,
+    analyticsSkippedOutOfWindow: 0,
+    analyticsSkippedMissingKey: 0,
+    analyticsSkippedInvalid: 60,
+    truncated: false,
+  });
+  assert.equal(r.status, 'gap');
+  assert.equal(r.reason, 'analytics-attrition-majority');
+});
+
+test('resolveCheck1Status: duplicates alone do NOT trigger the attrition guard (healthy re-serves)', () => {
+  // docs/mech-analytics-migration.md:79-84 — the API re-serves the same
+  // row on every sweep touch, so `skippedDuplicate` is expected on any
+  // window with resolution-sweep activity. Including it in the numerator
+  // would fire the guard on perfectly healthy data. Guard the invariant
+  // structurally: the function does not accept a `analyticsSkippedDuplicate`
+  // parameter, so a future change that pipes it in is a signature-level
+  // breakage this call site would surface immediately. The runtime check
+  // below asserts a 90-duplicate window with no non-duplicate attrition
+  // stays pass.
+  const r = resolveCheck1Status({
+    subgraphOpen: 3,
+    analyticsOpen: 3,
+    analyticsIngested: 10,
+    analyticsRawRowCount: 100,
+    subgraphRowCount: 3,
+    analyticsSkippedOutOfWindow: 0,
+    analyticsSkippedMissingKey: 0,
+    analyticsSkippedInvalid: 0,
+    truncated: false,
+  });
+  assert.equal(r.status, 'pass');
+});
+
+test('resolveCheck1Status: subgraph ingested 0 rows from non-empty raw → gap (round-3 subgraph guard)', () => {
+  // Ojus's round-3 comment 3736451400 — mirror of the analytics zero-
+  // ingest guard. `fetchMarketplaceRequests` returns rows === [] after
+  // filtering missing sender/title/ts or past-window-end, but the raw
+  // page had entries. Without this branch it looks like a quiet window
+  // (subgraphRowCount === 0 but subgraphRawRowCount > 0 falls through
+  // to open-mismatch or exact-match depending on the analytics side).
+  // Analytics side kept healthy so the analytics guards don't fire first.
+  const r = resolveCheck1Status({
+    subgraphOpen: 0,
+    analyticsOpen: 0,
+    analyticsIngested: 5,
+    analyticsRawRowCount: 5,
+    subgraphRowCount: 0,
+    subgraphRawRowCount: 500,
+    subgraphSkippedMissingKey: 500,
+    subgraphSkippedAfterWindowEnd: 0,
+    analyticsSkippedOutOfWindow: 0,
+    analyticsSkippedMissingKey: 0,
+    analyticsSkippedInvalid: 0,
+    truncated: false,
+  });
+  assert.equal(r.status, 'gap');
+  assert.equal(r.reason, 'subgraph-ingested-zero');
+});
+
+test('resolveCheck1Status: majority of subgraph feed lost via missing-key → gap (round-3 subgraph guard)', () => {
+  // The subgraph side sibling of `analytics-attrition-majority`.
+  // `sender.id` (or `parsedRequest.questionTitle`) going missing on
+  // most `Request` entities lands entirely in `skippedMissingKey` and
+  // would otherwise present as a smaller `subgraphRowCount`,
+  // structurally indistinguishable from a genuinely quiet window.
+  const r = resolveCheck1Status({
+    subgraphOpen: 1,
+    analyticsOpen: 1,
+    analyticsIngested: 100,
+    analyticsRawRowCount: 100,
+    subgraphRowCount: 1,
+    subgraphRawRowCount: 100,
+    subgraphSkippedMissingKey: 60, // 60/100 = 60% > 50%
+    subgraphSkippedAfterWindowEnd: 0,
+    analyticsSkippedOutOfWindow: 0,
+    analyticsSkippedMissingKey: 0,
+    analyticsSkippedInvalid: 0,
+    truncated: false,
+  });
+  assert.equal(r.status, 'gap');
+  assert.equal(r.reason, 'subgraph-attrition-majority');
 });
 
 // ---------------------------------------------------------------------------
@@ -1270,49 +1365,3 @@ test('E2E round-2 regression: 500 unparseable rows + quiet subgraph must be GAP 
   assert.equal(decision.reason, 'analytics-ingested-zero');
 });
 
-test('E2E round-2 regression: consumed-drain hides discrepancy (advisory 4)', () => {
-  // Ojus's example for advisory 4: subgraph has 3 requests on title T
-  // for agent A but ONE is genuinely missing (2 usable). analytics has
-  // 4 correctly. Settlement drains agent A on match → open=0 on both
-  // sides. Comparing open alone: PASS. Comparing consumed too: divergence.
-  //
-  // Build subgraph feed: 2 requests (post the "missing" one) on title T.
-  const subgraphRequests = [
-    { requester: '0xa', title: 'Some market title' },
-    { requester: '0xa', title: 'Some market title' },
-  ];
-  // Build analytics feed: 4 requests on the same title.
-  const analyticsRows = Array.from({ length: 4 }, (_, i) => ({
-    request_id: `r${i}`,
-    requester: '0xa',
-    question_title: 'Some market title',
-    resolution_status: 'pending',
-    requested_at: '2026-07-02T00:00:00Z',
-    market_id: '0xM',
-  }));
-  // Settlement: agent A settles the market.
-  const dailyStats = [
-    { traderAgent: { id: '0xa' }, profitParticipants: [{ question: 'Some market title' }] },
-  ];
-  const subgraphOpen = computeSubgraphOpenCount(subgraphRequests, dailyStats);
-  const analyticsOpen = computeAnalyticsOpenCount(analyticsRows, dailyStats, NO_WINDOW);
-  // Confirm both open=0 (settlement drained both agent buckets fully).
-  assert.equal(subgraphOpen.open, 0);
-  assert.equal(analyticsOpen.open, 0);
-  // But consumed differs — that's the hidden discrepancy.
-  assert.equal(subgraphOpen.consumed, 2);
-  assert.equal(analyticsOpen.consumed, 4);
-  const decision = resolveCheck1Status({
-    subgraphOpen: subgraphOpen.open,
-    subgraphConsumed: subgraphOpen.consumed,
-    analyticsOpen: analyticsOpen.open,
-    analyticsConsumed: analyticsOpen.consumed,
-    analyticsIngested: analyticsOpen.ingested,
-    analyticsRawRowCount: analyticsRows.length,
-    subgraphRowCount: subgraphRequests.length,
-    analyticsSkippedOutOfWindow: 0,
-    truncated: false,
-  });
-  assert.equal(decision.status, 'divergence');
-  assert.equal(decision.reason, 'consumed-mismatch');
-});


### PR DESCRIPTION
The mech-analytics parity script (merged in #551) was failing production runs because two of the three checks compared the wrong quantities against how the consumer actually behaves post-swap. This PR fixes both, adds `--since/--until` for historical windows, and pulls the pure helpers into `-lib.mjs` so the fixes are unit-testable.

## Check 1 — open-market count parity: wrong gate

Was: filter mech-analytics scored-rows on `resolution_status='pending' AND market_id IS NOT NULL` (the "(a)" bucket) and compare that count to the subgraph-computed open count.

The consumer (`common-util/api/predict/mech-analytics.ts::fetchMechRequestsFromAnalytics`, roi-distribution.ts) does not filter on `market_id` at all. It only skips invalid rows and rows missing requester/title. 99% of chain-100 rows in `per_request_scores` have `market_id NULL` (the column is populated only for a small recent tail), so the previous gate dropped ~99% of legitimate rows. In prod the check saw 0 pending+market_id vs 1326 subgraph_open and exited 3 FAIL.

Now: reproduce the consumer's post-swap QMR pipeline on the analytics side (feed the scored-rows through the same filter, build the QMR by `question_title`, consume via `dailyProfitStatistics` using `normalizeTitle` matching) and compare open-count vs open-count. The (a)/(b)/(c) row bucket breakdown is still printed for context but is no longer the gated number. Implementation is in `computeAnalyticsOpenCount` in the -lib module and mirrors `computeSubgraphOpenCount` exactly.

## Check 3 — senderTotal parity: wrong counter

Was: sum `Sender.totalLegacyRequests + Sender.totalMarketplaceRequests` and compare to `agent_aggregates.n_mech_requests`.

Verified in the subgraph handler (`autonolas-subgraph/subgraphs/marketplace/src/marketplace/mech-marketplace.ts`):
- `handleMarketplaceRequest` (on-chain): `totalMarketplaceRequests += 1` AND `totalLegacyRequests += numRequests`
- `handleMarketplaceDeliveryWithSignatures` (off-chain): `totalOffChainRequests += numDeliveries` AND `totalLegacyRequests += numDeliveries`

So `totalLegacyRequests` is misnamed — it is the grand total of every request the Safe made (on-chain + off-chain), not a legacy tail. Summing it with `totalMarketplaceRequests` counts the on-chain path twice. That produced the chronic 2x divergence in prod (Gnosis 604,930 vs 302,465; Polygon 129,044 vs 64,519).

Now: use `totalLegacyRequests` alone, which matches `agent_aggregates.n_mech_requests` semantics one-to-one. The selection lives in `pickSubgraphSenderTotal` with a docstring pointing back to the two handler lines and the naming pitfall.

## New: `--since <iso>` / `--until <iso>`

Backfill windows before the live off-chain flow is turned on have zero mech-analytics data on recent windows, so `--window-days` alone can't gate them. Added explicit-window flags that mirror `mech-predict/scripts/verify_migration_swap.py:_compute_window`:
- Both timezone-aware (Z or ±HH:MM). Naive datetimes rejected.
- Mutually required (both or neither).
- `--until` must be strictly after `--since`.
- Mutually exclusive with `--window-days` / `--lag-buffer-minutes` (an explicit window means the operator chose the exact bounds).
- Daily-stats consumption cap is now `min(now - finalityLag, windowEnd + finalityLag)` so a historical window doesn't uselessly sweep months of daily-stats.

Example:
```
node scripts/verify-mech-analytics-parity.mjs \
  --since 2026-07-01T00:00:00Z --until 2026-07-08T00:00:00Z
```

## Preserved

- Exit code contract: 0 pass / 1 error / 2 vacuous / 3 divergence / 4 data gap
- `--output-dir` artifact writing (parity-<ts>.md + .json), secret scrubbing, `GIT_SHA` header
- Pagination truncation guards, `>=` boundary symmetry
- Docker + CI wiring (`Dockerfile.verify` and `publish-verify-image.yaml` updated to include the new -lib.mjs file)

## Tests

- Extracted pure helpers into `scripts/verify-mech-analytics-parity-lib.mjs` (townhall PR #148 pattern the merged script hadn't yet followed).
- Added `scripts/verify-mech-analytics-parity.test.mjs` using `node --test` (built-in, no new devDeps).

Runnable locally via `yarn --ignore-engines verify-mech-analytics-parity:test`.

---

## Review-round-2 fixes (commits 6dd1f05a and a69108dc)

Address https://github.com/valory-xyz/olas-website/pull/552#pullrequestreview (@OjusWiZard):

**Check 1 rewrite (comments 3735822997, 3735823002, 3735823009, 3735823013).** The pre-fix check-1 helpers didn't reproduce the consumer they claimed to mirror. Fixed together by extracting one shared QMR pipeline:

1. Shared `runQmrOpenCount(entries, dailyStats)` in `-lib.mjs`. Both `computeSubgraphOpenCount` and `computeAnalyticsOpenCount` become thin adapters that build entries then delegate. The 25 verbatim-identical lines are now one.
2. Analytics-side dedup on `request_id` in `computeAnalyticsOpenCount`, matching `mech-analytics.ts:171-197`. The API sends the same row again every time its resolution updates; without dedup every update re-inflates the analytics open count vs the subgraph. Also mirrors the consumer's filter order: dedup → window/ts (`ts <= 0 || ts < windowStartSec`) → invalid+remember-id → requester/title → ingest+remember-id.
3. Settlement title match uses the consumer's `p.question ?? p.metadata?.title` union unconditionally (roi-distribution.ts:573), not a per-platform participantTitleField flag.
4. QMR keyed on `normalizeTitle(title)` directly (no raw-title + normalizedIndex two-step). Collisions past the 100-char slice used to resolve to different raw keys on each feed (subgraph by blockTimestamp vs scored-rows by requested_at + cursor) — same data, different open count, false divergence. Now the tie-break is order-independent by construction.

**pickSubgraphSenderTotal data-gap contract (comment 3735823017).** Empty string and any non-finite numeric now return `null` instead of `0`/`NaN`. NaN in the sum would flip a data-gap verdict (exit 4) to a divergence verdict (exit 3); an empty string would silently understate the subgraph total.

**totalLegacyRequests docstring third increment site (comment 3735823023).** Documents `autonolas-subgraph @ 30d9043e agent-mech.ts:265-273` (wired via `subgraph.gnosis.yaml:389`). Correct identity is `totalLegacyRequests = SUM_agentMech(1) + SUM_mkt(numRequests) + SUM_offchain(n)`. Confirmed both sides read the same superset: `agent_aggregates.n_mech_requests` reads `totalLegacyRequests` directly (`mech-analytics/etl/readers/marketplace_subgraph.py:298`).

**Deleted the "equivalent non-overlapping split" sentence (comment 3735823032)** — false under batching, differs by `SUM(numRequests - 1)`.

**Window anchoring (comment 3735823039).** Trailing branch now anchors start to end: `windowEnd = now - lag; windowStart = windowEnd - windowDays * 86400`, so the span is exactly `windowDays` (mirrors `_compute_window`). Previously the span was `windowDays - lag`.

**New test: order-invariant collision (comment 3735823044).** Two feeds with the same logical rows in different order where two titles collide past char 100 with different per-agent counts, asserts `computeSubgraphOpenCount(...).open === computeAnalyticsOpenCount(...).open`. This is the invariant check 1 actually depends on.

**decideVerdict extracted + tested (comment 3735823046).** Verdict decision is now a pure function over `checkResults` in `-lib.mjs`. New tests cover exit codes 0/2/3/4 explicitly and both truncation-downgrade directions (truncated+match → gap, truncated+mismatch → gap-not-divergence).

**Check 3 header note for the post-swap semantics (comment 3735823049).** Script header now explicitly states check 3 gates the post-swap number; the current live-site formula at `roi-distribution.ts:349` still does the double-counting sum, so a green check 3 gates the safety of the swap, not what users see today. That prod fix is out of scope for this parity script — it needs product sign-off and a separate PR.

**Partial-vacuous exit (review-level: 5 of 6 checks can be vacuous → exit 0).** `decideVerdict` now downgrades to exit 2 if any check KIND has no non-vacuous result on any platform. Regression test hand-builds the reviewer's scenario (check 3 vacuous on both platforms → old code exited 0, new code exits 2).

**CI wiring (review-level: tests never run in CI).** New `parity-script-tests` job in `.github/workflows/main.yml` runs `yarn verify-mech-analytics-parity:test` on every PR and is included in the `all-checks-passed` aggregate so branch protection covers it.

Test count: 60/60 pass (was 44).

## Test plan

- [x] `yarn lint` clean
- [x] `node --test scripts/verify-mech-analytics-parity.test.mjs` 60/60 pass
- [x] `node scripts/verify-mech-analytics-parity.mjs --help` exits 0
- [x] `yarn audit:prod` and `yarn lint:lockfile` clean
- [ ] After merge: cut `v0.0.2` release to trigger `valory/olas-website-verify:0.0.2` publish for infra to re-run against the failing production window

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Review-round-3 fixes (commit 08184719)

Addresses [Ojus's round-2 review](https://github.com/valory-xyz/olas-website/pull/552) — three Important, three Advisory.

**Important 1 — `decideVerdict([])` returned exit 0 PASS (comment 3736091219).** Round 2 added `checkResults.length > 0 &&` to the all-vacuous branch, making an empty list fall through to the final `PASS`. Not reachable through the current script (`PLATFORMS` is static, `record()` unconditional) but the function is exported + independently unit-tested — any future caller inherits "nothing checked means PASS". Added explicit empty branch returning `exit 2 VACUOUS`, added a docstring invariant, flipped the existing test.

**Important 2 — analytics zero-ingest was passing (comment 3736091223).** The vacuous guard tested raw row counts, but the new `ts < windowStartSec` gate and `request_id` dedup operate downstream of it. 500 rows all-unparseable-`requested_at` → `ingested: 0, open: 0` with `scoredRows.rows.length === 500` bypassed the guard and reported "PASS: open-market counts match exactly (0)". Extracted the whole check-1 decision into `resolveCheck1Status` in `-lib.mjs` with an `analytics-ingested-zero → gap` branch plus a `> 50%` ratio guard for partial degradation. New tests reproduce Ojus's exact 500-rows-all-skipped scenario and assert exit 4 GAP.

**Important 3 — QMR-key rationale comment was factually wrong (comment 3736091227).** Rationale #1 claimed consumer parity, but `qmr` in `roi-distribution.ts` is raw-keyed (`:502-509`), `:513-516` only builds `normalizedQmrMap` (not `qmr`), it runs BEFORE consumption (not after), and `Map.set` keeps LAST-arriving (not first). Deleted rationale #1. Kept rationale #2 (order-independence between the two verifier feeds) which fully justifies the choice. Added an explicit note that this is a deliberate deviation appropriate for a two-sided verifier, not a mirror of the consumer.

**Advisory 4 — compare `consumed` alongside `open` (comment 3736091237).** Settlement drains the whole agent count on any match, so `open=0` on both sides can hide an inside-market discrepancy (subgraph consumed=3 vs analytics consumed=4). `resolveCheck1Status` now compares consumed as a tie-breaker on top of open equality; new `consumed-mismatch` reason flags this without relying on check 2's row diff.

**Advisory 5 — invalid counts on different populations, and DRY the filter (comment 3736091239).** Two changes:
- Extracted the shared requester/title filter into `extractRowUsability`. `classifyAnalyticsRows` and `computeAnalyticsOpenCount` now go through the same helper, with an anti-drift test asserting they agree on the same input.
- Kept classify's pre-dedup semantics (which mirror the raw physical row shape the artifact reader wants to see) but relabelled the bucket keys with `raw_*` prefix (`raw_invalid`, `raw_pending_with_market`, etc.) so the artifact makes the split with `computeAnalyticsOpenCount`'s post-dedup `skippedInvalid` legible during triage. Added a regression-guard test that pins the pre-dedup semantics of `classifyAnalyticsRows`.

**Advisory 6 — extract the truncation downgrade (comment 3736091247).** The `check1Truncated ? 'gap' : 'pass'` and `check2Truncated ? 'gap' : 'divergence'` computations lived inline in `parity.mjs`. Extracted both into `resolveCheck1Status` and `resolveCheck2Status` in `-lib.mjs`. Ten new tests cover the downgrade in both directions on both checks, in isolation from the entry script's side effects. Also added a test for `skippedMissingKey` (previously returned + emitted but never asserted), and removed the unused `_participantTitleField` parameter from `computeSubgraphOpenCount`.

Test count: 80/80 pass (was 60).


---

## Review-round-3 fixes (commit 0c5c710b)

Addresses [Ojus's round-3 review](https://github.com/valory-xyz/olas-website/pull/552) — three code fixes, one docstring note, one artifact-schema breaking-change callout. Four advisory items in the review body are deferred out of scope (listed below).

**Comment 2 — REVERT the round-2 `consumed !== analyticsConsumed → divergence` tie-breaker.** Reviewer self-corrected in round 3: `computeAnalyticsOpenCount` drops `resolution_status = 'invalid'` rows (mirroring the post-swap consumer), while the subgraph feed has no invalid concept, so the two `consumed` counts differ structurally on perfectly healthy data whenever a window contains an invalid row — chronic false divergence. Removed the branch from `resolveCheck1Status`, dropped both consumed-mismatch tests (unit + E2E), updated the precedence docstring, and added a note explaining why we tried and backed out. `subgraphConsumed` and `analyticsConsumed` stay in the artifact record for informational use. The longer-term fix Ojus suggested (drop invalid `request_id`s from the subgraph feed too so both sides model the post-swap consumer) is deferred to a follow-up PR — bigger change touching how the subgraph feed is built and how check 2 works.

**Comment 1 — WIDEN the analytics attrition guard numerator to include `skippedMissingKey` and `skippedInvalid`.** Round 2's guard only covered `skippedOutOfWindow` — a `requester`/`question_title` schema drift lands entirely in `skippedMissingKey`, and predict-api resolution regressions land in `skippedInvalid`, both invisible today. Ojus's repro: 5000 raw rows where 4999 lose `requester`, one survivor matches a subgraph row → old guard reported PASS on a feed that lost 99.98% of its rows. Widened numerator escalates to `analytics-attrition-majority` gap. `skippedDuplicate` stays OUT of the numerator (docs/mech-analytics-migration.md:79-84 — re-serves are normal healthy traffic).

**Comment 4 — MIRROR the guards on the subgraph side.** `fetchMarketplaceRequests` already computes `skippedMissingKey` and `skippedAfterWindowEnd`; threaded them through to `resolveCheck1Status` alongside a new `subgraphRawRowCount = marketplace.rows.length + skippedMissingKey + skippedAfterWindowEnd`. Added `subgraph-ingested-zero` and `subgraph-attrition-majority` branches. Without these a subgraph schema regression (e.g. `sender.id` going missing on most `Request` entities) presents as a smaller `subgraphRowCount`, structurally indistinguishable from a genuinely quiet window. One test per new branch.

**Comment 5 — DOCSTRING note above `classifyAnalyticsRows`.** Explicit statement that check 1 and check 2 audit different row populations by design. `computeAnalyticsOpenCount` (check 1) dedups on `request_id` and drops invalid + out-of-window rows; `classifyAnalyticsRows.usable` (check 2 feed via `diffRowSets`) applies only the requester/title presence test — no dedup, no window gate, no invalid drop. Consequence: check 2 is a row-set diff, not a backstop for check 1's ingestion guards. This is why the widened attrition guards in `resolveCheck1Status` cover every non-duplicate bucket.

### Breaking changes to the artifact schema

Round 2 renamed the `analytics_row_buckets` keys with a `raw_` prefix. Any ops dashboard or triage tool parsing the previous keys will read `undefined` after this cutover. Renamed keys:

- `analytics_row_buckets.pending_with_market` → `raw_pending_with_market`
- `analytics_row_buckets.invalid` → `raw_invalid`
- `analytics_row_buckets.no_market_id` → `raw_no_market_id`
- `analytics_row_buckets.resolved` → `raw_resolved`
- `analytics_row_buckets.skipped_missing_key` → `raw_skipped_missing_key`

### Follow-ups deferred out of scope

Called out here so they don't get lost — none block the parity gate handing to production infra.

- **Drop invalid `request_id`s from the subgraph feed** (round-3 comment 2 longer-term fix). Would let a `consumed`-vs-`consumed` compare in `resolveCheck1Status` stay non-false-positive by making both sides model the post-swap consumer. Touches how the subgraph feed is built and how check 2 works — separate PR.
- **Comment 3 (truncation branch on consumed-mismatch)** — moot after the comment-2 revert; branch removed.
- **Comment 6 (true-negative consumed test)** — moot after the comment-2 revert; test removed.
- **Advisory: check-3 malformed `totalLegacyRequests` returning null silently.** Real but not blocking; a follow-up separates it into a `parse-error` bucket so the operator can tell "missing counter" from "malformed counter."
- **Advisory: skip threshold at exactly 0.5.** Deliberate and tested; no change.
- **Advisory: 9-field options object has no integration test.** Lower risk; both call sites correct by inspection.

Test count: 83/83 pass (was 80).

