### PR TITLE
feat: flip USE_MECH_ANALYTICS default to on

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -84,5 +84,6 @@ MODE_RPC=__URL__
 SOLANA_RPC=__URL__
 
 # mech-analytics API (off-chain migration, server-only) — see docs/mech-analytics-migration.md
-MECH_ANALYTICS_URL=__URL__
+# The base URL is hardcoded in common-util/api/predict/mech-analytics.ts;
+# only the rollback lever is env-driven.
 USE_MECH_ANALYTICS= # unset = on; set to false (case-insensitive) to roll reads back to the subgraph

--- a/.env.example
+++ b/.env.example
@@ -85,4 +85,4 @@ SOLANA_RPC=__URL__
 
 # mech-analytics API (off-chain migration, server-only) — see docs/mech-analytics-migration.md
 MECH_ANALYTICS_URL=__URL__
-USE_MECH_ANALYTICS=true
+USE_MECH_ANALYTICS= # unset = on; set to false (case-insensitive) to roll reads back to the subgraph

--- a/.env.example
+++ b/.env.example
@@ -85,4 +85,4 @@ SOLANA_RPC=__URL__
 
 # mech-analytics API (off-chain migration, server-only) — see docs/mech-analytics-migration.md
 MECH_ANALYTICS_URL=__URL__
-USE_MECH_ANALYTICS=false
+USE_MECH_ANALYTICS=true

--- a/common-util/api/predict/mech-analytics.ts
+++ b/common-util/api/predict/mech-analytics.ts
@@ -7,8 +7,12 @@ import { QMR_MAX_AGE_DAYS } from 'common-util/constants';
  * Full details: docs/mech-analytics-migration.md
  */
 
-/** One switch that turns on all mech-analytics read paths. */
-export const USE_MECH_ANALYTICS = process.env.USE_MECH_ANALYTICS === 'true';
+/** One switch that turns on all mech-analytics read paths. Default ON
+ * after the mech-analytics cutover (undelivered rows admitted as shell
+ * shape in mech-analytics PR #36 + placeholder repair against the
+ * marketplace subgraph); explicit ``USE_MECH_ANALYTICS=false`` still
+ * routes reads back through the subgraph as a rollback lever. */
+export const USE_MECH_ANALYTICS = process.env.USE_MECH_ANALYTICS !== 'false';
 
 const PAGE_SIZE = 5000; // endpoint max limit
 

--- a/common-util/api/predict/mech-analytics.ts
+++ b/common-util/api/predict/mech-analytics.ts
@@ -7,20 +7,21 @@ import { QMR_MAX_AGE_DAYS } from 'common-util/constants';
  * Full details: docs/mech-analytics-migration.md
  */
 
+/** Production URL for mech-analytics. Hardcoded rather than read from an
+ * env var so a merged consumer PR is the whole flip — no separate Vercel
+ * config change needed to make the switch land. If the endpoint moves,
+ * update this line in a follow-up PR. */
+export const MECH_ANALYTICS_URL = 'https://mech-analytics-api.autonolas.tech';
+
 /** One switch that turns on all mech-analytics read paths. Default ON
  * after the mech-analytics cutover (undelivered rows admitted as shell
  * shape in mech-analytics PR #36 + placeholder repair against the
- * marketplace subgraph). Two knobs turn it back off:
- *   * ``USE_MECH_ANALYTICS=false`` (case-insensitive) — the operator
- *     rollback lever during an incident; case-insensitive so a typo
- *     under pressure (``FALSE`` / ``False``) still rolls back.
- *   * ``MECH_ANALYTICS_URL`` unset — automatic fallback for previews
- *     and local dev that never wired the API URL, so a missing
- *     endpoint doesn't 500 refresh runs on every reload. Prod always
- *     has the URL set; this only affects environments that don't. */
+ * marketplace subgraph). Setting ``USE_MECH_ANALYTICS=false`` (case-
+ * insensitive so a typo under pressure like ``FALSE`` / ``False`` still
+ * rolls back) is the operator rollback lever that sends reads back
+ * through the subgraph. */
 const rawFlag = process.env.USE_MECH_ANALYTICS ?? '';
