### PR TITLE
feat: add Polystrat to the Agent Economy Explorer

### DIFF
--- a/common-util/api/explorer.ts
+++ b/common-util/api/explorer.ts
@@ -25,6 +25,8 @@ import {
   getExplorerDailyProfitStatsQuery,
   getPolymarketBetsByTimeRangeQuery,
   mechAtaTransactionsQuery,
+  PolymarketBetRow,
+  PolymarketBetsResponse,
 } from 'common-util/graphql/queries';
 import { MetricWithStatus, WithMeta } from 'common-util/graphql/types';
 import { getMidnightUtcTimestampDaysAgo } from 'common-util/time';
@@ -155,8 +157,8 @@ const transformExplorerSeries = (
 
 // Page a registry subgraph's daily per-agent rows (the subgraph caps `first` at 1000,
 // so we skip-page until a short page). Chain-agnostic — `explorerOmenstratSeriesQuery`
-// is parameterised by `agentIds`, so the same query serves Omenstrat (Gnosis) and
-// Babydegen (Optimism + Mode). Returns the last page's `_meta` for lag/error detection.
+// is parameterised by `agentIds`, so the same query serves every registry-backed fleet
+// across chains. Returns the last page's `_meta` for lag/error detection.
 const pageRegistryRows = async (
   client: GraphQLClient,
   agentIds: number[],
@@ -473,7 +475,9 @@ export const fetchOmenstratExplorerSeries = async (
   return {
     value: {
       ...registry.value,
-      // Window-merge into prior history: a failed fetch ([]) leaves `previous` intact.
+      // Window-merge into prior history: fresh days overwrite stored ones. A fully-failed
+      // fetch ([]) leaves `previous` intact, but a partially-failed one can overwrite the
+      // oldest reached day with a partial sample (healed on the next full-window run).
       accuracy: mergeSeries(previous?.accuracy, accuracy ?? []),
       roi: mergeSeries(previous?.roi, roi ?? []),
     },
@@ -495,25 +499,24 @@ export type PolystratExplorerSeries = RegistrySeries & {
   accuracy: DaaSeriesPoint[];
 };
 
-type PolymarketBet = {
-  blockTimestamp: string;
-  outcomeIndex: number;
-  question: { resolution: { winningIndex: number } | null } | null;
-};
-
 /**
  * Daily Prediction Accuracy for Polystrat — same shape and cursor paging as
  * fetchOmenstratDailyAccuracy, but sourced from the predict-polymarket squid. The
  * squid has no server-side resolution filter, so unresolved bets come back and are
  * skipped in code — they get counted on a later run, once their market resolves and
- * the recent window is re-fetched.
+ * the recent window is re-fetched. Also returns the squid's indexed height (null if
+ * no page succeeded) so the caller can lag-check it — a stalled squid returns a
+ * successful-looking response with frozen data, so height is the only freshness signal.
  */
-const fetchPolystratDailyAccuracy = async (maxPages: number): Promise<DaaSeriesPoint[]> => {
-  const bets: PolymarketBet[] = [];
+const fetchPolystratDailyAccuracy = async (
+  maxPages: number
+): Promise<{ series: DaaSeriesPoint[]; squidHeight: number | null }> => {
+  const bets: PolymarketBetRow[] = [];
+  let squidHeight: number | null = null;
   const pages = Math.min(maxPages, ACCURACY_MAX_PAGES);
   let cursor = ACCURACY_CURSOR_START;
   for (let page = 0; page < pages; page += 1) {
-    let pageRows: PolymarketBet[];
+    let pageRows: PolymarketBetRow[];
     try {
       const data = (await requestWithRetry(() =>
         polymarketAgentsGraphClient.request(
@@ -523,8 +526,9 @@ const fetchPolystratDailyAccuracy = async (maxPages: number): Promise<DaaSeriesP
             blockTimestamp_lt: cursor,
           })
         )
-      )) as { bets: PolymarketBet[] };
+      )) as PolymarketBetsResponse;
       pageRows = data?.bets ?? [];
+      squidHeight = squidHeight ?? data?.squidStatus?.height ?? null;
     } catch (error) {
       console.error(
         `${POLYSTRAT_ACCURACY_SOURCE}: page ${page} failed after retries; keeping ${bets.length} bets`,
@@ -551,10 +555,11 @@ const fetchPolystratDailyAccuracy = async (maxPages: number): Promise<DaaSeriesP
     byDay.set(date, entry);
   });
 
-  return Array.from(byDay.entries())
+  const series = Array.from(byDay.entries())
     .filter(([, e]) => e.total >= POLYSTRAT_MIN_BETS_PER_DAY)
     .map(([date, e]) => ({ date, count: Math.round((e.correct / e.total) * 100) }))
     .sort((a, b) => a.date.localeCompare(b.date));
+  return { series, squidHeight };
 };
 
 /**
@@ -570,26 +575,43 @@ export const fetchPolystratExplorerSeries = async (
   const timestampLt = getMidnightUtcTimestampDaysAgo(0);
   const timestampGt = getMidnightUtcTimestampDaysAgo(SERIES_WINDOW_DAYS);
 
-  const [registry, accuracy] = await Promise.all([
+  // fetchPolystratDailyAccuracy swallows per-page errors internally (a total failure
+  // surfaces as squidHeight null), so no .catch is needed here.
+  const [registry, accuracy, chainBlock] = await Promise.all([
     fetchRegistrySeries('polygon', POLYSTRAT_AGENT_IDS, timestampGt, timestampLt),
-    fetchPolystratDailyAccuracy(accuracyPages).catch((error) => {
-      console.error(`Error fetching ${POLYSTRAT_ACCURACY_SOURCE}:`, error);
-      return null;
-    }),
+    fetchPolystratDailyAccuracy(accuracyPages),
+    getChainBlockNumber('polygon'),
   ]);
 
   if (!registry.value) {
     return { value: null, status: registry.status };
   }
 
+  // The squid doesn't error when unhealthy — it stops advancing — so a missing or
+  // lagging height marks the accuracy source stale (indicator only; registry data
+  // stays live, so nothing is frozen).
+  const accuracyLagging =
+    accuracy.squidHeight == null || checkSubgraphLag(chainBlock, accuracy.squidHeight, 'polygon');
+  const status = accuracyLagging
+    ? createStaleStatus({
+        indexingErrors: registry.status.indexingErrors,
+        fetchErrors: registry.status.fetchErrors,
+        laggingSubgraphs: [
+          ...(registry.status.laggingSubgraphs ?? []),
+          POLYSTRAT_ACCURACY_SOURCE,
+        ],
+      })
+    : registry.status;
+
   return {
     value: {
       ...registry.value,
-      // Window-merge into prior history: a failed fetch ([]) leaves `previous` intact.
-      accuracy: mergeSeries(polystratPrevious?.accuracy, accuracy ?? []),
+      // Window-merge into prior history: fresh days overwrite stored ones. A fully-failed
+      // fetch ([]) leaves `previous` intact, but a partially-failed one can overwrite the
+      // oldest reached day with a partial sample (healed on the next full-window run).
+      accuracy: mergeSeries(polystratPrevious?.accuracy, accuracy.series),
     },
-    // Registry drives staleness; accuracy is best-effort.
-    status: registry.status,
+    status,
   };
 };
 

--- a/common-util/api/explorer.ts
+++ b/common-util/api/explorer.ts
@@ -1,10 +1,14 @@
 import { GraphQLClient } from 'graphql-request';
 
-import { OMENSTRAT_AGENT_CLASSIFICATION } from 'common-util/constants';
+import {
+  OMENSTRAT_AGENT_CLASSIFICATION,
+  POLYSTRAT_AGENT_CLASSIFICATION,
+} from 'common-util/constants';
 import { DaaSeriesPoint } from 'common-util/explorer';
 import {
   BABYDEGEN_GRAPH_CLIENTS,
   MARKETPLACE_GRAPH_CLIENTS,
+  polymarketAgentsGraphClient,
   predictAgentsGraphClient,
   REGISTRY_GRAPH_CLIENTS,
 } from 'common-util/graphql/client';
@@ -19,6 +23,7 @@ import {
   explorerOmenstratSeriesQuery,
   getExplorerBetsQuery,
   getExplorerDailyProfitStatsQuery,
+  getPolymarketBetsByTimeRangeQuery,
   mechAtaTransactionsQuery,
 } from 'common-util/graphql/queries';
 import { MetricWithStatus, WithMeta } from 'common-util/graphql/types';
@@ -74,8 +79,8 @@ type DailyOmenstratResponse = WithMeta<{ dailyAgentPerformances: DailyOmenstratR
 // under agentId 12 contribute only ~45 active-day rows (mostly zero-activity test
 // services) — below the heatmap's quantile colour resolution, so they need no filtering.
 const OMENSTRAT_AGENT_IDS = [...OMENSTRAT_AGENT_CLASSIFICATION.valory_trader, 12];
-const CHAIN = 'gnosis';
-const SOURCE = 'registry:gnosis:explorer';
+// Polystrat (Polymarket) trader agents on Polygon — agentId 86 only.
+const POLYSTRAT_AGENT_IDS = POLYSTRAT_AGENT_CLASSIFICATION.valory_trader;
 
 // Wide enough to cover the trader's first active day (2023-07-12). The transform
 // trims leading zero-days, so an over-wide window just self-trims to inception.
@@ -199,23 +204,27 @@ const pageRegistryRows = async (
   return { rows, meta };
 };
 
-// Registry-derived DAA + transactions for Omenstrat (Gnosis).
+// Registry-derived DAA + transactions for one trader fleet (Omenstrat on Gnosis,
+// Polystrat on Polygon).
 const fetchRegistrySeries = async (
+  chain: 'gnosis' | 'polygon',
+  agentIds: number[],
   timestampGt: number,
   timestampLt: number
 ): Promise<MetricWithStatus<RegistrySeries | null>> => {
+  const source = `registry:${chain}:explorer`;
   try {
     const { rows, meta } = await pageRegistryRows(
-      REGISTRY_GRAPH_CLIENTS.gnosis,
-      OMENSTRAT_AGENT_IDS,
+      REGISTRY_GRAPH_CLIENTS[chain],
+      agentIds,
       timestampGt,
       timestampLt
     );
 
-    const chainBlock = await getChainBlockNumber(CHAIN);
-    const indexingErrors = meta?.hasIndexingErrors ? [SOURCE] : [];
-    const laggingSubgraphs = checkSubgraphLag(chainBlock, meta?.block?.number, CHAIN)
-      ? [SOURCE]
+    const chainBlock = await getChainBlockNumber(chain);
+    const indexingErrors = meta?.hasIndexingErrors ? [source] : [];
+    const laggingSubgraphs = checkSubgraphLag(chainBlock, meta?.block?.number, chain)
+      ? [source]
       : [];
 
     return {
@@ -223,10 +232,10 @@ const fetchRegistrySeries = async (
       status: createStaleStatus({ indexingErrors, fetchErrors: [], laggingSubgraphs }),
     };
   } catch (error) {
-    console.error(`Error fetching from ${SOURCE}:`, error);
+    console.error(`Error fetching from ${source}:`, error);
     // Return null/stale; saveSnapshot's mergeWithFallback keeps the last good
     // series in the blob, so a flaky-subgraph run never blanks the page.
-    return { value: null, status: getFetchErrorAndCreateStaleStatus(SOURCE) };
+    return { value: null, status: getFetchErrorAndCreateStaleStatus(source) };
   }
 };
 
@@ -394,6 +403,8 @@ const fetchOmenstratDailyRoi = async (windowDays: number): Promise<DaaSeriesPoin
 export type ExplorerFetchOptions = {
   /** Prior stored Omenstrat series to merge fresh windows into — preserves a deep backfill. */
   previous?: ExplorerSeries | null;
+  /** Prior stored Polystrat series to merge the fresh accuracy window into. */
+  polystratPrevious?: PolystratExplorerSeries | null;
   /** Accuracy bet pages to fetch (shallow cron default; large for a backfill). */
   accuracyPages?: number;
   /** ROI window in days (shallow cron default; large for a backfill). */
@@ -444,7 +455,7 @@ export const fetchOmenstratExplorerSeries = async (
   // Fetch in parallel; isolate each predict-agents query's failure so a flaky run
   // never blanks DAA/Transactions (a failed accuracy/roi window keeps prior history).
   const [registry, accuracy, roi] = await Promise.all([
-    fetchRegistrySeries(timestampGt, timestampLt),
+    fetchRegistrySeries('gnosis', OMENSTRAT_AGENT_IDS, timestampGt, timestampLt),
     fetchOmenstratDailyAccuracy(accuracyPages).catch((error) => {
       console.error(`Error fetching ${ACCURACY_SOURCE}:`, error);
       return null;
@@ -467,6 +478,117 @@ export const fetchOmenstratExplorerSeries = async (
       roi: mergeSeries(previous?.roi, roi ?? []),
     },
     // Registry drives staleness; accuracy/roi are best-effort.
+    status: registry.status,
+  };
+};
+
+// ── Polystrat (Polygon registry + predict-polymarket squid) ──────────────────
+const POLYSTRAT_ACCURACY_SOURCE = 'predict:polygon:explorer-accuracy';
+// Lower than Omenstrat's MIN_BETS_PER_DAY: Polystrat places ~2-15 bets/day (vs hundreds
+// on Omen), so 10 would blank most days. 3 still drops the only-extremes days (1-2 bets
+// can only show 0/50/100%).
+const POLYSTRAT_MIN_BETS_PER_DAY = 3;
+
+/** Polystrat daily series — registry DAA/transactions + squid-derived accuracy. */
+export type PolystratExplorerSeries = RegistrySeries & {
+  /** Prediction Accuracy — daily win-rate (%) of resolved bets; days below POLYSTRAT_MIN_BETS_PER_DAY omitted. */
+  accuracy: DaaSeriesPoint[];
+};
+
+type PolymarketBet = {
+  blockTimestamp: string;
+  outcomeIndex: number;
+  question: { resolution: { winningIndex: number } | null } | null;
+};
+
+/**
+ * Daily Prediction Accuracy for Polystrat — same shape and cursor paging as
+ * fetchOmenstratDailyAccuracy, but sourced from the predict-polymarket squid. The
+ * squid has no server-side resolution filter, so unresolved bets come back and are
+ * skipped in code — they get counted on a later run, once their market resolves and
+ * the recent window is re-fetched.
+ */
+const fetchPolystratDailyAccuracy = async (maxPages: number): Promise<DaaSeriesPoint[]> => {
+  const bets: PolymarketBet[] = [];
+  const pages = Math.min(maxPages, ACCURACY_MAX_PAGES);
+  let cursor = ACCURACY_CURSOR_START;
+  for (let page = 0; page < pages; page += 1) {
+    let pageRows: PolymarketBet[];
+    try {
+      const data = (await requestWithRetry(() =>
+        polymarketAgentsGraphClient.request(
+          getPolymarketBetsByTimeRangeQuery({
+            first: ACCURACY_BET_PAGE_SIZE,
+            blockTimestamp_gte: 0,
+            blockTimestamp_lt: cursor,
+          })
+        )
+      )) as { bets: PolymarketBet[] };
+      pageRows = data?.bets ?? [];
+    } catch (error) {
+      console.error(
+        `${POLYSTRAT_ACCURACY_SOURCE}: page ${page} failed after retries; keeping ${bets.length} bets`,
+        error
+      );
+      break;
+    }
+    if (pageRows.length === 0) break;
+    bets.push(...pageRows);
+    // Next page: bets strictly older than this page's last (oldest) bet — same
+    // page-boundary tradeoff as the Omenstrat accuracy cursor above.
+    cursor = Number(pageRows[pageRows.length - 1].blockTimestamp);
+    if (pageRows.length < ACCURACY_BET_PAGE_SIZE) break;
+  }
+
+  const byDay = new Map<string, { correct: number; total: number }>();
+  bets.forEach((bet) => {
+    const winningIndex = bet.question?.resolution?.winningIndex;
+    if (winningIndex == null || winningIndex < 0) return;
+    const date = new Date(Number(bet.blockTimestamp) * 1000).toISOString().slice(0, 10);
+    const entry = byDay.get(date) ?? { correct: 0, total: 0 };
+    entry.total += 1;
+    if (Number(bet.outcomeIndex) === Number(winningIndex)) entry.correct += 1;
+    byDay.set(date, entry);
+  });
+
+  return Array.from(byDay.entries())
+    .filter(([, e]) => e.total >= POLYSTRAT_MIN_BETS_PER_DAY)
+    .map(([date, e]) => ({ date, count: Math.round((e.correct / e.total) * 100) }))
+    .sort((a, b) => a.date.localeCompare(b.date));
+};
+
+/**
+ * Fetch Polystrat's daily series for the Explorer heatmap: DAA + transactions from
+ * the Polygon registry subgraph (full, cheap), and Prediction Accuracy from the
+ * predict-polymarket squid (a recent window, merged into the prior stored series).
+ */
+export const fetchPolystratExplorerSeries = async (
+  options: ExplorerFetchOptions = {}
+): Promise<MetricWithStatus<PolystratExplorerSeries | null>> => {
+  const { polystratPrevious = null, accuracyPages = ACCURACY_DEFAULT_PAGES } = options;
+
+  const timestampLt = getMidnightUtcTimestampDaysAgo(0);
+  const timestampGt = getMidnightUtcTimestampDaysAgo(SERIES_WINDOW_DAYS);
+
+  const [registry, accuracy] = await Promise.all([
+    fetchRegistrySeries('polygon', POLYSTRAT_AGENT_IDS, timestampGt, timestampLt),
+    fetchPolystratDailyAccuracy(accuracyPages).catch((error) => {
+      console.error(`Error fetching ${POLYSTRAT_ACCURACY_SOURCE}:`, error);
+      return null;
+    }),
+  ]);
+
+  if (!registry.value) {
+    return { value: null, status: registry.status };
+  }
+
+  return {
+    value: {
+      ...registry.value,
+      // Window-merge into prior history: a failed fetch ([]) leaves `previous` intact.
+      accuracy: mergeSeries(polystratPrevious?.accuracy, accuracy ?? []),
+    },
+    // Registry drives staleness; accuracy is best-effort.
     status: registry.status,
   };
 };
@@ -778,6 +900,8 @@ export const fetchMechExplorerSeries = async (
 /** Snapshot persisted to Vercel Blob under the `explorer` category. */
 export type ExplorerMetricsData = {
   omenstrat: MetricWithStatus<ExplorerSeries | null>;
+  /** Polystrat (Polygon, agentId 86) — registry DAA/transactions + squid accuracy. */
+  polystrat: MetricWithStatus<PolystratExplorerSeries | null>;
   /** Optimus (Optimism) — its own series so it can self-heal independently of Modius. */
   babydegenOptimus: MetricWithStatus<BabydegenAgentSeries | null>;
   /** Modius (Mode, wound down) — separate series for independent fallback + colour. */
@@ -802,9 +926,10 @@ export const fetchAllExplorerMetrics = async (
   options: ExplorerFetchOptions = {}
 ): Promise<ExplorerMetricsSnapshot | null> => {
   try {
-    const [omenstrat, babydegenOptimus, babydegenModius, babydegenBasius, mech] = await Promise.all(
-      [
+    const [omenstrat, polystrat, babydegenOptimus, babydegenModius, babydegenBasius, mech] =
+      await Promise.all([
         fetchOmenstratExplorerSeries(options),
+        fetchPolystratExplorerSeries(options),
         fetchBabydegenAgentSeries('optimism'),
         fetchBabydegenAgentSeries('mode'),
         fetchBabydegenAgentSeries('base'),
@@ -813,10 +938,9 @@ export const fetchAllExplorerMetrics = async (
           ataFromDays: options.ataFromDays,
           ataToDays: options.ataToDays,
         }),
-      ]
-    );
+      ]);
     return {
-      data: { omenstrat, babydegenOptimus, babydegenModius, babydegenBasius, mech },
+      data: { omenstrat, polystrat, babydegenOptimus, babydegenModius, babydegenBasius, mech },
       timestamp: Date.now(),
     };
   } catch (error) {

--- a/common-util/api/predict/accuracy.ts
+++ b/common-util/api/predict/accuracy.ts
@@ -7,6 +7,7 @@ import {
 import {
   getOmenBetsByTimeRangeQuery,
   getPolymarketBetsByTimeRangeQuery,
+  PolymarketBetsResponse,
 } from 'common-util/graphql/queries';
 import { MetricWithStatus, WithMeta } from 'common-util/graphql/types';
 import { getSnapshot, saveSnapshot } from 'common-util/snapshot-storage';
@@ -31,7 +32,8 @@ const BACKFILL_CHUNK_DAYS = 30;
 // roi-distribution.ts (and OMEN_GENESIS_DAY in omenstrat-brier.ts). Backfill walks
 // down to here, no further.
 const OMEN_GENESIS_DAY = 1763769600;
-const POLYMARKET_GENESIS_DAY = 1768867200;
+// 2026-01-16 — first (internal-testing) on-chain activity; public launch was 2026-02-10.
+const POLYMARKET_GENESIS_DAY = 1768521600;
 
 // JSON-safe per-day bucket: settled bets and how many were correct.
 type AccuracyBucket = { won: number; total: number };
@@ -120,14 +122,6 @@ const fetchOmenDayBuckets: FetchDayBuckets = async (
   return perDay;
 };
 
-type PolyBetRow = {
-  blockTimestamp: string;
-  outcomeIndex: number;
-  question: { resolution: { winningIndex: number } | null } | null;
-};
-// The squid handles errors differently (it stops advancing), so the lag check covers them.
-type PolyBetsResponse = { bets: PolyBetRow[]; squidStatus?: { height: number } };
-
 const fetchPolyDayBuckets: FetchDayBuckets = async (
   startDay,
   endDay,
@@ -148,7 +142,7 @@ const fetchPolyDayBuckets: FetchDayBuckets = async (
         blockTimestamp_gte: startDay,
         blockTimestamp_lt: cursor,
       })
-    )) as PolyBetsResponse;
+    )) as PolymarketBetsResponse;
 
     if (!metaChecked) {
       const height = response?.squidStatus?.height;

--- a/common-util/api/predict/roi-distribution.ts
+++ b/common-util/api/predict/roi-distribution.ts
@@ -36,7 +36,8 @@ const MIN_TRADES_FOR_ROI_DISPLAY = 10;
 
 // Genesis timestamps (UTC midnight) for each agent type
 const OMEN_GENESIS_TS = 1763769600;
-const POLYMARKET_GENESIS_TS = 1768867200;
+// 2026-01-16 — first (internal-testing) on-chain activity; public launch was 2026-02-10.
+const POLYMARKET_GENESIS_TS = 1768521600;
 // Earliest block timestamp to consider when fetching mech requests
 const GNOSIS_MECH_REQUESTS_GENESIS_TS = 1763078400;
 const POLYGON_MECH_REQUESTS_GENESIS_TS = 1763078400;

--- a/common-util/api/predict/staking-rewards.ts
+++ b/common-util/api/predict/staking-rewards.ts
@@ -18,7 +18,8 @@ const BACKFILL_CHUNK_DAYS = 30;
 
 // UTC-midnight genesis days, mirroring roi-distribution.ts / omenstrat-brier.ts.
 const OMEN_GENESIS_DAY = 1763769600;
-const POLYMARKET_GENESIS_DAY = 1768867200;
+// 2026-01-16 — first (internal-testing) on-chain activity; public launch was 2026-02-10.
+const POLYMARKET_GENESIS_DAY = 1768521600;
 
 // dayTimestamp (UTC midnight, string) -> summed rewardAmount that day (1e18 OLAS,
 // stored as a decimal string so the BigInt survives JSON).

--- a/common-util/graphql/queries.ts
+++ b/common-util/graphql/queries.ts
@@ -1093,6 +1093,17 @@ export const getPolymarketBetsByTimeRangeQuery = ({
   }
 `;
 
+/** One row of getPolymarketBetsByTimeRangeQuery — shared by every consumer so a squid
+ * schema change forces all of them to be touched together. */
+export type PolymarketBetRow = {
+  blockTimestamp: string;
+  outcomeIndex: number;
+  question: { resolution: { winningIndex: number } | null } | null;
+};
+// The squid handles errors differently from a subgraph (it stops advancing instead of
+// erroring), so freshness comes from squidStatus.height via a lag check.
+export type PolymarketBetsResponse = { bets: PolymarketBetRow[]; squidStatus?: { height: number } };
+
 export const getPolymarketBetsWithBettorQuery = ({
   first,
   pages,

--- a/components/ExplorerPage/DaaCalendarHeatmap.tsx
+++ b/components/ExplorerPage/DaaCalendarHeatmap.tsx
@@ -113,13 +113,30 @@ export const HEATMAP_LEVEL_COLORS_TEAL = [
   '#0a4a40', // 8 — deepest (dark teal)
 ];
 
-export type HeatmapRamp = 'purple' | 'red' | 'lime' | 'teal' | 'blue';
+// Polystrat indigo ramp — anchored on the Polystrat icon's deep navy. The navy is too
+// dark for straight white → brand tints (the light steps would read as the empty grey),
+// so like the teal ramp, levels 1–6 interpolate white → mid indigo and 7–8 deepen past
+// it into the icon navy #14127a.
+export const HEATMAP_LEVEL_COLORS_INDIGO = [
+  '#dfe5ee', // 0 — empty
+  '#e0e4fb', // 1
+  '#c2c9f6', // 2
+  '#a3aeef', // 3
+  '#8492e6', // 4
+  '#6577da', // 5
+  '#465bcb', // 6 — mid indigo
+  '#2b3aa6', // 7 — deeper
+  '#14127a', // 8 — deepest (Polystrat icon navy)
+];
+
+export type HeatmapRamp = 'purple' | 'red' | 'lime' | 'teal' | 'blue' | 'indigo';
 export const HEATMAP_RAMPS: Record<HeatmapRamp, string[]> = {
   purple: HEATMAP_LEVEL_COLORS,
   red: HEATMAP_LEVEL_COLORS_RED,
   lime: HEATMAP_LEVEL_COLORS_LIME,
   teal: HEATMAP_LEVEL_COLORS_TEAL,
   blue: HEATMAP_LEVEL_COLORS_BLUE,
+  indigo: HEATMAP_LEVEL_COLORS_INDIGO,
 };
 
 // row (0=Sun … 6=Sat) → label. All seven.

--- a/components/ExplorerPage/MetricSelector.tsx
+++ b/components/ExplorerPage/MetricSelector.tsx
@@ -65,7 +65,7 @@ export const MetricSelector = ({
             <span className="flex items-center gap-1 text-[14px] leading-5 tracking-[0.14px] text-[#78879c]">
               {metric.label}
               {metric.tooltip && (
-                <Popover side="top" contentClassName="whitespace-nowrap">
+                <Popover side="top" contentClassName="max-w-[320px]">
                   {metric.tooltip}
                 </Popover>
               )}

--- a/components/ExplorerPage/index.tsx
+++ b/components/ExplorerPage/index.tsx
@@ -27,8 +27,9 @@ type AgentData = {
 
 /**
  * All economies the Explorer can show: economy id → agent id → that agent's data.
- * Single-agent economies (Predict → Omenstrat) have one entry; multi-agent ones
- * (Babydegen → Optimus + Modius) have several, surfaced via a sub-toggle.
+ * Single-agent economies (Mech) have one entry; multi-agent ones (Predict →
+ * Omenstrat + Polystrat, Babydegen → Optimus + Basius + Modius) have several,
+ * surfaced via a sub-toggle.
  */
 export type ExplorerEconomies = Record<string, Record<string, AgentData>>;
 
@@ -111,6 +112,8 @@ const METRIC_CONFIG: Record<string, MetricDef> = {
     // Unweighted mean of the daily win-rates we have data for.
     headline: (s) =>
       s.length ? `${Math.round(s.reduce((sum, p) => sum + p.count, 0) / s.length)}%` : '--',
+    tooltip: () =>
+      'Average daily win rate, based on bets placed each day. Days with too few resolved bets are excluded.',
     selectable: (s) => s.length > 0,
   },
   aum: {
@@ -136,8 +139,9 @@ type EconomyMeta = { name: string; metrics: string[]; agents: AgentMeta[] };
 
 // Per-economy ordered metric tiles + its agents (label/icon + heatmap colour ramp).
 // The active metric resets to the first key on an economy switch; the active agent
-// resets to the economy's first agent. Babydegen colour-codes Optimus (red) vs Modius
-// (lime); Predict (purple) and Mech (teal) are single-agent.
+// resets to the economy's first agent. Predict colour-codes Omenstrat (purple) vs
+// Polystrat (indigo); Babydegen Optimus (red) / Basius (blue) / Modius (lime); Mech
+// (teal) is single-agent.
 const ECONOMY_META: Record<string, EconomyMeta> = {
   predict: {
     name: 'Predict',
@@ -148,6 +152,13 @@ const ECONOMY_META: Record<string, EconomyMeta> = {
         label: 'Omenstrat',
         icon: '/images/predict-page/omenstrat-icon.png',
         ramp: 'purple',
+      },
+      {
+        key: 'polystrat',
+        label: 'Polystrat',
+        icon: '/images/predict-page/polystrat-icon.png',
+        ramp: 'indigo',
+        marker: { date: '2026-02-10', label: 'Polystrat launched publicly' },
       },
     ],
   },

--- a/components/ExplorerPage/index.tsx
+++ b/components/ExplorerPage/index.tsx
@@ -69,7 +69,9 @@ type MetricDef = {
 
 // Metric → the noun used in the header/tooltip, how the tooltip value reads, the heatmap
 // colour scale, and how the headline tile value is computed from its daily series.
-const METRIC_CONFIG: Record<string, MetricDef> = {
+// An empty series renders '--' + a dimmed tile, never a real-looking 0 (a new agent's
+// pre-first-cron state, or a failed fetch with nothing to fall back on).
+const METRIC_CONFIG: Record<'daa' | 'transactions' | 'ata' | 'accuracy' | 'aum', MetricDef> = {
   daa: {
     label: 'Daily Active Agents',
     // Tile shows the latest day's value, so label it "Latest DAAs"; the heatmap header
@@ -79,21 +81,21 @@ const METRIC_CONFIG: Record<string, MetricDef> = {
     kind: 'count',
     scale: 'sequential',
     // Latest day's active-agent count.
-    headline: (s) => formatCount(s.length ? s[s.length - 1].count : 0),
+    headline: (s) => (s.length ? formatCount(s[s.length - 1].count) : '--'),
     // Spell out the day the headline value is for, e.g. "Daily Active Agents of June 29, 2026".
     tooltip: (s) =>
       s.length
         ? `Daily Active Agents as of ${dayjs(s[s.length - 1].date).format('MMMM D, YYYY')}`
         : undefined,
-    selectable: () => true,
+    selectable: (s) => s.length > 0,
   },
   transactions: {
     label: 'Total Transactions',
     unit: 'transactions',
     kind: 'count',
     scale: 'sequential',
-    headline: (s) => formatCount(s.reduce((sum, p) => sum + p.count, 0)),
-    selectable: () => true,
+    headline: (s) => (s.length ? formatCount(s.reduce((sum, p) => sum + p.count, 0)) : '--'),
+    selectable: (s) => s.length > 0,
   },
   ata: {
     label: 'Agent-to-Agent Transactions',
@@ -113,7 +115,7 @@ const METRIC_CONFIG: Record<string, MetricDef> = {
     headline: (s) =>
       s.length ? `${Math.round(s.reduce((sum, p) => sum + p.count, 0) / s.length)}%` : '--',
     tooltip: () =>
-      'Average daily win rate, based on bets placed each day. Days with too few resolved bets are excluded.',
+      'Average of each day’s win rate, with every day weighted equally regardless of bet count. Days with too few resolved bets are excluded.',
     selectable: (s) => s.length > 0,
   },
   aum: {
@@ -135,7 +137,10 @@ type AgentMeta = {
   /** A notable day to ring + annotate on the heatmap (e.g. a retirement or launch date). */
   marker?: { date: string; label: string };
 };
-type EconomyMeta = { name: string; metrics: string[]; agents: AgentMeta[] };
+// Keys constrained to METRIC_CONFIG's — a typo'd metric would otherwise compile and
+// crash the page at config.tileLabel.
+type MetricKey = keyof typeof METRIC_CONFIG;
+type EconomyMeta = { name: string; metrics: MetricKey[]; agents: AgentMeta[] };
 
 // Per-economy ordered metric tiles + its agents (label/icon + heatmap colour ramp).
 // The active metric resets to the first key on an economy switch; the active agent

--- a/pages/agent-economies/explorer.tsx
+++ b/pages/agent-economies/explorer.tsx
@@ -30,6 +30,10 @@ export const getStaticProps = async () => {
         series: data?.omenstrat?.value ?? { daa: [], transactions: [], accuracy: [], roi: [] },
         status: data?.omenstrat?.status ?? null,
       },
+      polystrat: {
+        series: data?.polystrat?.value ?? { daa: [], transactions: [], accuracy: [] },
+        status: data?.polystrat?.status ?? null,
+      },
     },
     babydegen: {
       optimus: {

--- a/pages/api/refresh-metrics/explorer.ts
+++ b/pages/api/refresh-metrics/explorer.ts
@@ -22,6 +22,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     const previousSnapshot = await getSnapshot({ category: 'explorer' });
     const previousData = previousSnapshot?.data as ExplorerMetricsData | undefined;
     const previous = previousData?.omenstrat?.value ?? null;
+    const polystratPrevious = previousData?.polystrat?.value ?? null;
     const mechPrevious = previousData?.mech?.value ?? null;
 
     // Mech ATA has no daily aggregate, so it's event-counted per day (Method A): the cron
@@ -30,6 +31,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     //   /api/refresh-metrics/explorer?ataFromDays=400&ataToDays=250  (then 250→100, 100→0)
     const metrics = await fetchAllExplorerMetrics({
       previous,
+      polystratPrevious,
       accuracyPages: toInt(req.query.accuracyPages),
       roiDays: toInt(req.query.roiDays),
       mechPrevious,
@@ -44,6 +46,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     const url = await saveSnapshot({ category: 'explorer', data: metrics });
 
     const value = metrics.data.omenstrat.value;
+    const polystrat = metrics.data.polystrat.value;
     const optimus = metrics.data.babydegenOptimus.value;
     const modius = metrics.data.babydegenModius.value;
     const basius = metrics.data.babydegenBasius.value;
@@ -63,6 +66,11 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
         transactions: value.transactions.length,
         accuracy: value.accuracy.length,
         roi: value.roi.length,
+      },
+      polystratCounts: polystrat && {
+        daa: polystrat.daa.length,
+        transactions: polystrat.transactions.length,
+        accuracy: polystrat.accuracy.length,
       },
       babydegenCounts: {
         optimus: seriesCounts(optimus),

--- a/pages/api/refresh-metrics/explorer.ts
+++ b/pages/api/refresh-metrics/explorer.ts
@@ -19,6 +19,8 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     // Keep params under what fits the 300s function limit (≈ accuracyPages 400 / roiDays
     // 365) — if the invocation overruns it's killed before saveSnapshot and nothing is
     // written. Go deeper by re-running with larger windows (each run merges into prior).
+    // Note accuracyPages caps BOTH accuracy loops (Omenstrat + Polystrat); each stops at
+    // its first short page, so the budget above still holds at current bet volumes.
     const previousSnapshot = await getSnapshot({ category: 'explorer' });
     const previousData = previousSnapshot?.data as ExplorerMetricsData | undefined;
     const previous = previousData?.omenstrat?.value ?? null;


### PR DESCRIPTION
Closes BDMARK-2261.

Adds Polystrat as a second agent under the Predict economy in the Agent Economy Explorer, using the SQD squid (introduced in #558) as the accuracy data source.

## What's included

- **Agent sub-toggle for Predict** — same switcher Babydegen uses; Omenstrat (purple) / Polystrat (indigo). Deep-link `?economy=predict` still lands on Omenstrat first.
- **Data** (`common-util/api/explorer.ts`):
  - DAA + transactions from the Polygon registry subgraph, agentId 86 (`POLYSTRAT_AGENT_CLASSIFICATION.valory_trader`). `fetchRegistrySeries` is parameterized by chain + agent IDs so Omenstrat/Polystrat share the paging/lag/transform code.
  - Daily prediction accuracy from the predict-polymarket squid (`getPolymarketBetsByTimeRangeQuery`, cursor-paged newest-backward, merged into the stored series like Omenstrat's). Unresolved bets are skipped and picked up once resolved.
  - Per-source sparsity threshold: Polystrat omits days with <3 resolved bets (vs Omenstrat's 10) — Polystrat places ~2–15 bets/day, so 10 would blank most days.
  - New `polystrat` key in the explorer snapshot; cron threads `polystratPrevious` and reports `polystratCounts`.
- **Indigo heatmap ramp** anchored on the Polystrat icon's deep navy (`#14127a`); light levels route through mid indigo so they stay distinguishable from the empty-cell grey (same shape as the teal ramp). Clearly darker than Basius's Base blue.
- **Launch marker** ringed on 2026-02-10 ("Polystrat launched publicly"), Basius-style.
- **Accuracy tile tooltip** ("Average daily win rate, based on bets placed each day…") via the same info popover the DAA tile uses; the tile popover now wraps long text (`max-w-[320px]` instead of `whitespace-nowrap`).

## Rollout

Nothing manual needed: the daily 06:00 UTC explorer cron populates the new snapshot key, and Polystrat's full history (~3–4k bets since late January) fits inside the default 12-page accuracy window, so the first run backfills to genesis. Hit `/api/refresh-metrics/explorer` once manually to populate sooner. Page is ISR with 1h revalidate.

## Testing

- `tsc --noEmit` + ESLint clean.
- Verified locally against the dev-scoped snapshot: sub-toggle, indigo ramp + legend, Feb 10 marker, and all three tiles populated; bet-volume distribution checked directly against the squid.

## Screenshots

<img width="1512" height="682" alt="image" src="https://github.com/user-attachments/assets/df4fada2-971b-4481-bd31-f230436b4962" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)