### PR TITLE
fix: treat null subgraph globals as zero for chains without activity yet

### DIFF
--- a/common-util/api/agent-economies/mech-fees.ts
+++ b/common-util/api/agent-economies/mech-fees.ts
@@ -70,10 +70,12 @@ export const fetchMechFeeMetrics = async () => {
       if (checkSubgraphLag(latestBlock, res.value?._meta?.block?.number, chain)) {
         laggingSubgraphs.push(`mechFees:${chain}`);
       }
-      // Per-field, so a present entity missing a field is caught too, not just a null entity.
+      // The query didn't fail, so a null Global just means no paid mech activity on this
+      // chain yet — expected, chains are wired up ahead of launch.
       const source = `mechFees:${chain}`;
-      const feesIn = readGlobalField(res.value?.global, 'totalFeesInUSD', source, fetchErrors);
-      const feesOut = readGlobalField(res.value?.global, 'totalFeesOutUSD', source, fetchErrors);
+      const globalEntity = res.value?.global ?? { totalFeesInUSD: '0', totalFeesOutUSD: '0' };
+      const feesIn = readGlobalField(globalEntity, 'totalFeesInUSD', source, fetchErrors);
+      const feesOut = readGlobalField(globalEntity, 'totalFeesOutUSD', source, fetchErrors);
       if (feesIn === null || feesOut === null) return;
 
       inUsd += Number(feesIn);

--- a/common-util/api/agent-economies/mech.ts
+++ b/common-util/api/agent-economies/mech.ts
@@ -132,11 +132,12 @@ const fetchMechGlobals = async (): Promise<
           laggingSubgraphs.push(`marketplace:${chain}`);
         }
 
-        // Zero-filling here would also distort the derived `other` bucket
-        // (totalRequests - known), so one nulled chain would skew two published numbers.
+        // The query didn't fail, so a null Global just means no marketplace activity on
+        // this chain yet — expected, chains are wired up ahead of launch.
         const source = `marketplace:${chain}`;
-        const requests = readGlobalField(data.global, 'totalRequests', source, fetchErrors);
-        const deliveries = readGlobalField(data.global, 'totalDeliveries', source, fetchErrors);
+        const globalEntity = data.global ?? { totalRequests: '0', totalDeliveries: '0' };
+        const requests = readGlobalField(globalEntity, 'totalRequests', source, fetchErrors);
+        const deliveries = readGlobalField(globalEntity, 'totalDeliveries', source, fetchErrors);
         if (requests === null || deliveries === null) return;
 
         totalRequests += Number(requests);

--- a/common-util/api/main-metrics.ts
+++ b/common-util/api/main-metrics.ts
@@ -143,8 +143,10 @@ const fetchTotalOlasStaked = async (): Promise<MetricWithStatus<string | null>> 
         if (checkSubgraphLag(chainBlock, data._meta?.block?.number, chain)) {
           laggingSubgraphs.push(`staking:${chain}`);
         }
+        // The query didn't fail, so a null Global just means no staking activity on this
+        // chain yet — expected, chains are wired up ahead of launch.
         const currentOlasStaked = readGlobalField(
-          data.global,
+          data.global ?? { currentOlasStaked: '0' },
           'currentOlasStaked',
           `staking:${chain}`,
           fetchErrors
@@ -350,8 +352,10 @@ export const fetchAtaTransactions = async (): Promise<MetricWithStatus<string | 
         if (checkSubgraphLag(chainBlock, data._meta?.block?.number, chain)) {
           laggingSubgraphs.push(`ata:${chain}`);
         }
+        // The query didn't fail, so a null Global just means no ATA transactions on this
+        // chain yet — expected, chains are wired up ahead of launch.
         const totalAtaTransactions = readGlobalField(
-          data.global,
+          data.global ?? { totalAtaTransactions: '0' },
           'totalAtaTransactions',
           `ata:${chain}`,
           fetchErrors

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "@babel/plugin-transform-modules-systemjs": "7.29.4",
     "ws": "8.21.0",
     "undici": "6.27.0",
-    "nanoid": "3.3.17"
+    "nanoid": "3.3.18"
   },
   "babel": {
     "presets": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -4946,10 +4946,10 @@ mz@^2.7.0:
     object-assign "^4.0.1"
     thenify-all "^1.0.0"
 
-nanoid@3.3.17, nanoid@^3.3.16:
-  version "3.3.17"
-  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.17.tgz#f1c3aa253c52547956a52c50bff754316f61037a"
-  integrity sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==
+nanoid@3.3.18, nanoid@^3.3.16:
+  version "3.3.18"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.18.tgz#f66a2de1199ffde0fcf21c8a5f13106b1c081913"
+  integrity sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==
 
 napi-postinstall@^0.3.0:
   version "0.3.3"


### PR DESCRIPTION
## Problem

Several published metrics are permanently frozen, with raw error keys leaking into the `StaleIndicator` tooltips:

- Homepage: **OLAS staked** (`staking:ethereum/arbitrum/celo:missing:currentOlasStaked`) and **ATA transactions** (`ata:ethereum/arbitrum:missing:totalAtaTransactions`)
- Mech economy page: **requests/deliveries** (`marketplace:ethereum/arbitrum`) and **fees** (`mechFees:ethereum/celo/arbitrum`)

## Cause

These chains were wired into the client maps ahead of activity (intentionally, so metrics pick them up automatically once data appears). Subgraph mappings only create the `Global` singleton on the first indexed event, so those fully-synced-but-inactive subgraphs answer `global: null`. `readGlobalField` treated that as a hard fetch error, so `mergeWithFallback` froze the whole cross-chain aggregate — verified live: `marketplace-arbitrum` is synced to head with `globals: []`.

## Fix

At the four `global` read sites, default a null entity to a zero-valued object — a successful query with no `Global` entity means no activity on that chain yet, which is expected. `readGlobalField` itself is unchanged: a present entity missing a field (schema drift) still records an error, and `mergeWithFallback` semantics are untouched.

Once deployed, the next cron runs publish healthy values and the frozen metrics unfreeze on their own — no blob cleanup or schema bump needed.

## Verification

- `yarn metric-status:test` — all pass
- `yarn lint` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)