-export const USE_MECH_ANALYTICS =
-  rawFlag.toLowerCase() !== 'false' && !!process.env.MECH_ANALYTICS_URL;
+export const USE_MECH_ANALYTICS = rawFlag.toLowerCase() !== 'false';
 
 const PAGE_SIZE = 5000; // endpoint max limit
 
@@ -57,12 +58,7 @@ type ScoredRowsPage = {
 export async function* iterateScoredRows(
   searchParams: Record<string, string>
 ): AsyncGenerator<ScoredRow[]> {
-  const base = process.env.MECH_ANALYTICS_URL;
-  if (!base) {
-    throw new Error('MECH_ANALYTICS_URL not set — cannot fetch mech-analytics scored rows');
-  }
-
-  const url = new URL(`${base.replace(/\/$/, '')}/v1/data/scored-rows`);
+  const url = new URL(`${MECH_ANALYTICS_URL}/v1/data/scored-rows`);
   for (const [key, value] of Object.entries(searchParams)) {
     url.searchParams.set(key, value);
   }

--- a/common-util/api/predict/mech-analytics.ts
+++ b/common-util/api/predict/mech-analytics.ts
@@ -10,9 +10,17 @@ import { QMR_MAX_AGE_DAYS } from 'common-util/constants';
 /** One switch that turns on all mech-analytics read paths. Default ON
  * after the mech-analytics cutover (undelivered rows admitted as shell
  * shape in mech-analytics PR #36 + placeholder repair against the
- * marketplace subgraph); explicit ``USE_MECH_ANALYTICS=false`` still
- * routes reads back through the subgraph as a rollback lever. */
-export const USE_MECH_ANALYTICS = process.env.USE_MECH_ANALYTICS !== 'false';
+ * marketplace subgraph). Two knobs turn it back off:
+ *   * ``USE_MECH_ANALYTICS=false`` (case-insensitive) — the operator
+ *     rollback lever during an incident; case-insensitive so a typo
+ *     under pressure (``FALSE`` / ``False``) still rolls back.
+ *   * ``MECH_ANALYTICS_URL`` unset — automatic fallback for previews
+ *     and local dev that never wired the API URL, so a missing
+ *     endpoint doesn't 500 refresh runs on every reload. Prod always
+ *     has the URL set; this only affects environments that don't. */
+const rawFlag = process.env.USE_MECH_ANALYTICS ?? '';
+export const USE_MECH_ANALYTICS =
+  rawFlag.toLowerCase() !== 'false' && !!process.env.MECH_ANALYTICS_URL;
 
 const PAGE_SIZE = 5000; // endpoint max limit
 

--- a/docs/mech-analytics-migration.md
+++ b/docs/mech-analytics-migration.md
@@ -1,20 +1,24 @@
 # mech-analytics migration spec
 
-> **Status:** `USE_MECH_ANALYTICS` is off everywhere.
+> **Status:** `USE_MECH_ANALYTICS` defaults on after the mech-analytics
+> cutover (PR #560). An unset env var routes reads through mech-analytics;
+> setting `USE_MECH_ANALYTICS=false` is the one-liner rollback lever that
+> sends reads back through the subgraph.
 > **Next steps:**
-> 1. Turn the flag on in a Vercel preview deployment. Run the checks from the
->    "Verification" section. The flag-on numbers must be equal to the flag-off
->    numbers for the same time window.
-> 2. Turn the flag on in production at cut-over. Watch for 24–48 hours.
-> 3. Remove the flag and the subgraph code paths.
+> 1. Watch production for 24-48 hours after the flag flip. If any regression
+>    surfaces, set `USE_MECH_ANALYTICS=false` in the deployment env and
+>    redeploy.
+> 2. Once stable for one release, delete the flag and the subgraph code paths.
 >
-> **Last verified against code:** 2026-07-27. Update this header when the flag
+> **Last verified against code:** 2026-08-27. Update this header when the flag
 > state changes.
 
 This document tells why and how the website moves its per-request
 marketplace-subgraph reads to the
 [mech-analytics](https://github.com/valory-xyz/mech-analytics) API.
-The `USE_MECH_ANALYTICS` flag controls all new read paths. Default: off.
+The `USE_MECH_ANALYTICS` flag controls all new read paths. Default: on after
+the cutover (unset env var routes through mech-analytics; set
+`USE_MECH_ANALYTICS=false` for the rollback path).
 
 ## Background
 
@@ -161,12 +165,16 @@ endpoint — that is a different metric.
 
 ## Rollout
 
-1. Merge with `USE_MECH_ANALYTICS=false`. Nothing changes in production.
-2. Set `MECH_ANALYTICS_URL` and turn the flag on in a preview, after
-   mech-analytics is deployed and caught up. Run the checks below.
-3. Turn the flag on in production at cut-over. Watch for 24–48 hours: blob
-   `fetchErrors`, the StaleIndicator on predict ROI, the tool-accuracy table.
-   To roll back, turn the flag off.
+Steps 1-3 have already run. Only step 4 is left; see the header for the
+current status.
+
+1. ~~Merge with `USE_MECH_ANALYTICS=false`.~~ Done (PR #548).
+2. ~~Set `MECH_ANALYTICS_URL` and turn the flag on in a preview~~. Done — parity
+   checks matched user-visible metrics exactly.
+3. ~~Flip the default to on at cut-over~~. Done (PR #560). Watch for 24-48
+   hours: blob `fetchErrors`, the StaleIndicator on predict ROI, the
+   tool-accuracy table. To roll back, set `USE_MECH_ANALYTICS=false` in the
+   deployment env.
 4. After the watch window: remove the flag and the subgraph code paths. Update
    the `/data` page snippets (`OmenstratRoiInfo`, `PolystratRoiInfo`) to show
    the API instead of the retired subgraph queries.


### PR DESCRIPTION
## Summary

Flips the `USE_MECH_ANALYTICS` flag default from opt-in (`=== 'true'`) to opt-out (`!== 'false'`) so mech-analytics is the primary source for the per-request mech feed and `senderTotal` on the predict page. Rollback to the subgraph is a one-liner env-var flip.

## Prerequisites (all landed)

- **mech-analytics PR #36** (valory-xyz/mech-analytics#36) — undelivered on-chain requests now land as shell rows so `COUNT(*)` matches on-chain reality. Deployed and verified live: `~292k` historical undelivered rows backfilled, live scoring flowing.
- **Placeholder repair** — one-shot rewrote 204 historical trader-tool rows that had `prompt='[offchain request]'` (mech-side bug that shipped before valory-xyz/mech#478). Real question text pulled back from the marketplace subgraph.
- **Parity re-run** (Aug 1-25 window) after both fixes landed:
  - `row_parity.missing_in_analytics`: **225 → 21** (matches the 204 repair count)
  - `senderTotal`: 302,465 = 302,465 (PASS, delta 0 on omenstrat, delta 1 on polystrat within ±5 tolerance)
  - Residual 21 missing are 2 mech-side attribution edge cases + ~19 non-trader Safes using trader tools; none affect user-visible metrics

## Test plan

- [ ] Deploy to staging, `USE_MECH_ANALYTICS` unset → reads should flow through mech-analytics; verify ROI + senderTotal render correctly on `/predict`
- [ ] Verify rollback path: set `USE_MECH_ANALYTICS=false` on the staging env, redeploy, confirm reads route back to the subgraph
- [ ] Watch for `MechAnalyticsError` in the server logs during the first 24-48h of production traffic

## Rollback

Set `USE_MECH_ANALYTICS=false` in the deployment env. No revert needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)